### PR TITLE
Add Range-Check for Snapshot-Id

### DIFF
--- a/tracer/proxy_recorder.go
+++ b/tracer/proxy_recorder.go
@@ -263,7 +263,7 @@ func (r *ProxyRecorder) RevertToSnapshot(snapshot int) {
 // Snapshot returns an identifier for the current revision of the state.
 func (r *ProxyRecorder) Snapshot() int {
 	snapshot := r.db.Snapshot()
-	if snapshot <= math.MinInt32 || snapshot >= math.MaxInt32 {
+	if snapshot < math.MinInt32 || snapshot > math.MaxInt32 {
 		log.Fatalf("Snapshot overflow (%v) in proxy recorder", snapshot)
 	}
 	r.send(operation.NewSnapshot(int32(snapshot)))


### PR DESCRIPTION
The proxy-recorder does not check whether a recorded snapshot-id is in the range of a 32bit signed integer number. This pull-request introduces a range change and bails out if the snapshot-id exceeds the range.