### PR TITLE
Adds new compressed GetCodeHash operation

### DIFF
--- a/tracer/operation/getcodehash_lc.go
+++ b/tracer/operation/getcodehash_lc.go
@@ -1,0 +1,45 @@
+package operation
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Fantom-foundation/Aida/tracer/dict"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+)
+
+// Get-code-hash data structure with last contract address
+type GetCodeHashLc struct {
+}
+
+// Return the get-code-hash-lc operation identifier.
+func (op *GetCodeHashLc) GetOpId() byte {
+	return GetCodeHashLcID
+}
+
+// Create a new get-code-hash-lc operation.
+func NewGetCodeHashLc() *GetCodeHashLc {
+	return &GetCodeHashLc{}
+}
+
+// Read a get-code-hash-lc operation from a file.
+func ReadGetCodeHashLc(file *os.File) (Operation, error) {
+	return NewGetCodeHashLc(), nil
+}
+
+// Write the get-code-hash-lc operation to a file.
+func (op *GetCodeHashLc) Write(f *os.File) error {
+	return nil
+}
+
+// Execute the get-code-hash-lc operation.
+func (op *GetCodeHashLc) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	db.GetCodeHash(contract)
+}
+
+// Print a debug message for get-code-hash-lc.
+func (op *GetCodeHashLc) Debug(ctx *dict.DictionaryContext) {
+	contract := ctx.LastContractAddress()
+	fmt.Printf("\tcontract: %v\n", contract)
+}

--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -30,6 +30,7 @@ const (
 	CreateAccountID
 	GetBalanceID
 	GetCodeHashID
+	GetCodeHashLcID
 	SuicideID
 	ExistID
 	FinaliseID
@@ -62,6 +63,7 @@ var opDict = map[byte]OperationDictionary{
 	CreateAccountID:         {label: "CreateAccount", readfunc: ReadCreateAccount},
 	GetBalanceID:            {label: "GetBalance", readfunc: ReadGetBalance},
 	GetCodeHashID:           {label: "GetCodeHash", readfunc: ReadGetCodeHash},
+	GetCodeHashLcID:         {label: "GetCodeLcHash", readfunc: ReadGetCodeHashLc},
 	SuicideID:               {label: "Suicide", readfunc: ReadSuicide},
 	ExistID:                 {label: "Exist", readfunc: ReadExist},
 	FinaliseID:              {label: "Finalise", readfunc: ReadFinalise},

--- a/tracer/proxy_recorder.go
+++ b/tracer/proxy_recorder.go
@@ -76,8 +76,14 @@ func (r *ProxyRecorder) SetNonce(addr common.Address, nonce uint64) {
 
 // GetCodeHash returns the hash of the EVM bytecode.
 func (r *ProxyRecorder) GetCodeHash(addr common.Address) common.Hash {
+	prevCIdx := r.dctx.PrevContractIndex
 	cIdx := r.dctx.EncodeContract(addr)
-	r.send(operation.NewGetCodeHash(cIdx))
+	if prevCIdx == cIdx {
+		r.send(operation.NewGetCodeHashLc())
+	} else {
+		r.send(operation.NewGetCodeHash(cIdx))
+	}
+
 	hash := r.db.GetCodeHash(addr)
 	return hash
 }


### PR DESCRIPTION
New operation GetCodeHashLc executes GetCodeHash with the most recently used contract address without writing the address to the trace file.

This new operation replay roughly 50% of GetCodeHash.