### PR TITLE
Make operation profilig more precise.

### DIFF
--- a/tracer/operation/beginblock.go
+++ b/tracer/operation/beginblock.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,8 +39,9 @@ func (op *BeginBlock) Write(f *os.File) error {
 }
 
 // Execute the begin-block operation.
-func (op *BeginBlock) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *BeginBlock) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	ctx.ClearIndexCaches()
+	return time.Duration(0)
 }
 
 // Print a debug message for begin-block.

--- a/tracer/operation/createaccount.go
+++ b/tracer/operation/createaccount.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,9 +39,11 @@ func (op *CreateAccount) Write(f *os.File) error {
 }
 
 // Execute the create account operation.
-func (op *CreateAccount) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *CreateAccount) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.DecodeContract(op.ContractIndex)
+	start := time.Now()
 	db.CreateAccount(contract)
+	return time.Since(start)
 }
 
 // Print a debug message for snapshot operation.

--- a/tracer/operation/endblock.go
+++ b/tracer/operation/endblock.go
@@ -2,6 +2,7 @@ package operation
 
 import (
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -32,7 +33,8 @@ func (op *EndBlock) Write(f *os.File) error {
 }
 
 // Execute the end-block operation.
-func (op *EndBlock) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *EndBlock) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
+	return time.Duration(0)
 }
 
 // Print a debug message for end-block.

--- a/tracer/operation/endtransaction.go
+++ b/tracer/operation/endtransaction.go
@@ -3,6 +3,7 @@ package operation
 import (
 	"encoding/binary"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -34,8 +35,9 @@ func (op *EndTransaction) Write(f *os.File) error {
 }
 
 // Execute the end-transaction operation.
-func (op *EndTransaction) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *EndTransaction) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	ctx.InitSnapshot()
+	return time.Duration(0)
 }
 
 // Print a debug message for end-transaction.

--- a/tracer/operation/exist.go
+++ b/tracer/operation/exist.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,9 +39,11 @@ func (op *Exist) Write(f *os.File) error {
 }
 
 // Execute the exist operation.
-func (op *Exist) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *Exist) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.DecodeContract(op.ContractIndex)
+	start := time.Now()
 	db.Exist(contract)
+	return time.Since(start)
 }
 
 // Print a debug message for exist.

--- a/tracer/operation/finalise.go
+++ b/tracer/operation/finalise.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,8 +39,10 @@ func (op *Finalise) Write(f *os.File) error {
 }
 
 // Execute the finalise operation.
-func (op *Finalise) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *Finalise) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
+	start := time.Now()
 	db.Finalise(op.DeleteEmptyObjects)
+	return time.Since(start)
 }
 
 // Print a debug message for finalise.

--- a/tracer/operation/getbalance.go
+++ b/tracer/operation/getbalance.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,9 +39,11 @@ func (op *GetBalance) Write(f *os.File) error {
 }
 
 // Execute the get-balance operation.
-func (op *GetBalance) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetBalance) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.DecodeContract(op.ContractIndex)
+	start := time.Now()
 	db.GetBalance(contract)
+	return time.Since(start)
 }
 
 // Print a debug message for get-balance.

--- a/tracer/operation/getcodehash.go
+++ b/tracer/operation/getcodehash.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,9 +39,11 @@ func (op *GetCodeHash) Write(f *os.File) error {
 }
 
 // Execute the get-code-hash operation.
-func (op *GetCodeHash) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetCodeHash) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.DecodeContract(op.ContractIndex)
+	start := time.Now()
 	db.GetCodeHash(contract)
+	return time.Since(start)
 }
 
 // Print a debug message for get-code-hash.

--- a/tracer/operation/getcodehash_lc.go
+++ b/tracer/operation/getcodehash_lc.go
@@ -3,6 +3,7 @@ package operation
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -33,9 +34,11 @@ func (op *GetCodeHashLc) Write(f *os.File) error {
 }
 
 // Execute the get-code-hash-lc operation.
-func (op *GetCodeHashLc) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetCodeHashLc) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.LastContractAddress()
+	start := time.Now()
 	db.GetCodeHash(contract)
+	return time.Since(start)
 }
 
 // Print a debug message for get-code-hash-lc.

--- a/tracer/operation/getcommittedstate.go
+++ b/tracer/operation/getcommittedstate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -39,10 +40,12 @@ func (op *GetCommittedState) Write(f *os.File) error {
 }
 
 // Execute the get-committed-state operation.
-func (op *GetCommittedState) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetCommittedState) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.DecodeContract(op.ContractIndex)
 	storage := ctx.DecodeStorage(op.StorageIndex)
+	start := time.Now()
 	db.GetCommittedState(contract, storage)
+	return time.Since(start)
 }
 
 // Print debug message for get-committed-state.

--- a/tracer/operation/getcommittedstate_lcls.go
+++ b/tracer/operation/getcommittedstate_lcls.go
@@ -3,6 +3,7 @@ package operation
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -33,10 +34,12 @@ func (op *GetCommittedStateLcls) Write(f *os.File) error {
 }
 
 // Execute the get-committed-state-lcls operation.
-func (op *GetCommittedStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetCommittedStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.LastContractAddress()
 	storage := ctx.LookupStorage(0)
+	start := time.Now()
 	db.GetCommittedState(contract, storage)
+	return time.Since(start)
 }
 
 // Print a debug message for get-committed-state-lcls operation.

--- a/tracer/operation/getstate.go
+++ b/tracer/operation/getstate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -39,10 +40,12 @@ func (op *GetState) Write(f *os.File) error {
 }
 
 // Execute the get-state operation.
-func (op *GetState) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetState) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.DecodeContract(op.ContractIndex)
 	storage := ctx.DecodeStorage(op.StorageIndex)
+	start := time.Now()
 	db.GetState(contract, storage)
+	return time.Since(start)
 }
 
 // Print a debug message.

--- a/tracer/operation/getstate_lc.go
+++ b/tracer/operation/getstate_lc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,10 +39,12 @@ func (op *GetStateLc) Write(f *os.File) error {
 }
 
 // Execute the get-state-lc operation.
-func (op *GetStateLc) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetStateLc) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.LastContractAddress()
 	storage := ctx.DecodeStorage(op.StorageIndex)
+	start := time.Now()
 	db.GetState(contract, storage)
+	return time.Since(start)
 }
 
 // Print a debug message.

--- a/tracer/operation/getstate_lccs.go
+++ b/tracer/operation/getstate_lccs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -43,10 +44,12 @@ func (op *GetStateLccs) Write(f *os.File) error {
 }
 
 // Execute the get-state-lccs operation.
-func (op *GetStateLccs) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetStateLccs) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.LastContractAddress()
 	storage := ctx.LookupStorage(int(op.StoragePosition))
+	start := time.Now()
 	db.GetState(contract, storage)
+	return time.Since(start)
 }
 
 // Print a debug message.

--- a/tracer/operation/getstate_lcls.go
+++ b/tracer/operation/getstate_lcls.go
@@ -3,6 +3,7 @@ package operation
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -33,10 +34,12 @@ func (op *GetStateLcls) Write(f *os.File) error {
 }
 
 // Execute the get-state-lcls operation.
-func (op *GetStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *GetStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.LastContractAddress()
 	storage := ctx.LookupStorage(0)
+	start := time.Now()
 	db.GetState(contract, storage)
+	return time.Since(start)
 }
 
 // Print a debug message for get-state-lcls operation.

--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -95,10 +95,10 @@ func getLabel(i byte) string {
 
 // Operation interface.
 type Operation interface {
-	GetOpId() byte                                  // get operation identifier
-	Write(*os.File) error                           // write operation to a file
-	Execute(state.StateDB, *dict.DictionaryContext) // execute operation on a stateDB instance
-	Debug(*dict.DictionaryContext)                  // print debug message for operation
+	GetOpId() byte                                                // get operation identifier
+	Write(*os.File) error                                         // write operation to a file
+	Execute(state.StateDB, *dict.DictionaryContext) time.Duration // execute operation on a stateDB instance
+	Debug(*dict.DictionaryContext)                                // print debug message for operation
 }
 
 // Read an operation from file.
@@ -146,13 +146,8 @@ func Write(f *os.File, op Operation) {
 
 // Execute an operation and profile it.
 func Execute(op Operation, db state.StateDB, ctx *dict.DictionaryContext) {
-	var start time.Time
+	elapsed := op.Execute(db, ctx)
 	if Profiling {
-		start = time.Now()
-	}
-	op.Execute(db, ctx)
-	if Profiling {
-		elapsed := time.Since(start)
 		op := op.GetOpId()
 		n := opFrequencyy[op]
 		duration := opDuration[op]

--- a/tracer/operation/reverttosnapshot.go
+++ b/tracer/operation/reverttosnapshot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,9 +39,11 @@ func (op *RevertToSnapshot) Write(f *os.File) error {
 }
 
 // Execute the revert-to-snapshot operation.
-func (op *RevertToSnapshot) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *RevertToSnapshot) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	id := ctx.GetSnapshot(op.SnapshotID)
+	start := time.Now()
 	db.RevertToSnapshot(int(id))
+	return time.Since(start)
 }
 
 // Print a debug message for revert-to-snapshot operation.

--- a/tracer/operation/setstate.go
+++ b/tracer/operation/setstate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -40,11 +41,13 @@ func (op *SetState) Write(f *os.File) error {
 }
 
 // Execute the set-state operation.
-func (op *SetState) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *SetState) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.DecodeContract(op.ContractIndex)
 	storage := ctx.DecodeStorage(op.StorageIndex)
 	value := ctx.DecodeValue(op.ValueIndex)
+	start := time.Now()
 	db.SetState(contract, storage, value)
+	return time.Since(start)
 }
 
 // Print a debug message for set-state.

--- a/tracer/operation/setstate_lcls.go
+++ b/tracer/operation/setstate_lcls.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -39,11 +40,13 @@ func (op *SetStateLcls) Write(f *os.File) error {
 }
 
 // Execute the set-state-lcls operation.
-func (op *SetStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *SetStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.LastContractAddress()
 	storage := ctx.LookupStorage(0)
 	value := ctx.DecodeValue(op.ValueIndex)
+	start := time.Now()
 	db.SetState(contract, storage, value)
+	return time.Since(start)
 }
 
 // Print a debug message for set-state-lcls.

--- a/tracer/operation/snapshot.go
+++ b/tracer/operation/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -43,12 +44,15 @@ func (op *Snapshot) Write(f *os.File) error {
 }
 
 // Execute the snapshot operation.
-func (op *Snapshot) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *Snapshot) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
+	start := time.Now()
 	ID := db.Snapshot()
+	elapsed := time.Since(start)
 	if ID > math.MaxUint16 {
 		log.Fatalf("Snapshot ID exceeds 16 bit")
 	}
 	ctx.AddSnapshot(op.SnapshotID, uint16(ID))
+	return elapsed
 }
 
 // Print the details for the snapshot operation.

--- a/tracer/operation/suicide.go
+++ b/tracer/operation/suicide.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"github.com/Fantom-foundation/Aida/tracer/state"
@@ -38,9 +39,11 @@ func (op *Suicide) Write(f *os.File) error {
 }
 
 // Execute the suicide operation.
-func (op *Suicide) Execute(db state.StateDB, ctx *dict.DictionaryContext) {
+func (op *Suicide) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
 	contract := ctx.DecodeContract(op.ContractIndex)
+	start := time.Now()
 	db.Suicide(contract)
+	return time.Since(start)
 }
 
 // Print a debug message for suicide.


### PR DESCRIPTION
Operation profiling measured dictionary lookups and other overheads caused by the Aida replay framework. This improvement ensures that the actual runtime of an operation is measured by pushing the responsibility of measuring to the execute() method of an operation.