### PR TITLE
Restrict build step to C++ library only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ gen-world-state:
 		./cmd/gen-world-state
 
 trace:
-	@cd carmen/go ; \
-	go generate ./... ; \
-	cd ../.. ; \
+	@cd carmen/go/lib ; \
+	./build_libcarmen.sh ; \
+	cd ../../.. ; \
 	GOPROXY=$(GOPROXY) \
 	GOPRIVATE=github.com/Fantom-foundation/Carmen \
 	go build -ldflags "-s -w" \


### PR DESCRIPTION
The more general `go generate` call tries to regenerate additional files that are not needed for a regular build (e.g. mock definitions for unit tests). Thus, this PR replaces the `go generate` call with a direct C++ build script call.