### PR TITLE
Add Code Dictionary

### DIFF
--- a/tracer/dict/code_dictionary.go
+++ b/tracer/dict/code_dictionary.go
@@ -1,0 +1,136 @@
+package dict
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"os"
+)
+
+// Entry limit of code dictionary
+var CodeDictionaryLimit uint32 = math.MaxUint32 - 1
+
+// Dictionary data structure encodes/decodes byte code to a
+// dictionary index or vice versa.
+type CodeDictionary struct {
+	codeToIdx map[string]uint32 // code (as string) to an index map for encoding
+	idxToCode []string          // code  slice for decoding
+}
+
+// Init initializes or clears a code dictionary.
+func (d *CodeDictionary) Init() {
+	d.codeToIdx = map[string]uint32{}
+	d.idxToCode = []string{}
+}
+
+// NewCodeDictionary creates a new code dictionary.
+func NewCodeDictionary() *CodeDictionary {
+	p := new(CodeDictionary)
+	p.Init()
+	return p
+}
+
+// Encode byte code to a dictionary index.
+func (d *CodeDictionary) Encode(code []byte) (uint32, error) {
+	// find byte code
+	sCode := string(code)
+	idx, ok := d.codeToIdx[string(sCode)]
+	if !ok {
+		idx = uint32(len(d.idxToCode))
+		if idx >= CodeDictionaryLimit {
+			return 0, errors.New("Code dictionary exhausted")
+		}
+		d.codeToIdx[sCode] = idx
+		d.idxToCode = append(d.idxToCode, sCode)
+	}
+	return idx, nil
+}
+
+// Decode a dictionary index to byte code.
+func (d *CodeDictionary) Decode(idx uint32) ([]byte, error) {
+	if idx < uint32(len(d.idxToCode)) {
+		return []byte(d.idxToCode[idx]), nil
+	} else {
+		return nil, errors.New("Index out-of-bound")
+	}
+}
+
+// Write dictionary to a binary file.
+func (d *CodeDictionary) Write(filename string) error {
+	// open code dictionary file for writing
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		f.Close()
+	}()
+
+	// write all dictionary entries
+	for _, code := range d.idxToCode {
+		// write length of code block
+		if len(code) >= math.MaxUint32 {
+			return errors.New("Code size exceeds uint32")
+		}
+		length := uint32(len(code))
+		err := binary.Write(f, binary.LittleEndian, &length)
+		if err != nil {
+			return err
+		}
+
+		// write code
+		if _, err := f.Write([]byte(code)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Read dictionary from a binary file.
+func (d *CodeDictionary) Read(filename string) error {
+	// clear code dictionary
+	d.Init()
+
+	// open code dictionary file for reading
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		f.Close()
+	}()
+
+	// read entries from file
+	for ctr := uint32(0); true; ctr++ {
+		// read next entry
+
+		// read length
+		var length uint32
+		err := binary.Read(f, binary.LittleEndian, &length)
+		if err == io.EOF {
+			return nil
+		} else if err != nil {
+			return errors.New("Code dictionary file/reading is corrupted")
+		}
+
+		// read byte code
+		code := make([]byte, length)
+		n, err := f.Read(code)
+		if err != nil {
+			return errors.New("Code dictionary file/reading is corrupted")
+		} else if n != int(length) {
+			return errors.New("Code byte has wrong file size.")
+		}
+
+		// encode entry
+		idx, err := d.Encode(code)
+
+		if err != nil {
+			return err
+		} else if idx != ctr {
+			return errors.New("Corrupted code dictionary file entries")
+		}
+	}
+	return nil
+}

--- a/tracer/dict/code_dictionary_test.go
+++ b/tracer/dict/code_dictionary_test.go
@@ -1,0 +1,150 @@
+package dict
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"reflect"
+	"testing"
+)
+
+// Positive Test: Encode bytecode, and compare whether the decoded bytecode is the same,
+// and its index is zero.
+func TestPositiveCodeDictionarySimple1(t *testing.T) {
+	encodedCode := []byte{0x1, 0x0, 0x02, 0x5, 0x7}
+	dict := NewCodeDictionary()
+	idx, err1 := dict.Encode(encodedCode)
+	decodedCode, err2 := dict.Decode(idx)
+	if !reflect.DeepEqual(encodedCode, decodedCode) || err1 != nil || err2 != nil || idx != 0 {
+		t.Fatalf("Encoding/Decoding failed")
+	}
+}
+
+// Negative Test: Encode two bytecodes, and compare whether the decoded bytecode are the same,
+// and their dictionary indices are zero and one.
+func TestPositiveCodeDictionarySimple2(t *testing.T) {
+	encodedCode1 := []byte{0x1, 0x0, 0x2, 0x0, 0x5}
+	encodedCode2 := []byte{0x1, 0x0, 0x2}
+	dict := NewCodeDictionary()
+	idx1, err1 := dict.Encode(encodedCode1)
+	idx2, err2 := dict.Encode(encodedCode2)
+	decodedCode1, err3 := dict.Decode(idx1)
+	decodedCode2, err4 := dict.Decode(idx2)
+	if !reflect.DeepEqual(encodedCode1, decodedCode1) || err1 != nil || err3 != nil || idx1 != 0 {
+		t.Fatalf("Encoding/Decoding failed")
+	}
+	if !reflect.DeepEqual(encodedCode2, decodedCode2) || err2 != nil || err4 != nil || idx2 != 1 {
+		t.Fatalf("Encoding/Decoding failed")
+	}
+}
+
+// Positive Test: Encode the same byte code twice and check that it
+// is encoded only once, and its index is zero.
+func TestPositiveCodeDictionarySimple3(t *testing.T) {
+	encodedCode := []byte{0x1, 0x02, 0x3, 0x4}
+	dict := NewCodeDictionary()
+	idx1, err1 := dict.Encode(encodedCode)
+	idx2, err2 := dict.Encode(encodedCode)
+	decodedCode1, err3 := dict.Decode(idx1)
+	decodedCode2, err4 := dict.Decode(idx2)
+	if !reflect.DeepEqual(encodedCode, decodedCode1) || err1 != nil || err3 != nil || idx1 != 0 {
+		t.Fatalf("Encoding/Decoding failed")
+	}
+	if !reflect.DeepEqual(encodedCode, decodedCode2) || err2 != nil || err4 != nil || idx2 != 0 {
+		t.Fatalf("Encoding/Decoding failed")
+	}
+}
+
+// Negative Test: Check whether dictionary overflows can be captured.
+func TestNegativeCodeDictionaryOverflow(t *testing.T) {
+	encodedCode1 := []byte{0x1, 0x0, 0x2, 0x0, 0x5}
+	encodedCode2 := []byte{0x1, 0x0, 0x2}
+	dict := NewCodeDictionary()
+	// set limit to one storage
+	CodeDictionaryLimit = 1
+	_, err1 := dict.Encode(encodedCode1)
+	if err1 != nil {
+		t.Fatalf("Failed to encode a storage key")
+	}
+	_, err2 := dict.Encode(encodedCode2)
+	if err2 == nil {
+		t.Fatalf("Failed to report error when adding an exising storage key")
+	}
+	// reset limit
+	CodeDictionaryLimit = math.MaxUint32
+}
+
+// Negative Test: Check whether invalid index for Decode() can be captured.
+// (Retrieving index 0 on an empty dictionary)
+func TestNegativeCodeDictionaryDecodingFailure1(t *testing.T) {
+	dict := NewCodeDictionary()
+	_, err := dict.Decode(0)
+	if err == nil {
+		t.Fatalf("Failed to detect wrong index for Decode()")
+	}
+}
+
+// Negative Test: Check whether invalid index for Decode() can be captured.
+// (Retrieving index MaxUint32 on an empty dictionary)
+func TestNegativeCodeDictionaryDecodingFailure2(t *testing.T) {
+	dict := NewCodeDictionary()
+	_, err := dict.Decode(math.MaxUint32)
+	if err == nil {
+		t.Fatalf("Failed to detect wrong index for Decode()")
+	}
+}
+
+// Negative Test: Create corrupted file and read file as dictionary.
+func TestNegativeCodeDictionaryReadFailure(t *testing.T) {
+	filename := "./test.dict"
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open file")
+	}
+	// write corrupted entry
+	data := []byte("hellodello")
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("Failed to write data")
+	}
+	err = f.Close()
+	if err != nil {
+		t.Fatalf("Failed to close file")
+	}
+	rDict := NewCodeDictionary()
+	err = rDict.Read(filename)
+	if err == nil {
+		t.Fatalf("Failed to report error when reading a corrupted file")
+	}
+	os.Remove(filename)
+}
+
+// Positive Test: Encode two byte codes, write them to file, and read them from file.
+// Check whether the newly created dictionary read from file is identical.
+func TestPositiveCodeDictionaryReadWrite(t *testing.T) {
+	filename := "./test.dict"
+	encodedCode1 := []byte{0x1, 0x0, 0x2, 0x0, 0x5}
+	encodedCode2 := []byte{0x1, 0x0, 0x2}
+	wDict := NewCodeDictionary()
+	idx1, err1 := wDict.Encode(encodedCode1)
+	idx2, err2 := wDict.Encode(encodedCode2)
+	err := wDict.Write(filename)
+	if err != nil {
+		t.Fatalf("Failed to write file")
+	}
+	rDict := NewCodeDictionary()
+	err = rDict.Read(filename)
+	if err != nil {
+		t.Fatalf("Failed to read file")
+	}
+	decodedCode1, err3 := rDict.Decode(idx1)
+	decodedCode2, err4 := rDict.Decode(idx2)
+	if !reflect.DeepEqual(encodedCode1, decodedCode1) || err1 != nil || err3 != nil || idx1 != 0 {
+		fmt.Printf("%v %v\n", encodedCode1, decodedCode1)
+		t.Fatalf("Encoding/Decoding failed")
+	}
+	if !reflect.DeepEqual(encodedCode2, decodedCode2) || err2 != nil || err4 != nil || idx2 != 1 {
+		fmt.Printf("%v %v\n", encodedCode2, decodedCode2)
+		t.Fatalf("Encoding/Decoding failed")
+	}
+	os.Remove(filename)
+}


### PR DESCRIPTION
This PR adds a code dictionary to Aida so that the bytecode of a SetCode instruction can be stored in the trace. The dictionary is a simple map that converts a bytecode to a unique ordinal number. Note that the internal representation of bytecode is a string not a slice of byte (due to the map inside the dictionary).