### PR TITLE
Fixes snapshot mapping

### DIFF
--- a/tracer/dict/dictionary_context.go
+++ b/tracer/dict/dictionary_context.go
@@ -121,10 +121,7 @@ func (ctx *DictionaryContext) InitSnapshot() {
 
 // Add snaphot-id mapping for execution of RevertSnapshot.
 func (ctx *DictionaryContext) AddSnapshot(recordedID int32, replayedID int32) {
-	err := ctx.SnapshotIndex.Add(recordedID, replayedID)
-	if err != nil {
-		log.Fatalf("Snapshot mapping could not be added. Error: %v", err)
-	}
+	ctx.SnapshotIndex.Add(recordedID, replayedID)
 }
 
 // Get snaphot-id.

--- a/tracer/dict/snapshot_index.go
+++ b/tracer/dict/snapshot_index.go
@@ -26,13 +26,8 @@ func NewSnapshotIndex() *SnapshotIndex {
 }
 
 // Add new snapshot-id mapping.
-func (oIdx *SnapshotIndex) Add(recordedID int32, replayedID int32) error {
-	var err error = nil
-	if _, ok := oIdx.recordedToReplayed[recordedID]; ok {
-		err = errors.New("snapshot-id already exists")
-	}
+func (oIdx *SnapshotIndex) Add(recordedID int32, replayedID int32) {
 	oIdx.recordedToReplayed[recordedID] = replayedID
-	return err
 }
 
 // Retrieve replayed snapshot-id from a recorded-id.

--- a/tracer/operation/snapshot.go
+++ b/tracer/operation/snapshot.go
@@ -3,6 +3,8 @@ package operation
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
+	"math"
 	"os"
 
 	"github.com/Fantom-foundation/aida/tracer/dict"
@@ -40,7 +42,9 @@ func (op *Snapshot) Write(f *os.File) error {
 // Execute the snapshot operation.
 func (op *Snapshot) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
 	ID := db.Snapshot()
-	// TODO: check that ID does not exceed 32bit
+	if ID > math.MaxInt32 {
+		log.Fatalf("Snapshot ID exceeds 32 bit")
+	}
 	ctx.AddSnapshot(op.SnapshotID, int32(ID))
 }
 


### PR DESCRIPTION
After reverting to an old snapshot, stateDB may reuse abandoned snapshot ID. 

Example:
```
Snapshot()           // create snapshot id 2
Snapshot()           // create snapshot id 3
RevertToSnapshot(2)  // revert to snapshot id 2
Snapshot()           // create snapshot id 3 <-- reuse id 3
```

Issue: current behavior does not allow reusing old snapshot id. The program exits with "Error: snapshot-id already exists".
Solution: allows reusing snapshot id.

Resolve #8