### PR TITLE
Add SetCode Operation

### DIFF
--- a/tracer/dict/dictionary_context.go
+++ b/tracer/dict/dictionary_context.go
@@ -16,6 +16,7 @@ type DictionaryContext struct {
 	StorageDictionary  *StorageDictionary  // dictionary to compact storage addresses
 	StorageCache       *IndexCache         // storage address cache
 	ValueDictionary    *ValueDictionary    // dictionary to compact storage values
+	CodeDictionary     *CodeDictionary     // dictionary to compact the bytecode of contracts
 	SnapshotIndex      *SnapshotIndex      // snapshot index for execution (not for recording/replaying)
 }
 
@@ -191,6 +192,28 @@ func (ctx *DictionaryContext) GetSnapshot(recordedID int32) int32 {
 		log.Fatalf("Replayed Snapshot ID is missing. Error: %v", err)
 	}
 	return replayedID
+}
+
+////////////////////////////////////////////////////////////////
+// Code methods
+////////////////////////////////////////////////////////////////
+
+// Encode a bytecode to an index.
+func (ctx *DictionaryContext) EncodeCode(code []byte) uint32 {
+	bcIdx, err := ctx.CodeDictionary.Encode(code)
+	if err != nil {
+		log.Fatalf("Byte-code could not be encoded. Error: %v", err)
+	}
+	return bcIdx
+}
+
+// Decode the bytecode from an index.
+func (ctx *DictionaryContext) DecodeCode(bcIdx uint32) []byte {
+	code, err := ctx.CodeDictionary.Decode(bcIdx)
+	if err != nil {
+		log.Fatalf("Byte-code index could not be decoded. Error: %v", err)
+	}
+	return code
 }
 
 ////////////////////////////////////////////////////////////////

--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -33,6 +33,7 @@ const (
 	GetBalanceID
 	GetCodeHashID
 	GetCodeHashLcID
+	SetCodeID
 	SuicideID
 	ExistID
 	FinaliseID
@@ -66,6 +67,7 @@ var opDict = map[byte]OperationDictionary{
 	GetBalanceID:            {label: "GetBalance", readfunc: ReadGetBalance},
 	GetNonceID:              {label: "GetNonce", readfunc: ReadGetNonce},
 	SetNonceID:              {label: "SetNonce", readfunc: ReadSetNonce},
+	SetCodeID:               {label: "SetCode", readfunc: ReadSetCode},
 	GetCodeHashID:           {label: "GetCodeHash", readfunc: ReadGetCodeHash},
 	GetCodeHashLcID:         {label: "GetCodeLcHash", readfunc: ReadGetCodeHashLc},
 	SuicideID:               {label: "Suicide", readfunc: ReadSuicide},

--- a/tracer/operation/setcode.go
+++ b/tracer/operation/setcode.go
@@ -1,0 +1,58 @@
+package operation
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Fantom-foundation/Aida/tracer/dict"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+)
+
+// SetCode data structure
+type SetCode struct {
+	ContractIndex uint32 // encoded contract address
+	CodeIndex     uint32 // encoded bytecode
+}
+
+// GetOpId returns the set-code operation identifier.
+func (op *SetCode) GetOpId() byte {
+	return SetCodeID
+}
+
+// NewSetCode creates a new set-code operation.
+func NewSetCode(cIdx uint32, bcIdx uint32) *SetCode {
+	return &SetCode{ContractIndex: cIdx, CodeIndex: bcIdx}
+}
+
+// ReadSetCode reads a set-code operation from a file.
+func ReadSetCode(file *os.File) (Operation, error) {
+	data := new(SetCode)
+	err := binary.Read(file, binary.LittleEndian, data)
+	return data, err
+}
+
+// Write the set-code operation to a file.
+func (op *SetCode) Write(f *os.File) error {
+	err := binary.Write(f, binary.LittleEndian, *op)
+	return err
+}
+
+// Execute the set-code operation.
+func (op *SetCode) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Duration {
+	// TODO: Uncomment when SetCode is implemented.
+	// contract := ctx.DecodeContract(op.ContractIndex)
+	// code := ctx.DecodeCode(op.CodeIndex)
+	// start := time.Now()
+	// db.SetCode(contract, code)
+	// return time.Since(start)
+	return time.Duration(0)
+}
+
+// Debug prints a debug message for set-code.
+func (op *SetCode) Debug(ctx *dict.DictionaryContext) {
+	fmt.Sprintf("\tcontract: %v code: %x\n",
+		ctx.DecodeContract(op.ContractIndex),
+		ctx.DecodeCode(op.CodeIndex))
+}

--- a/tracer/proxy_recorder.go
+++ b/tracer/proxy_recorder.go
@@ -100,6 +100,9 @@ func (r *ProxyRecorder) GetCode(addr common.Address) []byte {
 
 // Setcode sets the EVM bytecode of a contract.
 func (r *ProxyRecorder) SetCode(addr common.Address, code []byte) {
+	cIdx := r.dctx.EncodeContract(addr)
+	bcIdx := r.dctx.EncodeCode(code)
+	r.send(operation.NewSetCode(cIdx, bcIdx))
 	r.db.SetCode(addr, code)
 }
 


### PR DESCRIPTION
This PR adds the SetCode() operation for the recorder and replayer. SetCode() has not been implemented in the StateDB interface. As soon as this is done, the commented code in the Execute() methods needs to be uncommented for the replayer.