### PR TITLE
Add account hash to address map load from substate

### DIFF
--- a/cmd/gen-world-state/flags/flags.go
+++ b/cmd/gen-world-state/flags/flags.go
@@ -53,6 +53,21 @@ var (
 		Required: true,
 	}
 
+	// StartingBlock represents the ID of starting block
+	StartingBlock = cli.Uint64Flag{
+		Name:    "from",
+		Aliases: []string{"from-block"},
+		Usage:   "starting block ID",
+		Value:   1,
+	}
+
+	// EndingBlock represents the ID of ending block
+	EndingBlock = cli.Uint64Flag{
+		Name:    "to",
+		Aliases: []string{"to-block"},
+		Usage:   "ending block ID",
+	}
+
 	// TargetBlock represents the ID of target block to be reached by state evolve process
 	TargetBlock = cli.IntFlag{
 		Name:     "target",

--- a/world-state/db/snapshot/account.go
+++ b/world-state/db/snapshot/account.go
@@ -1,0 +1,171 @@
+// Package snapshot implements database interfaces for the world state manager.
+package snapshot
+
+import (
+	"bytes"
+	"context"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/substate"
+	"sync"
+)
+
+// SubstateIterator defines an interface of substate iterator we use to collect addresses.
+type SubstateIterator interface {
+	Next() bool
+	Value() *substate.Transaction
+	Release()
+}
+
+// ZeroAddressBytes represents the content of an empty address.
+var ZeroAddressBytes = common.Address{}.Bytes()
+
+// CollectAccounts collects accounts from the substate database iterator and sends them for processing.
+func CollectAccounts(ctx context.Context, in SubstateIterator, toBlock uint64, workers int) <-chan common.Address {
+	out := make(chan common.Address, workers*10)
+	go collectSubStateAccounts(ctx, in, toBlock, out, workers)
+	return out
+}
+
+// WriteAccountAddresses writes account addresses received from an input queue into world state snapshot database.
+func WriteAccountAddresses(ctx context.Context, in <-chan common.Address, db *StateDB) error {
+	var hashing = crypto.NewKeccakState()
+
+	ctxDone := ctx.Done()
+	for {
+		select {
+		case <-ctxDone:
+			return ctx.Err()
+		case adr, open := <-in:
+			if !open {
+				return nil
+			}
+
+			// calculate the hash of the account
+			err := db.PutHashToAccountAddress(crypto.HashData(hashing, adr.Bytes()), adr)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// FilterUniqueAccounts extracts accounts from input queue and sends only unique occurrences to the output.
+// The filter will close output channel once done processing incoming accounts.
+func FilterUniqueAccounts(ctx context.Context, in <-chan common.Address, out chan<- common.Address) {
+	defer close(out)
+
+	visited := make(map[common.Address]bool, 20_000_000)
+	ctxDone := ctx.Done()
+	for {
+		select {
+		case <-ctxDone:
+			return
+		case adr, open := <-in:
+			if !open {
+				return
+			}
+
+			// is this a unique address?
+			_, found := visited[adr]
+			if found {
+				continue
+			}
+
+			select {
+			case <-ctxDone:
+				return
+			case out <- adr:
+				visited[adr] = true
+			}
+		}
+	}
+}
+
+// collectSubStateAccounts iterates SubState database transactions and sends them for processing to a worker channel.
+// The iteration walker will close output channel once all the internal workers are done collecting addresses.
+func collectSubStateAccounts(ctx context.Context, in SubstateIterator, toBlock uint64, out chan<- common.Address, workers int) {
+	defer close(out)
+
+	// prepare structures for account collectors
+	work := make(chan *substate.Transaction, workers)
+	var wg sync.WaitGroup
+
+	// start account collector workers
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go extractSubStateAccounts(ctx, work, out, &wg)
+	}
+
+	// iterate SubStates to get transactions
+	ctxDone := ctx.Done()
+	for in.Next() {
+		tx := in.Value()
+		if toBlock > 0 && tx.Block > toBlock {
+			break
+		}
+
+		select {
+		case <-ctxDone:
+			break
+		case work <- tx:
+		}
+	}
+
+	// signal workers we are done iterating and wait for their termination
+	close(work)
+	wg.Wait()
+}
+
+// extractSubStateAccounts worker executes account collector job on substate records received via input queue.
+// Found account addresses are sent to an output queue for processing.
+// We do not care about sending unique address from the worker since it's expected to run in parallel,
+// the filtering should be done later down the queue line.
+func extractSubStateAccounts(ctx context.Context, in <-chan *substate.Transaction, out chan<- common.Address, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	ctxDone := ctx.Done()
+	for {
+		select {
+		case <-ctxDone:
+			return
+		case tx, open := <-in:
+			if !open {
+				return
+			}
+
+			// non-zero env coinbase
+			if tx.Substate.Env != nil && !bytes.Equal(tx.Substate.Env.Coinbase.Bytes(), ZeroAddressBytes) {
+				out <- tx.Substate.Env.Coinbase
+			}
+
+			// message sender and recipient
+			if tx.Substate.Message != nil {
+				out <- tx.Substate.Message.From
+
+				if tx.Substate.Message.To != nil {
+					out <- *tx.Substate.Message.To
+				}
+			}
+
+			// input alloc
+			if tx.Substate.InputAlloc != nil {
+				for adr := range tx.Substate.InputAlloc {
+					out <- adr
+				}
+			}
+
+			// output alloc
+			if tx.Substate.OutputAlloc != nil {
+				for adr := range tx.Substate.OutputAlloc {
+					out <- adr
+				}
+			}
+
+			// non-zero result contract address
+			if tx.Substate.Result != nil && !bytes.Equal(tx.Substate.Result.ContractAddress.Bytes(), ZeroAddressBytes) {
+				out <- tx.Substate.Result.ContractAddress
+			}
+		}
+	}
+}

--- a/world-state/db/snapshot/account_test.go
+++ b/world-state/db/snapshot/account_test.go
@@ -1,0 +1,194 @@
+package snapshot
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/substate"
+	"testing"
+)
+
+// mockIteratorSize represents the number of accounts created in the iterator
+const mockIteratorSize = 50
+
+type mockSubstateIterator struct {
+	list    []common.Address
+	hashing crypto.KeccakState
+	current int
+}
+
+func (i *mockSubstateIterator) Next() bool {
+	i.current++
+	return i.current < len(i.list)
+}
+
+func (i *mockSubstateIterator) Address() common.Address {
+	if i.current >= 0 && i.current < len(i.list) {
+		return i.list[i.current]
+	}
+	return common.Address{}
+}
+
+func (i *mockSubstateIterator) Value() *substate.Transaction {
+	if i.current < 0 || i.current >= len(i.list) {
+		panic(fmt.Errorf("invalid iterator position"))
+	}
+
+	// we mention each address as many times as we can (6x)
+	st := substate.Transaction{
+		Block:       uint64(len(i.list)),
+		Transaction: i.current,
+		Substate: &substate.Substate{
+			InputAlloc: map[common.Address]*substate.SubstateAccount{
+				i.list[i.current]: {},
+			},
+			OutputAlloc: map[common.Address]*substate.SubstateAccount{
+				i.list[i.current]: {},
+			},
+			Env: &substate.SubstateEnv{
+				Coinbase: i.list[i.current],
+			},
+			Message: &substate.SubstateMessage{
+				From: i.list[i.current],
+				To:   &i.list[i.current],
+			},
+			Result: &substate.SubstateResult{
+				ContractAddress: i.list[i.current],
+			},
+		},
+	}
+	return &st
+}
+
+func (i *mockSubstateIterator) Release() {
+	i.current = -1 // we do not point to any valid account after the release
+}
+
+func (i *mockSubstateIterator) IsKnown(a common.Address) bool {
+	for j := 0; j < mockIteratorSize; j++ {
+		if bytes.Equal(a.Bytes(), i.list[j].Bytes()) {
+			return true
+		}
+	}
+	return false
+}
+
+// makeMockIterator creates an instance of mock substate iterator for testing.
+func makeMockIterator(t *testing.T) *mockSubstateIterator {
+	iter := mockSubstateIterator{
+		list:    make([]common.Address, mockIteratorSize),
+		hashing: crypto.NewKeccakState(),
+		current: -1, // we do not point to any valid account at the beginning
+	}
+
+	for i := 0; i < mockIteratorSize; i++ {
+		pk, err := crypto.GenerateKey()
+		if err != nil {
+			t.Fatalf("failed test data build; could not create random keys; %s", err.Error())
+		}
+
+		iter.list[i] = crypto.PubkeyToAddress(pk.PublicKey)
+	}
+
+	return &iter
+}
+
+func TestCollectAccounts(t *testing.T) {
+	// prep mock iterator
+	ti := makeMockIterator(t)
+
+	// collect accounts from the iterator
+	visited := make(map[common.Address]int, len(ti.list))
+	ac := CollectAccounts(context.Background(), ti, 0, 5)
+
+	for {
+		ac, open := <-ac
+		if !open {
+			break
+		}
+
+		// increase visited counter to verify number of appearances
+		visited[ac]++
+
+		// check if the address is in the mock iterator
+		if !ti.IsKnown(ac) {
+			t.Fatalf("failed account check; expected to know %s, iterator reported FALSE", ac.String())
+		}
+	}
+
+	// check if each account has been visited expected number of times
+	for a, c := range visited {
+		if c != 6 {
+			t.Errorf("failed account frequency check; expected 6x account %s, got %dx", a.String(), c)
+		}
+	}
+}
+
+func TestFilterUniqueAccounts(t *testing.T) {
+	// prep mock iterator
+	ti := makeMockIterator(t)
+
+	ac := CollectAccounts(context.Background(), ti, 0, 5)
+
+	visited := make(map[common.Address]bool, len(ti.list))
+	unique := make(chan common.Address, cap(ac))
+	go FilterUniqueAccounts(context.Background(), ac, unique)
+
+	var count int
+	for {
+		ac, open := <-unique
+		if !open {
+			break
+		}
+
+		// check if the address is in the mock iterator
+		if !ti.IsKnown(ac) {
+			t.Fatalf("failed account check; expected to know %s, iterator reported FALSE", ac.String())
+		}
+
+		_, found := visited[ac]
+		if found {
+			t.Fatalf("failed unique account check; expected to see %s only once, got repeated occurence", ac.String())
+		}
+
+		count++
+	}
+
+	// do the unique number corresponds with expected
+	if count != len(ti.list) {
+		t.Errorf("failed account list size check; expected to see %d unique accounts, found %d", len(ti.list), count)
+	}
+}
+
+func TestWriteAccountAddresses(t *testing.T) {
+	// create in-memory database
+	db, err := OpenStateDB("")
+	if err != nil {
+		t.Fatalf("failed test data build; could not create test DB; %s", err.Error())
+	}
+
+	// prep mock iterator
+	ti := makeMockIterator(t)
+
+	err = WriteAccountAddresses(context.Background(), CollectAccounts(context.Background(), ti, uint64(len(ti.list)), 5), db)
+	if err != nil {
+		t.Fatalf("failed to write accounts; expected no error, got %s", err.Error())
+	}
+
+	// loop all accounts and check their mapping exists in the database
+	ti.Release()
+	for ti.Next() {
+		h := db.AccountAddressToHash(ti.Address())
+
+		adr, err := db.HashToAccountAddress(h)
+		if err != nil {
+			t.Fatalf("failed hash to address; expected to find hash %s, got error %s", h.String(), err.Error())
+		}
+
+		if !bytes.Equal(ti.Address().Bytes(), adr.Bytes()) {
+			t.Errorf("failed hash address check; expected to get %s, got %s", ti.Address().String(), adr.String())
+		}
+	}
+}

--- a/world-state/db/snapshot/iterator_test.go
+++ b/world-state/db/snapshot/iterator_test.go
@@ -39,6 +39,12 @@ func makeTestDB(t *testing.T) (*StateDB, map[common.Hash]types.Account, map[comm
 		hash := crypto.HashData(hashing, addr.Bytes())
 		adh[hash] = addr
 
+		// write the mapping into the test DB
+		err = db.PutHashToAccountAddress(hash, addr)
+		if err != nil {
+			t.Fatalf("failed test data build; could not write hash to address mapping; %s", err.Error())
+		}
+
 		// add this account to the map
 		acc := types.Account{
 			Hash:    hash,


### PR DESCRIPTION
The update allows world state dump manager to collect accounts from substate database and create a map from account hash to account address inside the world state DB. The DB interface has been extended to provide mapping loader and conversion in both directions.

We don't have substate data below block 4.5M. To resolve, we plan to feed at least some of the missing account addresses from a plain file import with another PR. Available data sources are Erigon pre-states, and GraphQL API server.

Added code unit test coverage is 89%, module test coverage is 73%.

Please review and comment. Thank you very much.