### PR TITLE
Initialize code dictionary and add test cases for dictionary context

### DIFF
--- a/tracer/dict/dictionary_context.go
+++ b/tracer/dict/dictionary_context.go
@@ -16,7 +16,7 @@ type DictionaryContext struct {
 	PrevContractIndex  uint32              // previously used contract index
 
 	StorageDictionary *StorageDictionary // dictionary to compact storage addresses
-	StorageCache      *IndexCache        // storage address cache
+	StorageIndexCache *IndexCache        // storage address cache
 
 	ValueDictionary *ValueDictionary // dictionary to compact storage values
 
@@ -31,7 +31,7 @@ func NewDictionaryContext() *DictionaryContext {
 		ContractDictionary: NewContractDictionary(),
 		PrevContractIndex:  InvalidContractIndex,
 		StorageDictionary:  NewStorageDictionary(),
-		StorageCache:       NewIndexCache(),
+		StorageIndexCache:  NewIndexCache(),
 		ValueDictionary:    NewValueDictionary(),
 		CodeDictionary:     NewCodeDictionary(),
 		SnapshotIndex:      NewSnapshotIndex(),
@@ -121,7 +121,7 @@ func (ctx *DictionaryContext) EncodeStorage(storage common.Hash) (uint32, int) {
 	if err != nil {
 		log.Fatalf("Storage address could not be encoded. Error: %v", err)
 	}
-	pos := ctx.StorageCache.Place(sIdx)
+	pos := ctx.StorageIndexCache.Place(sIdx)
 	return sIdx, pos
 }
 
@@ -131,14 +131,14 @@ func (ctx *DictionaryContext) DecodeStorage(sIdx uint32) common.Hash {
 	if err != nil {
 		log.Fatalf("Storage index could not be decoded. Error: %v", err)
 	}
-	ctx.StorageCache.Place(sIdx)
+	ctx.StorageIndexCache.Place(sIdx)
 	return storage
 }
 
 // ReadStorage reads index-cache and returns the storage address.
 // TODO: rename method
 func (ctx *DictionaryContext) ReadStorage(sPos int) common.Hash {
-	sIdx, err := ctx.StorageCache.Get(sPos)
+	sIdx, err := ctx.StorageIndexCache.Get(sPos)
 	if err != nil {
 		log.Fatalf("Storage position could not be found. Error: %v", err)
 	}
@@ -152,7 +152,7 @@ func (ctx *DictionaryContext) ReadStorage(sPos int) common.Hash {
 // LookupStorage reads and updates index-cache.
 // TODO: rename method
 func (ctx *DictionaryContext) LookupStorage(sPos int) common.Hash {
-	sIdx, err := ctx.StorageCache.Get(sPos)
+	sIdx, err := ctx.StorageIndexCache.Get(sPos)
 	if err != nil {
 		log.Fatalf("Storage position could not be found. Error: %v", err)
 	}
@@ -233,5 +233,5 @@ func (ctx *DictionaryContext) DecodeCode(bcIdx uint32) []byte {
 // ClearIndexCaches clears index caches and previous addresses.
 func (ctx *DictionaryContext) ClearIndexCaches() {
 	ctx.PrevContractIndex = InvalidContractIndex
-	ctx.StorageCache.Clear()
+	ctx.StorageIndexCache.Clear()
 }

--- a/tracer/dict/dictionary_context_test.go
+++ b/tracer/dict/dictionary_context_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestDictionaryContextWriteReadEmpty writes and reads an empty dictionary
-// context to a directory
+// context to a directory.
 func TestDictionaryContextWriteReadEmpty(t *testing.T) {
 	DictionaryContextDir := "./test_dictionary_context"
 	if err := os.Mkdir(DictionaryContextDir, 0700); err != nil {
@@ -23,7 +23,7 @@ func TestDictionaryContextWriteReadEmpty(t *testing.T) {
 	}
 }
 
-// TestDictionaryContextEncodeContract encodes an address and check the returned index
+// TestDictionaryContextEncodeContract encodes an address and check the returned index.
 func TestDictionaryContextEncodeContract(t *testing.T) {
 	ctx := NewDictionaryContext()
 	encodedAddr := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
@@ -49,7 +49,7 @@ func TestDictionaryContextDecodeContract(t *testing.T) {
 
 // TestDictionaryContextLastContractAddress fetches the last used addresses
 // after encodeing and decoding, then compares whether they match the actual
-// last used contract addresses
+// last used contract addresses.
 func TestDictionaryContextLastContractAddress(t *testing.T) {
 	ctx := NewDictionaryContext()
 	encodedAddr1 := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
@@ -79,7 +79,7 @@ func TestDictionaryContextLastContractAddress(t *testing.T) {
 	}
 }
 
-// TestDictionaryContextEncodeStorage encodes a storage key and checks the returned index
+// TestDictionaryContextEncodeStorage encodes a storage key and checks the returned index.
 func TestDictionaryContextEncodeStorage(t *testing.T) {
 	ctx := NewDictionaryContext()
 	encodedKey := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
@@ -169,7 +169,7 @@ func TestDictionaryContextLookupStorage(t *testing.T) {
 	}
 }
 
-// TestDictionaryContextEncodeValue encodes a value and compares the returned index
+// TestDictionaryContextEncodeValue encodes a value and compares the returned index.
 func TestDictionaryContextEncodeValue(t *testing.T) {
 	ctx := NewDictionaryContext()
 	encodedValue := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
@@ -194,7 +194,7 @@ func TestDictionaryContextDecodeValue(t *testing.T) {
 }
 
 // TestDictionaryContextSnapshot adds a new snapshot pair to the snapshot
-// dictionary, then gets the replayed snapshot id from the dictionary
+// dictionary, then gets the replayed snapshot id from the dictionary.
 func TestDictionaryContextSnapshot(t *testing.T) {
 	ctx := NewDictionaryContext()
 	recordedID := int32(39)
@@ -210,7 +210,7 @@ func TestDictionaryContextSnapshot(t *testing.T) {
 	}
 }
 
-// TestDictionaryContextEncodeCode encodes byte-code to code dictionary
+// TestDictionaryContextEncodeCode encodes byte-code to code dictionary.
 func TestDictionaryContextEncodeCode(t *testing.T) {
 	ctx := NewDictionaryContext()
 	encodedCode := []byte{0x99, 0xe0, 0x5, 0xed, 0xce, 0xdf, 0xf5}
@@ -221,7 +221,7 @@ func TestDictionaryContextEncodeCode(t *testing.T) {
 }
 
 // TestDictionaryContextDecodeCode encodes then decodes byte-code, and compares
-// whether the byte-code arrays are matches
+// whether the byte-code arrays are matches.
 func TestDictionaryContextDecodeCode(t *testing.T) {
 	ctx := NewDictionaryContext()
 	encodedCode := []byte{0x99, 0xe0, 0x5, 0xed, 0xce, 0xdf, 0xf5}
@@ -236,7 +236,7 @@ func TestDictionaryContextDecodeCode(t *testing.T) {
 }
 
 // TestDictionaryContextClearIndexContext clears index caches and previous addresses
-// and confirms empty values
+// and confirms empty values.
 func TestDictionaryContextClearIndexContext(t *testing.T) {
 	ctx := NewDictionaryContext()
 	encodedAddr := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
@@ -247,7 +247,7 @@ func TestDictionaryContextClearIndexContext(t *testing.T) {
 	if ctx.PrevContractIndex != InvalidContractIndex {
 		t.Fatalf("Failed to clear previous contract index")
 	}
-	if pos, err := ctx.StorageCache.Get(0); err == nil || pos != 0 {
+	if pos, err := ctx.StorageIndexCache.Get(0); err == nil || pos != 0 {
 		t.Fatalf("Failed to clear storge cache")
 	}
 }


### PR DESCRIPTION
Root cause: missing the initilaization of code dictionary This pull request fix #60 and add test cases checking functions in dictionary_context.go