### PR TITLE
Clean-up Finalise handling in StateDB and Carmen adapter

### DIFF
--- a/tracer/operation/endtransaction.go
+++ b/tracer/operation/endtransaction.go
@@ -36,7 +36,6 @@ func (op *EndTransaction) Write(f *os.File) error {
 // Execute the end-transaction operation.
 func (op *EndTransaction) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
 	ctx.InitSnapshot()
-	db.EndTransaction()
 }
 
 // Print a debug message for end-transaction.

--- a/tracer/state/carmen.go
+++ b/tracer/state/carmen.go
@@ -92,13 +92,10 @@ func (s *carmenStateDB) RevertToSnapshot(id int) {
 	s.db.RevertToSnapshot(id)
 }
 
-func (s *carmenStateDB) EndTransaction() error {
-	s.db.EndTransaction()
-	return nil // TODO: check for errors
-}
-
 func (s *carmenStateDB) Finalise(deleteEmptyObjects bool) {
-	// nothing to do
+	// In Geth 'Finalise' is called to end a transaction and seal its effects.
+	// In Carmen, this event is called 'EndTransaction'.
+	s.db.EndTransaction()
 }
 
 func (s *carmenStateDB) PrepareSubstate(substate *substate.SubstateAlloc) {

--- a/tracer/state/geth.go
+++ b/tracer/state/geth.go
@@ -80,11 +80,6 @@ func (s *gethStateDb) RevertToSnapshot(id int) {
 	s.db.RevertToSnapshot(id)
 }
 
-func (s *gethStateDb) EndTransaction() error {
-	// Nothing to do, all covered in Finalise.
-	return nil
-}
-
 func (s *gethStateDb) Finalise(deleteEmptyObjects bool) {
 	s.db.Finalise(deleteEmptyObjects)
 }

--- a/tracer/state/state.go
+++ b/tracer/state/state.go
@@ -36,7 +36,6 @@ type StateDB interface {
 	// Transaction handling
 	Snapshot() int
 	RevertToSnapshot(int)
-	EndTransaction() error
 	Finalise(bool)
 
 	// ---- Optional Development & Debugging Features ----


### PR DESCRIPTION
Turns out that the 'Finalise' operation has the intended semantic of 'EndTransaction'. Thus, this PR removes the 'EndTransaction' method of the StateDB.