### PR TITLE
Reduces bytes for storing SnapshotID from 4 bytes to 2 bytes

### DIFF
--- a/tracer/dict/dictionary_context.go
+++ b/tracer/dict/dictionary_context.go
@@ -180,12 +180,12 @@ func (ctx *DictionaryContext) InitSnapshot() {
 }
 
 // Add snaphot-id mapping for execution of RevertSnapshot.
-func (ctx *DictionaryContext) AddSnapshot(recordedID int32, replayedID int32) {
+func (ctx *DictionaryContext) AddSnapshot(recordedID uint16, replayedID uint16) {
 	ctx.SnapshotIndex.Add(recordedID, replayedID)
 }
 
 // Get snaphot-id.
-func (ctx *DictionaryContext) GetSnapshot(recordedID int32) int32 {
+func (ctx *DictionaryContext) GetSnapshot(recordedID uint16) uint16 {
 	replayedID, err := ctx.SnapshotIndex.Get(recordedID)
 	if err != nil {
 		log.Fatalf("Replayed Snapshot ID is missing. Error: %v", err)
@@ -194,7 +194,7 @@ func (ctx *DictionaryContext) GetSnapshot(recordedID int32) int32 {
 }
 
 ////////////////////////////////////////////////////////////////
-// Snapshot methods
+// Index cache methods
 ////////////////////////////////////////////////////////////////
 
 // Clear count queues.

--- a/tracer/dict/snapshot_index.go
+++ b/tracer/dict/snapshot_index.go
@@ -10,12 +10,12 @@ import (
 // for reverting a snapshot.
 
 type SnapshotIndex struct {
-	recordedToReplayed map[int32]int32
+	recordedToReplayed map[uint16]uint16
 }
 
 // Initialize a snapshot index.
 func (oIdx *SnapshotIndex) Init() {
-	oIdx.recordedToReplayed = make(map[int32]int32)
+	oIdx.recordedToReplayed = make(map[uint16]uint16)
 }
 
 // Create new snapshot index data structure.
@@ -26,12 +26,12 @@ func NewSnapshotIndex() *SnapshotIndex {
 }
 
 // Add new snapshot-id mapping.
-func (oIdx *SnapshotIndex) Add(recordedID int32, replayedID int32) {
+func (oIdx *SnapshotIndex) Add(recordedID uint16, replayedID uint16) {
 	oIdx.recordedToReplayed[recordedID] = replayedID
 }
 
 // Retrieve replayed snapshot-id from a recorded-id.
-func (oIdx *SnapshotIndex) Get(recordedID int32) (int32, error) {
+func (oIdx *SnapshotIndex) Get(recordedID uint16) (uint16, error) {
 	replayedID, ok := oIdx.recordedToReplayed[recordedID]
 	if !ok {
 		return 0, errors.New("snapshot-id does not exist")

--- a/tracer/dict/snapshot_index_test.go
+++ b/tracer/dict/snapshot_index_test.go
@@ -7,10 +7,10 @@ import (
 // Add()
 // Positive Test: Add a new set of mappings and compare the size of index map
 func TestPositiveSnapshotIndexAdd(t *testing.T) {
-	var recordedID1 int32 = 1
-	var recordedID2 int32 = 2
-	var replayedID1 int32 = 0
-	var replayedID2 int32 = 1
+	var recordedID1 uint16 = 1
+	var recordedID2 uint16 = 2
+	var replayedID1 uint16 = 0
+	var replayedID2 uint16 = 1
 	snapshotIdx := NewSnapshotIndex()
 	snapshotIdx.Add(recordedID1, replayedID1)
 	snapshotIdx.Add(recordedID2, replayedID2)
@@ -24,8 +24,8 @@ func TestPositiveSnapshotIndexAdd(t *testing.T) {
 
 // Positive Test: Add an ID twice, and check index result.
 func TestPositiveSnapshotIndexAddDuplicateID(t *testing.T) {
-	var recordedID int32 = 1
-	var replayedID int32 = 0
+	var recordedID uint16 = 1
+	var replayedID uint16 = 0
 	snapshotIdx := NewSnapshotIndex()
 	snapshotIdx.Add(recordedID, replayedID)
 	replayedID = 2
@@ -45,8 +45,8 @@ func TestPositiveSnapshotIndexAddDuplicateID(t *testing.T) {
 // Get()
 // Positive Test: Add ID to SnapshotIndex and compare with index result.
 func TestPositiveSnapshotIndexGet(t *testing.T) {
-	var recordedID int32 = 1
-	var replayedID int32 = 8
+	var recordedID uint16 = 1
+	var replayedID uint16 = 8
 	snapshotIdx := NewSnapshotIndex()
 	snapshotIdx.Add(recordedID, replayedID)
 	ID, err := snapshotIdx.Get(recordedID)
@@ -60,8 +60,8 @@ func TestPositiveSnapshotIndexGet(t *testing.T) {
 
 // Negative Test: ID of Get mismatches.
 func TestNegativeSnapshotIndexGet(t *testing.T) {
-	var recordedID int32 = 1
-	var replayedID int32 = 8
+	var recordedID uint16 = 1
+	var replayedID uint16 = 8
 	snapshotIdx := NewSnapshotIndex()
 	snapshotIdx.Add(recordedID, replayedID)
 	_, err := snapshotIdx.Get(recordedID + 1)

--- a/tracer/operation/reverttosnapshot.go
+++ b/tracer/operation/reverttosnapshot.go
@@ -11,7 +11,7 @@ import (
 
 // Revert-to-snapshot operation's data structure with returned snapshot id
 type RevertToSnapshot struct {
-	SnapshotID int32
+	SnapshotID uint16
 }
 
 // Return the revert-to-snapshot operation identifier.
@@ -21,7 +21,7 @@ func (op *RevertToSnapshot) GetOpId() byte {
 
 // Create a new revert-to-snapshot operation.
 func NewRevertToSnapshot(SnapshotID int) *RevertToSnapshot {
-	return &RevertToSnapshot{SnapshotID: int32(SnapshotID)}
+	return &RevertToSnapshot{SnapshotID: uint16(SnapshotID)}
 }
 
 // Read a revert-to-snapshot operation from file.

--- a/tracer/operation/snapshot.go
+++ b/tracer/operation/snapshot.go
@@ -13,7 +13,7 @@ import (
 
 // Snapshot data structure
 type Snapshot struct {
-	SnapshotID int32 // returned ID (for later mapping)
+	SnapshotID uint16 // returned ID (for later mapping)
 }
 
 // Return the snapshot operation identifier.
@@ -22,8 +22,11 @@ func (op *Snapshot) GetOpId() byte {
 }
 
 // Create a new snapshot operation.
-func NewSnapshot(SnapshotID int32) *Snapshot {
-	return &Snapshot{SnapshotID: SnapshotID}
+func NewSnapshot(snapshotID int) *Snapshot {
+	if snapshotID > math.MaxUint16 {
+		log.Fatalf("Snapshot ID exceeds 16 bit")
+	}
+	return &Snapshot{SnapshotID: uint16(snapshotID)}
 }
 
 // Read a snapshot operation from a file.
@@ -42,10 +45,10 @@ func (op *Snapshot) Write(f *os.File) error {
 // Execute the snapshot operation.
 func (op *Snapshot) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
 	ID := db.Snapshot()
-	if ID > math.MaxInt32 {
-		log.Fatalf("Snapshot ID exceeds 32 bit")
+	if ID > math.MaxUint16 {
+		log.Fatalf("Snapshot ID exceeds 16 bit")
 	}
-	ctx.AddSnapshot(op.SnapshotID, int32(ID))
+	ctx.AddSnapshot(op.SnapshotID, uint16(ID))
 }
 
 // Print the details for the snapshot operation.

--- a/tracer/proxy_recorder.go
+++ b/tracer/proxy_recorder.go
@@ -240,8 +240,7 @@ func (r *ProxyRecorder) RevertToSnapshot(snapshot int) {
 // Snapshot returns an identifier for the current revision of the state.
 func (r *ProxyRecorder) Snapshot() int {
 	snapshot := r.db.Snapshot()
-	// TODO: check overrun
-	r.send(operation.NewSnapshot(int32(snapshot)))
+	r.send(operation.NewSnapshot(snapshot))
 	return snapshot
 }
 


### PR DESCRIPTION
Reduces upper limit of storage ID to 65535 (uint16). This reduces the trace size of Snapshot and RevertToSnapshot from 5 bytes to 3 bytes.