### PR TITLE
Implement compression techniques for GetState

### DIFF
--- a/tracer/dict/contract_dictionary.go
+++ b/tracer/dict/contract_dictionary.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Entry limit of contract dictionary
-var ContractDictionaryLimit uint32 = math.MaxUint32
+var ContractDictionaryLimit uint32 = math.MaxUint32 - 1
 
 // Dictionary data structure encodes/decodes a contract address
 // to a dictionary index or vice versa.

--- a/tracer/dict/dictionary_context.go
+++ b/tracer/dict/dictionary_context.go
@@ -3,16 +3,20 @@ package dict
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"log"
+	"math"
 )
+
+const InvalidContractIndex = math.MaxUint32
 
 // DictionaryContext is a Facade for all dictionaries used
 // to encode/decode state operations on file.
 type DictionaryContext struct {
 	ContractDictionary *ContractDictionary // dictionary to compact contract addresses
+	PrevContractIndex  uint32              // previously used contract index
 	StorageDictionary  *StorageDictionary  // dictionary to compact storage addresses
+	StorageCache       *IndexCache         // storage address cache
 	ValueDictionary    *ValueDictionary    // dictionary to compact storage values
-
-	SnapshotIndex *SnapshotIndex // Snapshot index for execution (not for recording/replaying)
+	SnapshotIndex      *SnapshotIndex      // snapshot index for execution (not for recording/replaying)
 }
 
 // Create new dictionary context.
@@ -21,8 +25,14 @@ func NewDictionaryContext() *DictionaryContext {
 		ContractDictionary: NewContractDictionary(),
 		StorageDictionary:  NewStorageDictionary(),
 		ValueDictionary:    NewValueDictionary(),
-		SnapshotIndex:      NewSnapshotIndex()}
+		SnapshotIndex:      NewSnapshotIndex(),
+		PrevContractIndex:  InvalidContractIndex,
+		StorageCache:       NewIndexCache()}
 }
+
+////////////////////////////////////////////////////////////////
+// I/O
+////////////////////////////////////////////////////////////////
 
 var DictDir string = "./"
 
@@ -60,23 +70,87 @@ func (ctx *DictionaryContext) Write() {
 	}
 }
 
+////////////////////////////////////////////////////////////////
+// Contract methods
+////////////////////////////////////////////////////////////////
+
 // Encode a given contract address and return a contract index.
 func (ctx *DictionaryContext) EncodeContract(contract common.Address) uint32 {
 	cIdx, err := ctx.ContractDictionary.Encode(contract)
 	if err != nil {
 		log.Fatalf("Contract address could not be encoded. Error: %v", err)
 	}
+	ctx.PrevContractIndex = cIdx
 	return cIdx
 }
 
+// Decode the contract address for a given index.
+func (ctx *DictionaryContext) DecodeContract(cIdx uint32) common.Address {
+	contract, err := ctx.ContractDictionary.Decode(cIdx)
+	if err != nil {
+		log.Fatalf("Contract index could not be decoded. Error: %v", err)
+	}
+	ctx.PrevContractIndex = cIdx
+	return contract
+}
+
+// Read the contract address for a given index.
+func (ctx *DictionaryContext) LastContractAddress() common.Address {
+	if ctx.PrevContractIndex == InvalidContractIndex {
+		log.Fatalf("Last contract address undefined")
+	}
+	return ctx.DecodeContract(ctx.PrevContractIndex)
+}
+
+////////////////////////////////////////////////////////////////
+// Storage methods
+////////////////////////////////////////////////////////////////
+
 // Endcode a given storage address and retrun a storage address index.
-func (ctx *DictionaryContext) EncodeStorage(storage common.Hash) uint32 {
+func (ctx *DictionaryContext) EncodeStorage(storage common.Hash) (uint32, int) {
 	sIdx, err := ctx.StorageDictionary.Encode(storage)
 	if err != nil {
 		log.Fatalf("Storage address could not be encoded. Error: %v", err)
 	}
-	return sIdx
+	pos := ctx.StorageCache.Place(sIdx)
+	return sIdx, pos
 }
+
+// Decode the storage address for a given index.
+func (ctx *DictionaryContext) DecodeStorage(sIdx uint32) common.Hash {
+	storage, err := ctx.StorageDictionary.Decode(sIdx)
+	if err != nil {
+		log.Fatalf("Storage index could not be decoded. Error: %v", err)
+	}
+	ctx.StorageCache.Place(sIdx)
+	return storage
+}
+
+// Read the storage address for a given index.
+func (ctx *DictionaryContext) ReadStorage(sPos int) common.Hash {
+	sIdx, err := ctx.StorageCache.Lookup(sPos)
+	if err != nil {
+		log.Fatalf("Storage position could not be found. Error: %v", err)
+	}
+	storage, err := ctx.StorageDictionary.Decode(sIdx)
+	if err != nil {
+		log.Fatalf("Storage index could not be decoded. Error: %v", err)
+	}
+	return storage
+}
+
+// Look up the storage address for a given index.
+func (ctx *DictionaryContext) LookupStorage(sPos int) common.Hash {
+	sIdx, err := ctx.StorageCache.Lookup(sPos)
+	if err != nil {
+		log.Fatalf("Storage position could not be found. Error: %v", err)
+	}
+	return ctx.DecodeStorage(sIdx)
+}
+
+////////////////////////////////////////////////////////////////
+// Value methods
+////////////////////////////////////////////////////////////////
 
 // Encode a storage value and return a value index.
 func (ctx *DictionaryContext) EncodeValue(value common.Hash) uint64 {
@@ -87,24 +161,6 @@ func (ctx *DictionaryContext) EncodeValue(value common.Hash) uint64 {
 	return vIdx
 }
 
-// Decode the contract address for a given index.
-func (ctx *DictionaryContext) DecodeContract(cIdx uint32) common.Address {
-	contract, err := ctx.ContractDictionary.Decode(cIdx)
-	if err != nil {
-		log.Fatalf("Contract index could not be decoded. Error: %v", err)
-	}
-	return contract
-}
-
-// Decode the storage address for a given index.
-func (ctx *DictionaryContext) DecodeStorage(sIdx uint32) common.Hash {
-	storage, err := ctx.StorageDictionary.Decode(sIdx)
-	if err != nil {
-		log.Fatalf("Storage index could not be decoded. Error: %v", err)
-	}
-	return storage
-}
-
 // Decode the storage value for a given index.
 func (ctx *DictionaryContext) DecodeValue(vIdx uint64) common.Hash {
 	value, err := ctx.ValueDictionary.Decode(vIdx)
@@ -113,6 +169,10 @@ func (ctx *DictionaryContext) DecodeValue(vIdx uint64) common.Hash {
 	}
 	return value
 }
+
+////////////////////////////////////////////////////////////////
+// Snapshot methods
+////////////////////////////////////////////////////////////////
 
 // Init snaphot map.
 func (ctx *DictionaryContext) InitSnapshot() {
@@ -131,4 +191,14 @@ func (ctx *DictionaryContext) GetSnapshot(recordedID int32) int32 {
 		log.Fatalf("Replayed Snapshot ID is missing. Error: %v", err)
 	}
 	return replayedID
+}
+
+////////////////////////////////////////////////////////////////
+// Snapshot methods
+////////////////////////////////////////////////////////////////
+
+// Clear count queues.
+func (ctx *DictionaryContext) ClearIndexCaches() {
+	ctx.PrevContractIndex = InvalidContractIndex
+	ctx.StorageCache.ClearIndexCache()
 }

--- a/tracer/dict/index_cache.go
+++ b/tracer/dict/index_cache.go
@@ -1,0 +1,74 @@
+package dict
+
+import (
+	"errors"
+	"math"
+)
+
+// Length of cache (i.e. 2^8)
+const CacheLength = 256
+
+// IndexCache data structure for implementing a LRU cache
+// policy.
+type IndexCache struct {
+	top  int                 // last accessed inde
+	data [CacheLength]uint32 // data elements of cache
+}
+
+// ClearIndexCache clears the count queue by setting
+// all data elements to MaxUint32, which is an an
+// invalid index.
+func (q *IndexCache) ClearIndexCache() {
+	q.top = 0
+	for i := 0; i < CacheLength; i++ {
+		q.data[i] = math.MaxUint32
+	}
+}
+
+// NewIndexCache creates a new queue for counting positions.
+func NewIndexCache() *IndexCache {
+	q := new(IndexCache)
+	q.ClearIndexCache()
+	return q
+}
+
+// Place puts a new element into cache.
+func (q *IndexCache) Place(item uint32) int {
+	// find the index in cache
+	for i := 0; i < CacheLength; i++ {
+		if q.data[i] == item {
+			// calculate position in queue
+			// relevant for encoding
+			j := (q.top - i) % CacheLength
+			if j < 0 {
+				j += CacheLength
+			}
+			tmp := q.data[q.top]
+			q.data[q.top] = q.data[i]
+			q.data[i] = tmp
+			return j
+		}
+	}
+	// element is not found => place it as the most recent one
+	q.top++
+	q.top = q.top % CacheLength
+	q.data[q.top] = item
+	return -1
+}
+
+// Look up an element given a position in cache.
+func (q *IndexCache) Lookup(pos int) (uint32, error) {
+	if pos < 0 || pos >= CacheLength {
+		return 0, errors.New("Position out of bound")
+	}
+	// calculate position in queue
+	// relevant for encoding
+	j := (q.top - pos) % CacheLength
+	if j < 0 {
+		j += CacheLength
+	}
+	if q.data[j] == math.MaxUint32 {
+		return 0, errors.New("Undefined index in cache")
+	}
+	return q.data[j], nil
+}

--- a/tracer/dict/storage_dictionary.go
+++ b/tracer/dict/storage_dictionary.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Entry limit of storage dictionary
-var StorageDictionaryLimit uint32 = math.MaxUint32
+var StorageDictionaryLimit uint32 = math.MaxUint32 - 1
 
 // Dictionary data structure encodes/decodes a storage address
 // to a dictionary index or vice versa.

--- a/tracer/dict/value_dictionary.go
+++ b/tracer/dict/value_dictionary.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Entry limit of storage dictionary
-var ValueDictionaryLimit uint64 = math.MaxUint64
+var ValueDictionaryLimit uint64 = math.MaxUint64 - 1
 
 // Dictionary data structure encodes/decodes a storage address
 // to a dictionary index or vice versa.

--- a/tracer/operation/beginblock.go
+++ b/tracer/operation/beginblock.go
@@ -39,6 +39,7 @@ func (op *BeginBlock) Write(f *os.File) error {
 
 // Execute the begin-block operation.
 func (op *BeginBlock) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+	ctx.ClearIndexCaches()
 }
 
 // Print a debug message for begin-block.

--- a/tracer/operation/getstate_lc.go
+++ b/tracer/operation/getstate_lc.go
@@ -1,0 +1,52 @@
+package operation
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/Fantom-foundation/Aida/tracer/dict"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+)
+
+// Get-state data structure with last contract address
+type GetStateLc struct {
+	StorageIndex uint32 // encoded storage address
+}
+
+// Return the get-state-lc operation identifier.
+func (op *GetStateLc) GetOpId() byte {
+	return GetStateLcID
+}
+
+// Create a new get-state-lc operation.
+func NewGetStateLc(sIdx uint32) *GetStateLc {
+	return &GetStateLc{StorageIndex: sIdx}
+}
+
+// Read a get-state-lc operation from a file.
+func ReadGetStateLc(file *os.File) (Operation, error) {
+	data := new(GetStateLc)
+	err := binary.Read(file, binary.LittleEndian, data)
+	return data, err
+}
+
+// Write the get-state-lc operation to file.
+func (op *GetStateLc) Write(f *os.File) error {
+	err := binary.Write(f, binary.LittleEndian, *op)
+	return err
+}
+
+// Execute the get-state-lc operation.
+func (op *GetStateLc) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	storage := ctx.DecodeStorage(op.StorageIndex)
+	db.GetState(contract, storage)
+}
+
+// Print a debug message.
+func (op *GetStateLc) Debug(ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	storage := ctx.DecodeStorage(op.StorageIndex)
+	fmt.Printf("\tcontract: %v\t storage: %v\n", contract, storage)
+}

--- a/tracer/operation/getstate_lccs.go
+++ b/tracer/operation/getstate_lccs.go
@@ -1,0 +1,57 @@
+package operation
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Fantom-foundation/Aida/tracer/dict"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+)
+
+// Get-state data structure for using last contract address
+// and cached storage address (lccs)
+type GetStateLccs struct {
+	StoragePosition uint8 // position in storage cache
+}
+
+// Return the get-state-lccs operation identifier.
+func (op *GetStateLccs) GetOpId() byte {
+	return GetStateLccsID
+}
+
+// Create a new get-state-lccs operation.
+func NewGetStateLccs(sPos int) *GetStateLccs {
+	if sPos < 0 || sPos > 255 {
+		log.Fatalf("Position out of range")
+	}
+	return &GetStateLccs{StoragePosition: uint8(sPos)}
+}
+
+// Read a get-state-lccs operation from a file.
+func ReadGetStateLccs(file *os.File) (Operation, error) {
+	data := new(GetStateLccs)
+	err := binary.Read(file, binary.LittleEndian, data)
+	return data, err
+}
+
+// Write the get-state-lccs operation to file.
+func (op *GetStateLccs) Write(f *os.File) error {
+	err := binary.Write(f, binary.LittleEndian, *op)
+	return err
+}
+
+// Execute the get-state-lccs operation.
+func (op *GetStateLccs) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	storage := ctx.LookupStorage(int(op.StoragePosition))
+	db.GetState(contract, storage)
+}
+
+// Print a debug message.
+func (op *GetStateLccs) Debug(ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	storage := ctx.ReadStorage(int(op.StoragePosition))
+	fmt.Printf("\tcontract: %v\t storage: %v\n", contract, storage)
+}

--- a/tracer/operation/lastgetstate.go
+++ b/tracer/operation/lastgetstate.go
@@ -1,0 +1,47 @@
+package operation
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Fantom-foundation/Aida/tracer/dict"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+)
+
+// Get-state data structure
+type LastGetState struct {
+}
+
+// Return the last-get-state operation identifier.
+func (op *LastGetState) GetOpId() byte {
+	return LastGetStateID
+}
+
+// Create a new last-get-state operation.
+func NewLastGetState() *LastGetState {
+	return new(LastGetState)
+}
+
+// Read a last-get-state operation from a file.
+func ReadLastGetState(file *os.File) (Operation, error) {
+	return NewLastGetState(), nil
+}
+
+// Write the last-get-state operation to file.
+func (op *LastGetState) Write(f *os.File) error {
+	return nil
+}
+
+// Execute the last-get-state operation.
+func (op *LastGetState) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	storage := ctx.LookupStorage(0)
+	db.GetState(contract, storage)
+}
+
+// Print a debug message for last-get-state operation.
+func (op *LastGetState) Debug(ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	storage := ctx.LookupStorage(0)
+	fmt.Printf("\tcontract: %v\t storage: %v\n", contract, storage)
+}

--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -18,6 +18,9 @@ var Profiling = false
 // Operation IDs of the StateDB interface
 const (
 	GetStateID = iota
+	LastGetStateID
+	GetStateLcID
+	GetStateLccsID
 	SetStateID
 	GetCommittedStateID
 	SnapshotID
@@ -45,6 +48,9 @@ type OperationDictionary struct {
 // opDict contains a dictionary of operation's label and read function.
 var opDict = map[byte]OperationDictionary{
 	GetStateID:          {label: "GetState", readfunc: ReadGetState},
+	LastGetStateID:      {label: "LastGetState", readfunc: ReadLastGetState},
+	GetStateLcID:        {label: "GetStateLc", readfunc: ReadGetStateLc},
+	GetStateLccsID:      {label: "GetStateLccs", readfunc: ReadGetStateLccs},
 	SetStateID:          {label: "SetState", readfunc: ReadSetState},
 	GetCommittedStateID: {label: "GetCommittedState", readfunc: ReadGetCommittedState},
 	SnapshotID:          {label: "Snapshot", readfunc: ReadSnapshot},

--- a/tracer/proxy_recorder.go
+++ b/tracer/proxy_recorder.go
@@ -14,152 +14,175 @@ import (
 // ProxyRecorder datastructure for capturing and recording
 // invoked StateDB operations.
 type ProxyRecorder struct {
-	db   state.StateDB            // state db
-	dctx *dict.DictionaryContext  // dictionary context for decoding information
-	ch   chan operation.Operation // channel used for streaming captured operation
+	db    state.StateDB            // state db
+	dctx  *dict.DictionaryContext  // dictionary context for decoding information
+	ch    chan operation.Operation // channel used for streaming captured operation
+	debug bool
 }
 
-// Create a new StateDB proxy.
-func NewProxyRecorder(db state.StateDB, dctx *dict.DictionaryContext, ch chan operation.Operation) state.StateDB {
-	p := new(ProxyRecorder)
-	p.db = db
-	p.dctx = dctx
-	p.ch = ch
-	return p
+// NewProxyRecorder creates a new StateDB proxy.
+func NewProxyRecorder(db state.StateDB, dctx *dict.DictionaryContext, ch chan operation.Operation, debug bool) *ProxyRecorder {
+	r := new(ProxyRecorder)
+	r.db = db
+	r.dctx = dctx
+	r.ch = ch
+	r.debug = debug
+	return r
 }
 
-// Create account an account.
-func (s *ProxyRecorder) CreateAccount(addr common.Address) {
-	cIdx := s.dctx.EncodeContract(addr)
-	s.ch <- operation.NewCreateAccount(cIdx)
-	s.db.CreateAccount(addr)
+// send new operation on channel.
+func (r *ProxyRecorder) send(op operation.Operation) {
+	if r.debug {
+		operation.Debug(r.dctx, op)
+	}
+	r.ch <- op
 }
 
-// Subtract amount from a contract address.
-func (s *ProxyRecorder) SubBalance(addr common.Address, amount *big.Int) {
-	s.db.SubBalance(addr, amount)
+// CreateAccounts creates a new account.
+func (r *ProxyRecorder) CreateAccount(addr common.Address) {
+	cIdx := r.dctx.EncodeContract(addr)
+	r.send(operation.NewCreateAccount(cIdx))
+	r.db.CreateAccount(addr)
 }
 
-// Add amount to a contract address.
-func (s *ProxyRecorder) AddBalance(addr common.Address, amount *big.Int) {
-	s.db.AddBalance(addr, amount)
+// SubtractBalance subtracts amount from a contract address.
+func (r *ProxyRecorder) SubBalance(addr common.Address, amount *big.Int) {
+	r.db.SubBalance(addr, amount)
 }
 
-// Obtain the amount of a contract address.
-func (s *ProxyRecorder) GetBalance(addr common.Address) *big.Int {
-	cIdx := s.dctx.EncodeContract(addr)
-	s.ch <- operation.NewGetBalance(cIdx)
-	balance := s.db.GetBalance(addr)
+// AddBalance adds amount to a contract address.
+func (r *ProxyRecorder) AddBalance(addr common.Address, amount *big.Int) {
+	r.db.AddBalance(addr, amount)
+}
+
+// GetBalance retrieves the amount of a contract address.
+func (r *ProxyRecorder) GetBalance(addr common.Address) *big.Int {
+	cIdx := r.dctx.EncodeContract(addr)
+	r.send(operation.NewGetBalance(cIdx))
+	balance := r.db.GetBalance(addr)
 	return balance
 }
 
-// Obtain the nonce of a contract address.
-func (s *ProxyRecorder) GetNonce(addr common.Address) uint64 {
-	nonce := s.db.GetNonce(addr)
+// GetNonce retrieves the nonce of a contract address.
+func (r *ProxyRecorder) GetNonce(addr common.Address) uint64 {
+	nonce := r.db.GetNonce(addr)
 	return nonce
 }
 
-// Set the nonce of a contract address.
-func (s *ProxyRecorder) SetNonce(addr common.Address, nonce uint64) {
-	s.db.SetNonce(addr, nonce)
+// SetNonce sets the nonce of a contract address.
+func (r *ProxyRecorder) SetNonce(addr common.Address, nonce uint64) {
+	r.db.SetNonce(addr, nonce)
 }
 
-// Return the hash of the EVM bytecode.
-func (s *ProxyRecorder) GetCodeHash(addr common.Address) common.Hash {
-	cIdx := s.dctx.EncodeContract(addr)
-	s.ch <- operation.NewGetCodeHash(cIdx)
-	hash := s.db.GetCodeHash(addr)
+// GetCodeHash returns the hash of the EVM bytecode.
+func (r *ProxyRecorder) GetCodeHash(addr common.Address) common.Hash {
+	cIdx := r.dctx.EncodeContract(addr)
+	r.send(operation.NewGetCodeHash(cIdx))
+	hash := r.db.GetCodeHash(addr)
 	return hash
 }
 
-// Return the EVM bytecode of a contract.
-func (s *ProxyRecorder) GetCode(addr common.Address) []byte {
-	code := s.db.GetCode(addr)
+// GetCode returns the EVM bytecode of a contract.
+func (r *ProxyRecorder) GetCode(addr common.Address) []byte {
+	code := r.db.GetCode(addr)
 	return code
 }
 
-// Set the EVM bytecode of a contract.
-func (s *ProxyRecorder) SetCode(addr common.Address, code []byte) {
-	s.db.SetCode(addr, code)
+// Setcode sets the EVM bytecode of a contract.
+func (r *ProxyRecorder) SetCode(addr common.Address, code []byte) {
+	r.db.SetCode(addr, code)
 }
 
-// Return the EVM bytecode's size.
-func (s *ProxyRecorder) GetCodeSize(addr common.Address) int {
-	size := s.db.GetCodeSize(addr)
+// GetCodeSize returns the EVM bytecode's size.
+func (r *ProxyRecorder) GetCodeSize(addr common.Address) int {
+	size := r.db.GetCodeSize(addr)
 	return size
 }
 
-// Add gas to the refund counter.
-func (s *ProxyRecorder) AddRefund(gas uint64) {
-	s.db.AddRefund(gas)
+// AddRefund adds gas to the refund counter.
+func (r *ProxyRecorder) AddRefund(gas uint64) {
+	r.db.AddRefund(gas)
 }
 
-// Subtract gas to the refund counter.
-func (s *ProxyRecorder) SubRefund(gas uint64) {
-	s.db.SubRefund(gas)
+// SubRefund subtracts gas to the refund counter.
+func (r *ProxyRecorder) SubRefund(gas uint64) {
+	r.db.SubRefund(gas)
 }
 
-// Obtain the current value of the refund counter.
-func (s *ProxyRecorder) GetRefund() uint64 {
-	gas := s.db.GetRefund()
+// GetRefund returns the current value of the refund counter.
+func (r *ProxyRecorder) GetRefund() uint64 {
+	gas := r.db.GetRefund()
 	return gas
 }
 
-// Retrieve a value that is already committed.
-func (s *ProxyRecorder) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
-	cIdx := s.dctx.EncodeContract(addr)
-	sIdx := s.dctx.EncodeStorage(key)
-	s.ch <- operation.NewGetCommittedState(cIdx, sIdx)
-	value := s.db.GetCommittedState(addr, key)
+// GetCommittedState retrieves a value that is already committed.
+func (r *ProxyRecorder) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
+	cIdx := r.dctx.EncodeContract(addr)
+	sIdx, _ := r.dctx.EncodeStorage(key)
+	r.send(operation.NewGetCommittedState(cIdx, sIdx))
+	value := r.db.GetCommittedState(addr, key)
 	return value
 }
 
-// Retrieve a value from the StateDB.
-func (s *ProxyRecorder) GetState(addr common.Address, key common.Hash) common.Hash {
-	cIdx := s.dctx.EncodeContract(addr)
-	sIdx := s.dctx.EncodeStorage(key)
-	s.ch <- operation.NewGetState(cIdx, sIdx)
-	value := s.db.GetState(addr, key)
+// GetState retrieves a value from the StateDB.
+func (r *ProxyRecorder) GetState(addr common.Address, key common.Hash) common.Hash {
+	prevCIdx := r.dctx.PrevContractIndex
+	cIdx := r.dctx.EncodeContract(addr)
+	sIdx, sPos := r.dctx.EncodeStorage(key)
+	var op operation.Operation
+	if cIdx == prevCIdx {
+		if sPos == 0 {
+			op = operation.NewLastGetState()
+		} else if sPos != -1 {
+			op = operation.NewGetStateLccs(sPos)
+		} else {
+			op = operation.NewGetStateLc(sIdx)
+		}
+	} else {
+		op = operation.NewGetState(cIdx, sIdx)
+	}
+	r.send(op)
+	value := r.db.GetState(addr, key)
 	return value
 }
 
-// Set a value in the StateDB.
-func (s *ProxyRecorder) SetState(addr common.Address, key common.Hash, value common.Hash) {
-	cIdx := s.dctx.EncodeContract(addr)
-	sIdx := s.dctx.EncodeStorage(key)
-	vIdx := s.dctx.EncodeValue(value)
-	s.ch <- operation.NewSetState(cIdx, sIdx, vIdx)
-	s.db.SetState(addr, key, value)
+// SetState sets a value in the StateDB.
+func (r *ProxyRecorder) SetState(addr common.Address, key common.Hash, value common.Hash) {
+	cIdx := r.dctx.EncodeContract(addr)
+	sIdx, _ := r.dctx.EncodeStorage(key)
+	vIdx := r.dctx.EncodeValue(value)
+	r.send(operation.NewSetState(cIdx, sIdx, vIdx))
+	r.db.SetState(addr, key, value)
 }
 
-// Mark the given account as suicided. This clears the account balance.
+// Suicide marks the given account as suicided. This clears the account balance.
 // The account is still available until the state is committed;
 // return a non-nil account after Suicide.
-func (s *ProxyRecorder) Suicide(addr common.Address) bool {
-	cIdx := s.dctx.EncodeContract(addr)
-	s.ch <- operation.NewSuicide(cIdx)
-	ok := s.db.Suicide(addr)
+func (r *ProxyRecorder) Suicide(addr common.Address) bool {
+	cIdx := r.dctx.EncodeContract(addr)
+	r.send(operation.NewSuicide(cIdx))
+	ok := r.db.Suicide(addr)
 	return ok
 }
 
-// Check whether a contract has been suicided.
-func (s *ProxyRecorder) HasSuicided(addr common.Address) bool {
-	hasSuicided := s.db.HasSuicided(addr)
+// HasSuicided checks whether a contract has been suicided.
+func (r *ProxyRecorder) HasSuicided(addr common.Address) bool {
+	hasSuicided := r.db.HasSuicided(addr)
 	return hasSuicided
 }
 
-// Check whether the contract exists in the StateDB.
+// Exist checks whether the contract exists in the StateDB.
 // Notably this also returns true for suicided accounts.
-func (s *ProxyRecorder) Exist(addr common.Address) bool {
-	cIdx := s.dctx.EncodeContract(addr)
-	s.ch <- operation.NewExist(cIdx)
-	return s.db.Exist(addr)
+func (r *ProxyRecorder) Exist(addr common.Address) bool {
+	cIdx := r.dctx.EncodeContract(addr)
+	r.send(operation.NewExist(cIdx))
+	return r.db.Exist(addr)
 }
 
-// Check whether the contract is either non-existent
+// Empty checks whether the contract is either non-existent
 // or empty according to the EIP161 specification (balance = nonce = code = 0).
-func (s *ProxyRecorder) Empty(addr common.Address) bool {
-	empty := s.db.Empty(addr)
+func (r *ProxyRecorder) Empty(addr common.Address) bool {
+	empty := r.db.Empty(addr)
 	return empty
 }
 
@@ -172,86 +195,86 @@ func (s *ProxyRecorder) Empty(addr common.Address) bool {
 // - Add the contents of the optional tx access list (2930)
 //
 // This method should only be called if Berlin/2929+2930 is applicable at the current number.
-func (s *ProxyRecorder) PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	s.db.PrepareAccessList(sender, dest, precompiles, txAccesses)
+func (r *ProxyRecorder) PrepareAccessList(render common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	r.db.PrepareAccessList(render, dest, precompiles, txAccesses)
 }
 
-// Add an address to the access list.
-func (s *ProxyRecorder) AddAddressToAccessList(addr common.Address) {
-	s.db.AddAddressToAccessList(addr)
+// AddAddressToAccessList adds an address to the access list.
+func (r *ProxyRecorder) AddAddressToAccessList(addr common.Address) {
+	r.db.AddAddressToAccessList(addr)
 }
 
-// Check whether an address is in the access list.
-func (s *ProxyRecorder) AddressInAccessList(addr common.Address) bool {
-	ok := s.db.AddressInAccessList(addr)
+// AddressInAccessList checks whether an address is in the access list.
+func (r *ProxyRecorder) AddressInAccessList(addr common.Address) bool {
+	ok := r.db.AddressInAccessList(addr)
 	return ok
 }
 
-// Check whether the (address, slot)-tuple is in the access list.
-func (s *ProxyRecorder) SlotInAccessList(addr common.Address, slot common.Hash) (bool, bool) {
-	addressOk, slotOk := s.db.SlotInAccessList(addr, slot)
+// SlotInAccessList checks whether the (address, slot)-tuple is in the access list.
+func (r *ProxyRecorder) SlotInAccessList(addr common.Address, slot common.Hash) (bool, bool) {
+	addressOk, slotOk := r.db.SlotInAccessList(addr, slot)
 	return addressOk, slotOk
 }
 
-// Add the given (address, slot)-tuple to the access list
-func (s *ProxyRecorder) AddSlotToAccessList(addr common.Address, slot common.Hash) {
-	s.db.AddSlotToAccessList(addr, slot)
+// AddSlotToAccessList adds the given (address, slot)-tuple to the access list
+func (r *ProxyRecorder) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	r.db.AddSlotToAccessList(addr, slot)
 }
 
-// Revert all state changes from a given revision.
-func (s *ProxyRecorder) RevertToSnapshot(snapshot int) {
-	s.ch <- operation.NewRevertToSnapshot(snapshot)
-	s.db.RevertToSnapshot(snapshot)
+// RevertToSnapshot reverts all state changes from a given revision.
+func (r *ProxyRecorder) RevertToSnapshot(snapshot int) {
+	r.send(operation.NewRevertToSnapshot(snapshot))
+	r.db.RevertToSnapshot(snapshot)
 }
 
-// Return an identifier for the current revision of the state.
-func (s *ProxyRecorder) Snapshot() int {
-	snapshot := s.db.Snapshot()
+// Snapshot returns an identifier for the current revision of the state.
+func (r *ProxyRecorder) Snapshot() int {
+	snapshot := r.db.Snapshot()
 	// TODO: check overrun
-	s.ch <- operation.NewSnapshot(int32(snapshot))
+	r.send(operation.NewSnapshot(int32(snapshot)))
 	return snapshot
 }
 
-// Add a log entry.
-func (s *ProxyRecorder) AddLog(log *types.Log) {
-	s.db.AddLog(log)
+// AddLog adds a log entry.
+func (r *ProxyRecorder) AddLog(log *types.Log) {
+	r.db.AddLog(log)
 }
 
-// Retrieve log entries.
-func (s *ProxyRecorder) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
-	return s.db.GetLogs(hash, blockHash)
+// GetLogs retrieves log entries.
+func (r *ProxyRecorder) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	return r.db.GetLogs(hash, blockHash)
 }
 
-// Adds SHA3 preimage.
-func (s *ProxyRecorder) AddPreimage(addr common.Hash, image []byte) {
-	s.db.AddPreimage(addr, image)
+// AddPreimage adds a SHA3 preimage.
+func (r *ProxyRecorder) AddPreimage(addr common.Hash, image []byte) {
+	r.db.AddPreimage(addr, image)
 }
 
-// Performs a function over all storage locations in a contract.
-func (s *ProxyRecorder) ForEachStorage(addr common.Address, fn func(common.Hash, common.Hash) bool) error {
-	err := s.db.ForEachStorage(addr, fn)
+// ForEachStorage performs a function over all storage locations in a contract.
+func (r *ProxyRecorder) ForEachStorage(addr common.Address, fn func(common.Hash, common.Hash) bool) error {
+	err := r.db.ForEachStorage(addr, fn)
 	return err
 }
 
-// Set the current transaction hash and index.
-func (s *ProxyRecorder) Prepare(thash common.Hash, ti int) {
-	s.db.Prepare(thash, ti)
+// Prepare sets the current transaction hash and index.
+func (r *ProxyRecorder) Prepare(thash common.Hash, ti int) {
+	r.db.Prepare(thash, ti)
 }
 
 // Finalise the state in StateDB.
-func (s *ProxyRecorder) Finalise(deleteEmptyObjects bool) {
-	s.ch <- operation.NewFinalise(deleteEmptyObjects)
-	s.db.Finalise(deleteEmptyObjects)
+func (r *ProxyRecorder) Finalise(deleteEmptyObjects bool) {
+	r.send(operation.NewFinalise(deleteEmptyObjects))
+	r.db.Finalise(deleteEmptyObjects)
 }
 
-// Computes the current hash of the StateDB.
+// IntermediateRoot computes the current hash of the StateDB.
 // It is called in between transactions to get the root hash that
 // goes into transaction receipts.
-func (s *ProxyRecorder) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
-	return s.db.IntermediateRoot(deleteEmptyObjects)
+func (r *ProxyRecorder) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	return r.db.IntermediateRoot(deleteEmptyObjects)
 }
 
-// Get substate post allocation.
-func (s *ProxyRecorder) GetSubstatePostAlloc() substate.SubstateAlloc {
-	return s.db.GetSubstatePostAlloc()
+// GetSubstatePostAlloc gets substate post allocation.
+func (r *ProxyRecorder) GetSubstatePostAlloc() substate.SubstateAlloc {
+	return r.db.GetSubstatePostAlloc()
 }


### PR DESCRIPTION
This pull request changes the trace recorder/replayer by introducing new encodings for the GetState operation. The GetState operations has the following new encodings:
 - LastGetState: the last used contract/storage address is used,
 - GetStateLc: the last accessed contract address is used, storage key is store as index
 - GetStateLccs: the last accessed contract address is used and an index of a storage key cache is used.

For a sample of 100K blocks the disk space for a GetState operation is reduced from 9 bytes to 2.86 bytes on average.