### PR TITLE
Add new compressed SetState Operation

### DIFF
--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -22,6 +22,7 @@ const (
 	GetStateLcID
 	GetStateLccsID
 	SetStateID
+	SetStateLclsID
 	GetCommittedStateID
 	SnapshotID
 	RevertToSnapshotID
@@ -52,6 +53,7 @@ var opDict = map[byte]OperationDictionary{
 	GetStateLcID:        {label: "GetStateLc", readfunc: ReadGetStateLc},
 	GetStateLccsID:      {label: "GetStateLccs", readfunc: ReadGetStateLccs},
 	SetStateID:          {label: "SetState", readfunc: ReadSetState},
+	SetStateLclsID:      {label: "SetStateLcls", readfunc: ReadSetStateLcls},
 	GetCommittedStateID: {label: "GetCommittedState", readfunc: ReadGetCommittedState},
 	SnapshotID:          {label: "Snapshot", readfunc: ReadSnapshot},
 	RevertToSnapshotID:  {label: "RevertToSnapshot", readfunc: ReadRevertToSnapshot},
@@ -80,6 +82,10 @@ func getLabel(i byte) string {
 	if i < 0 || i >= NumOperations {
 		log.Fatalf("getLabel failed; index is out-of-bound")
 	}
+	if _, ok := opDict[i]; !ok {
+		log.Fatalf("operation is not defined")
+	}
+
 	return opDict[i].label
 }
 

--- a/tracer/operation/setstate_lcls.go
+++ b/tracer/operation/setstate_lcls.go
@@ -1,0 +1,58 @@
+package operation
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/Fantom-foundation/Aida/tracer/dict"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+)
+
+// SetStateLcls data structure for last contract address and last storage
+// address.
+type SetStateLcls struct {
+	ValueIndex uint64 // encoded storage value
+}
+
+// Return the set-state-lcls identifier
+func (op *SetStateLcls) GetOpId() byte {
+	return SetStateLclsID
+}
+
+// Create a new set-state-lcls operation.
+func NewSetStateLcls(vIdx uint64) *SetStateLcls {
+	return &SetStateLcls{ValueIndex: vIdx}
+}
+
+// Read a set-state-lcls operation from file.
+func ReadSetStateLcls(file *os.File) (Operation, error) {
+	data := new(SetStateLcls)
+	err := binary.Read(file, binary.LittleEndian, data)
+	return data, err
+}
+
+// Write the set-state-lcls operation to file.
+func (op *SetStateLcls) Write(f *os.File) error {
+	err := binary.Write(f, binary.LittleEndian, *op)
+	return err
+}
+
+// Execute the set-state-lcls operation.
+func (op *SetStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	storage := ctx.LookupStorage(0)
+	value := ctx.DecodeValue(op.ValueIndex)
+	db.SetState(contract, storage, value)
+}
+
+// Print a debug message for set-state-lcls.
+func (op *SetStateLcls) Debug(ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	storage := ctx.ReadStorage(0)
+	value := ctx.DecodeValue(op.ValueIndex)
+	fmt.Printf("\tcontract: %v\t storage: %v\t value: %v\n",
+		contract,
+		storage,
+		value)
+}

--- a/tracer/proxy_recorder.go
+++ b/tracer/proxy_recorder.go
@@ -148,10 +148,15 @@ func (r *ProxyRecorder) GetState(addr common.Address, key common.Hash) common.Ha
 
 // SetState sets a value in the StateDB.
 func (r *ProxyRecorder) SetState(addr common.Address, key common.Hash, value common.Hash) {
+	prevCIdx := r.dctx.PrevContractIndex
 	cIdx := r.dctx.EncodeContract(addr)
-	sIdx, _ := r.dctx.EncodeStorage(key)
+	sIdx, sPos := r.dctx.EncodeStorage(key)
 	vIdx := r.dctx.EncodeValue(value)
-	r.send(operation.NewSetState(cIdx, sIdx, vIdx))
+	if cIdx == prevCIdx && sPos == 0 {
+		r.send(operation.NewSetStateLcls(vIdx))
+	} else {
+		r.send(operation.NewSetState(cIdx, sIdx, vIdx))
+	}
 	r.db.SetState(addr, key, value)
 }
 


### PR DESCRIPTION
This new operation compresses SetState so that it refers to the last contract and last storage addresses without writing these addresses on the file.