### PR TITLE
Add CPU profiling support to replay tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,5 @@ reads the recorded traces and re-execute state operations from block 5,050,000 t
  - `--trace-debug` print replayed operations. 
  - `--validate` validate the state after replaying traces.
  - `--workers` sets the number of worker threads.
+ - `--profile` records and displays summary information on operation performance
+ - `--cpuprofile` records a CPU profile for the replay to be inspected using `pprof`

--- a/cmd/trace/config.go
+++ b/cmd/trace/config.go
@@ -3,8 +3,9 @@ package trace
 
 import (
 	"fmt"
-	"github.com/urfave/cli/v2"
 	"strconv"
+
+	"github.com/urfave/cli/v2"
 )
 
 // Chain id for recording either mainnet or testnets.
@@ -41,6 +42,10 @@ var (
 	profileFlag = cli.BoolFlag{
 		Name:  "profile",
 		Usage: "enables profiling",
+	}
+	cpuProfileFlag = cli.StringFlag{
+		Name:  "cpuprofile",
+		Usage: "enables CPU profiling",
 	}
 )
 

--- a/cmd/trace/trace_replay.go
+++ b/cmd/trace/trace_replay.go
@@ -2,6 +2,9 @@ package trace
 
 import (
 	"fmt"
+	"os"
+	"runtime/pprof"
+
 	"github.com/Fantom-foundation/Aida/tracer"
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/operation"
@@ -18,6 +21,7 @@ var TraceReplayCommand = cli.Command{
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		&profileFlag,
+		&cpuProfileFlag,
 		&stateDbImplementation,
 		&substate.SubstateDirFlag,
 		&substate.WorkersFlag,
@@ -103,6 +107,16 @@ func storageDriver(first uint64, last uint64, cliCtx *cli.Context) error {
 
 	// Get profiling flag
 	operation.Profiling = cliCtx.Bool(profileFlag.Name)
+
+	// Start CPU profiling if requested.
+	if profile_file_name := cliCtx.String(cpuProfileFlag.Name); profile_file_name != "" {
+		f, err := os.Create(profile_file_name)
+		if err != nil {
+			return err
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
 
 	// Instantiate the state DB under testing
 	db, err := makeStateDb(cliCtx)


### PR DESCRIPTION
With this change, CPU profiling support is added to the replay tool for latency investigation.