### PR TITLE
Add Set/Get-Nonce Operation

### DIFF
--- a/tracer/operation/getnonce.go
+++ b/tracer/operation/getnonce.go
@@ -1,0 +1,52 @@
+package operation
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Fantom-foundation/Aida/tracer/dict"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+)
+
+// GetNonce data structure
+type GetNonce struct {
+	ContractIndex uint32 // encoded contract address
+}
+
+// GetOpId returns the get-nonce operation identifier.
+func (op *GetNonce) GetOpId() byte {
+	return GetNonceID
+}
+
+// NewGetNonce creates a new get-nonce operation.
+func NewGetNonce(cIdx uint32) *GetNonce {
+	return &GetNonce{ContractIndex: cIdx}
+}
+
+// ReadGetNonce reads a get-nonce operation from a file.
+func ReadGetNonce(file *os.File) (Operation, error) {
+	data := new(GetNonce)
+	err := binary.Read(file, binary.LittleEndian, data)
+	return data, err
+}
+
+// Write the get-nonce operation to a file.
+func (op *GetNonce) Write(f *os.File) error {
+	err := binary.Write(f, binary.LittleEndian, *op)
+	return err
+}
+
+// Execute the get-nonce operation.
+func (op *GetNonce) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
+	contract := ctx.DecodeContract(op.ContractIndex)
+	start := time.Now()
+	db.GetNonce(contract)
+	return time.Since(start)
+}
+
+// Debug prints a debug message for get-nonce.
+func (op *GetNonce) Debug(ctx *dict.DictionaryContext) {
+	fmt.Printf("\tcontract: %v\n", ctx.DecodeContract(op.ContractIndex))
+}

--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -25,6 +25,8 @@ const (
 	SetStateLclsID
 	GetCommittedStateID
 	GetCommittedStateLclsID
+	GetNonceID
+	SetNonceID
 	SnapshotID
 	RevertToSnapshotID
 	CreateAccountID
@@ -62,6 +64,8 @@ var opDict = map[byte]OperationDictionary{
 	RevertToSnapshotID:      {label: "RevertToSnapshot", readfunc: ReadRevertToSnapshot},
 	CreateAccountID:         {label: "CreateAccount", readfunc: ReadCreateAccount},
 	GetBalanceID:            {label: "GetBalance", readfunc: ReadGetBalance},
+	GetNonceID:              {label: "GetNonce", readfunc: ReadGetNonce},
+	SetNonceID:              {label: "SetNonce", readfunc: ReadSetNonce},
 	GetCodeHashID:           {label: "GetCodeHash", readfunc: ReadGetCodeHash},
 	GetCodeHashLcID:         {label: "GetCodeLcHash", readfunc: ReadGetCodeHashLc},
 	SuicideID:               {label: "Suicide", readfunc: ReadSuicide},

--- a/tracer/operation/setnonce.go
+++ b/tracer/operation/setnonce.go
@@ -1,0 +1,53 @@
+package operation
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Fantom-foundation/Aida/tracer/dict"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+)
+
+// SetNonce data structure
+type SetNonce struct {
+	ContractIndex uint32 // encoded contract address
+	Nonce         uint64 // nonce
+}
+
+// GetOpId returns the set-nonce operation identifier.
+func (op *SetNonce) GetOpId() byte {
+	return SetNonceID
+}
+
+// NewSetNonce creates a new set-nonce operation.
+func NewSetNonce(cIdx uint32, nonce uint64) *SetNonce {
+	return &SetNonce{ContractIndex: cIdx, Nonce: nonce}
+}
+
+// ReadSetNonce reads a set-nonce operation from a file.
+func ReadSetNonce(file *os.File) (Operation, error) {
+	data := new(SetNonce)
+	err := binary.Read(file, binary.LittleEndian, data)
+	return data, err
+}
+
+// Write the set-nonce operation to a file.
+func (op *SetNonce) Write(f *os.File) error {
+	err := binary.Write(f, binary.LittleEndian, *op)
+	return err
+}
+
+// Execute the set-nonce operation.
+func (op *SetNonce) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
+	contract := ctx.DecodeContract(op.ContractIndex)
+	start := time.Now()
+	db.SetNonce(contract, op.Nonce)
+	return time.Since(start)
+}
+
+// Debug prints a debug message for set-nonce.
+func (op *SetNonce) Debug(ctx *dict.DictionaryContext) {
+	fmt.Printf("\tcontract: %v nonce: %v\n", ctx.DecodeContract(op.ContractIndex), op.Nonce)
+}

--- a/tracer/proxy_recorder.go
+++ b/tracer/proxy_recorder.go
@@ -65,12 +65,16 @@ func (r *ProxyRecorder) GetBalance(addr common.Address) *big.Int {
 
 // GetNonce retrieves the nonce of a contract address.
 func (r *ProxyRecorder) GetNonce(addr common.Address) uint64 {
+	cIdx := r.dctx.EncodeContract(addr)
+	r.send(operation.NewGetNonce(cIdx))
 	nonce := r.db.GetNonce(addr)
 	return nonce
 }
 
 // SetNonce sets the nonce of a contract address.
 func (r *ProxyRecorder) SetNonce(addr common.Address, nonce uint64) {
+	cIdx := r.dctx.EncodeContract(addr)
+	r.send(operation.NewSetNonce(cIdx, nonce))
 	r.db.SetNonce(addr, nonce)
 }
 


### PR DESCRIPTION
The StateDB operations GetNonce() and SetNonce() for recording and replaying have been added by this PR. Both versions are uncompressed. More statistics are required to find out whether compression is necessary for GetNonce() and SetNonce().