### PR TITLE
VM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ simulates transaction execution from block 5,000,000 to (and including) block 5,
 **Options**
  - `--chainid` sets the chain-id (useful if recording from testnet). Default: 250 (mainnet)`
  - `--cpuprofile` records a CPU profile for the replay to be inspected using `pprof`
+ - `--disable-progress` disable progress report. Default: `false`
  - `--substatedir` sets directory contain substate database. Default: `./substate.fantom`
  - `--trace-dir` sets trace file output directory. Default: `./`
  - `--trace-debug` print recorded operations. 
@@ -80,18 +81,19 @@ simulates transaction execution from block 5,000,000 to (and including) block 5,
 
 **Run**
 
-`./build/trace replay --worldstatedir path/to/world-state-4564025 5050000 5100000`
-reads the recorded traces and re-executes state operations from block 5,050,000 to 5,100,000. The tool initializes stateDB with accounts in the world state at block 4564025 from `path/to/world-state-4564025`. The storage operations are executed and update the stateDB sequentially in the order they were recorded. 
+`./build/trace replay --worldstatedir path/to/world-state 5050000 5100000`
+reads the recorded traces and re-executes state operations from block 5,050,000 to 5,100,000. The tool initializes stateDB with accounts in the world state from option `--worldstatedir`. The storage operations are executed and update the stateDB sequentially in the order they were recorded.
 
 **Options**
 
  - `--cpuprofile` records a CPU profile for the replay to be inspected using `pprof`
  - `--db-impl` select between `geth` and `carmen`. Default: `geth`
  - `--db-variant` select between implementation specific sub-variants, e.g. `go-ldb` or `cpp-file`
+ - `--disable-progress` disable progress report. Default: `false`
  - `--profile` records and displays summary information on operation performance
  - `--substatedir` sets directory contain substate database. Default: `./substate.fantom`
  - `--tracedir` sets trace file directory. Default: `./`
- - `--trace-debug` print replayed operations. 
+ - `--trace-debug` print replayed operations.
  - `--validate` validate the state after replaying traces.
  - `--workers` sets the number of worker threads.
  - `--worldstatedir` sets direcory contain world state.
@@ -108,9 +110,31 @@ reads the recorded traces and re-executes state operations from block 5,050,000 
  - `--cpuprofile` records a CPU profile for the replay to be inspected using `pprof`
  - `--db-impl` select between `geth` and `carmen`. Default: `geth`
  - `--db-variant` select between implementation specific sub-variants, e.g. `go-ldb` or `cpp-file`
+ - `--disable-progress` disable progress report. Default: `false`
  - `--profile` records and displays summary information on operation performance
  - `--substatedir` sets directory contain substate database. Default: `./substate.fantom`
  - `--tracedir` sets trace file directory. Default: `./`
- - `--trace-debug` print replayed operations. 
+ - `--trace-debug` print replayed operations.
+ - `--validate` validate the state after replaying traces.
+ - `--workers` sets the number of worker threads.
+
+### Run VM
+
+**Run**
+
+`./build/run-vm --worldstatedir path/to/world-state --db-impl [geth/carmen/memory] 4564026 5000000`
+executes transactions from block 4,564,026 to 5,000,000. The tool initializes stateDB with accounts in the world state from option `--worldstatedir`. Each transaction calls VM which issues a series of StateDB operations to a selected storage system.
+
+**Options**
+
+ - `--chainid` sets the chain-id (useful if recording from testnet). Default: 250 (mainnet)`
+ - `--cpuprofile` records a CPU profile for the replay to be inspected using `pprof`
+ - `--db-impl` select between `geth` and `carmen`. Default: `geth`
+ - `--db-variant` select between implementation specific sub-variants, e.g. `go-ldb` or `cpp-file`
+ - `--disable-progress` disable progress report. Default: `false`
+ - `--profile` records and displays summary information on operation performance
+ - `--substatedir` sets directory contain substate database. Default: `./substate.fantom`
+ - `--tracedir` sets trace file directory. Default: `./`
+ - `--trace-debug` print replayed operations.
  - `--validate` validate the state after replaying traces.
  - `--workers` sets the number of worker threads.

--- a/cmd/trace-cli/main.go
+++ b/cmd/trace-cli/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/Fantom-foundation/Aida/cmd/trace-cli/trace"
-	"github.com/ethereum/go-ethereum/substate"
 	"github.com/urfave/cli/v2"
 )
 
@@ -18,6 +17,7 @@ func initTraceApp() *cli.App {
 		Copyright: "(c) 2022 Fantom Foundation",
 		Flags:     []cli.Flag{},
 		Commands: []*cli.Command{
+			&trace.RunVMCommand,
 			&trace.TraceCompareLogCommand,
 			&trace.TraceRecordCommand,
 			&trace.TraceReplayCommand,
@@ -28,7 +28,6 @@ func initTraceApp() *cli.App {
 
 // main implements "trace" cli traceApplication.
 func main() {
-	substate.RecordReplay = true
 	app := initTraceApp()
 	if err := app.Run(os.Args); err != nil {
 		code := 1

--- a/cmd/trace-cli/trace/record.go
+++ b/cmd/trace-cli/trace/record.go
@@ -226,6 +226,7 @@ func sendOperation(dCtx *dict.DictionaryContext, ch chan operation.Operation, op
 
 // traceRecordAction implements trace command for recording.
 func traceRecordAction(ctx *cli.Context) error {
+	substate.RecordReplay = true
 	var err error
 
 	if ctx.Args().Len() != 2 {

--- a/cmd/trace-cli/trace/replay.go
+++ b/cmd/trace-cli/trace/replay.go
@@ -42,59 +42,39 @@ last block of the inclusive range of blocks to replay storage traces.`,
 }
 
 // traceReplayTask simulates storage operations from storage traces on stateDB.
-func traceReplayTask(first uint64, last uint64, cliCtx *cli.Context) error {
+func traceReplayTask(cfg *TraceConfig) error {
 	// load dictionaries & indexes
 	dCtx := dict.ReadDictionaryContext()
 
-	// get validation flag
-	validationEnabled := cliCtx.Bool(validateEndState.Name)
-	// get profiling flag
-	operation.Profiling = cliCtx.Bool(profileFlag.Name)
-	// get progress flag
-	enableProgress := !cliCtx.Bool(disableProgressFlag.Name)
-	// start CPU profiling if requested.
-	if profile_file_name := cliCtx.String(cpuProfileFlag.Name); profile_file_name != "" {
-		f, err := os.Create(profile_file_name)
-		if err != nil {
-			return err
-		}
-		pprof.StartCPUProfile(f)
-		defer pprof.StopCPUProfile()
-	}
-	// get number of workers
-	workers := cliCtx.Int(substate.WorkersFlag.Name)
-
 	// intialize the world state and advance it to the first block
-	fmt.Printf("trace replay: Load and advance worldstate to block %v\n", first-1)
-	ws, err := generateWorldState(cliCtx.String(worldStateDirFlag.Name), first-1, workers)
+	fmt.Printf("trace replay: Load and advance worldstate to block %v\n", cfg.first-1)
+	ws, err := generateWorldState(cfg.worldStateDir, cfg.first-1, cfg.workers)
 	if err != nil {
 		return err
 	}
 
 	// create a directory for the store to place all its files.
-	state_directory, err := ioutil.TempDir("", "state_db_*")
+	stateDirectory, err := ioutil.TempDir("", "state_db_*")
 	if err != nil {
 		return err
 	}
 
 	// instantiate the state DB under testing
-	impl := cliCtx.String(stateDbImplementation.Name)
-	variant := cliCtx.String(stateDbVariant.Name)
-	db, err := makeStateDB(state_directory, impl, variant)
+	db, err := makeStateDB(stateDirectory, cfg.impl, cfg.variant)
 	if err != nil {
 		return err
 	}
 
 	// prime stateDB
 	fmt.Printf("trace replay: Prime stateDB\n")
-	if cliCtx.String(stateDbImplementation.Name) != "memory" {
-		primeStateDB(ws, db)
-	} else {
+	if cfg.impl == "memory" {
 		db.PrepareSubstate(&ws)
+	} else {
+		primeStateDB(ws, db)
 	}
 
 	// initialize trace interator
-	traceIter := tracer.NewTraceIterator(first, last)
+	traceIter := tracer.NewTraceIterator(cfg.first, cfg.last)
 	defer traceIter.Release()
 
 	var (
@@ -102,7 +82,7 @@ func traceReplayTask(first uint64, last uint64, cliCtx *cli.Context) error {
 		sec     float64
 		lastSec float64
 	)
-	if enableProgress {
+	if cfg.enableProgress {
 		start = time.Now()
 		sec = time.Since(start).Seconds()
 		lastSec = time.Since(start).Seconds()
@@ -114,10 +94,10 @@ func traceReplayTask(first uint64, last uint64, cliCtx *cli.Context) error {
 		op := traceIter.Value()
 		if op.GetId() == operation.BeginBlockID {
 			block := op.(*operation.BeginBlock).BlockNumber
-			if block > last {
+			if block > cfg.last {
 				break
 			}
-			if enableProgress {
+			if cfg.enableProgress {
 				// report progress
 				sec = time.Since(start).Seconds()
 				if sec-lastSec >= 15 {
@@ -128,7 +108,7 @@ func traceReplayTask(first uint64, last uint64, cliCtx *cli.Context) error {
 
 		}
 		operation.Execute(op, db, dCtx)
-		if traceDebug {
+		if cfg.debug {
 			operation.Debug(dCtx, op)
 		}
 
@@ -137,16 +117,16 @@ func traceReplayTask(first uint64, last uint64, cliCtx *cli.Context) error {
 	sec = time.Since(start).Seconds()
 
 	// validate stateDB
-	if validationEnabled {
+	if cfg.enableValidation {
 		// advance the world state from the first block to the last block
-		advanceWorldState(ws, first, last, workers)
+		advanceWorldState(ws, cfg.first, cfg.last, cfg.workers)
 		if err := validateStateDB(ws, db); err != nil {
 			return fmt.Errorf("Validation failed. %v\n", err)
 		}
 	}
 
 	// print profile statistics (if enabled)
-	if operation.Profiling {
+	if operation.EnableProfiling {
 		operation.PrintProfiling()
 	}
 
@@ -157,10 +137,10 @@ func traceReplayTask(first uint64, last uint64, cliCtx *cli.Context) error {
 	}
 
 	// print progress summary
-	if enableProgress {
-		fmt.Printf("trace replay: Total elapsed time: %.3f s, processed %v blocks\n", sec, last-first+1)
+	if cfg.enableProgress {
+		fmt.Printf("trace replay: Total elapsed time: %.3f s, processed %v blocks\n", sec, cfg.last-cfg.first+1)
 		fmt.Printf("trace replay: Closing DB took %v\n", time.Since(start))
-		fmt.Printf("trace replay: Final disk usage: %v MiB\n", float32(getDirectorySize(state_directory))/float32(1024*1024))
+		fmt.Printf("trace replay: Final disk usage: %v MiB\n", float32(getDirectorySize(stateDirectory))/float32(1024*1024))
 	}
 
 	return nil
@@ -169,26 +149,31 @@ func traceReplayTask(first uint64, last uint64, cliCtx *cli.Context) error {
 // traceReplayAction implements trace command for replaying.
 func traceReplayAction(ctx *cli.Context) error {
 	var err error
-
-	// process arguments
-	if ctx.Args().Len() != 2 {
-		return fmt.Errorf("trace replay command requires exactly 2 arguments")
+	cfg, err := NewTraceConfig(ctx)
+	if err != nil {
+		return err
 	}
+
+	operation.EnableProfiling = ctx.Bool(profileFlag.Name)
+	// set trace directory
 	tracer.TraceDir = ctx.String(traceDirectoryFlag.Name) + "/"
 	dict.DictionaryContextDir = ctx.String(traceDirectoryFlag.Name) + "/"
-	if ctx.Bool(traceDebugFlag.Name) {
-		traceDebug = true
-	}
-	first, last, argErr := SetBlockRange(ctx.Args().Get(0), ctx.Args().Get(1))
-	if argErr != nil {
-		return argErr
+
+	// start CPU profiling if requested.
+	if profileFileName := ctx.String(cpuProfileFlag.Name); profileFileName != "" {
+		f, err := os.Create(profileFileName)
+		if err != nil {
+			return err
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
 	}
 
 	// run storage driver
 	substate.SetSubstateFlags(ctx)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
-	err = traceReplayTask(first, last, ctx)
+	err = traceReplayTask(cfg)
 
 	return err
 }

--- a/cmd/trace-cli/trace/run_vm.go
+++ b/cmd/trace-cli/trace/run_vm.go
@@ -1,0 +1,282 @@
+package trace
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"runtime/pprof"
+	"time"
+
+	"github.com/Fantom-foundation/Aida/tracer"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/Fantom-foundation/substate-cli/cmd/substate-cli/replay"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/substate"
+	"github.com/urfave/cli/v2"
+)
+
+// runVMCommand data structure for the record app
+var RunVMCommand = cli.Command{
+	Action:    runVM,
+	Name:      "run-vm",
+	Usage:     "run VM on the world-state",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	Flags: []cli.Flag{
+		&chainIDFlag,
+		&cpuProfileFlag,
+		&disableProgressFlag,
+		&profileFlag,
+		&stateDbImplementation,
+		&stateDbVariant,
+		&substate.WorkersFlag,
+		&substate.SubstateDirFlag,
+		&validateEndState,
+		&worldStateDirFlag,
+	},
+	Description: `
+The trace record command requires two arguments:
+<blockNumFirst> <blockNumLast>
+
+<blockNumFirst> and <blockNumLast> are the first and
+last block of the inclusive range of blocks to trace transactions.`,
+}
+
+var profile bool
+
+// runVMTask executes VM on a chosen storage system.
+func runVMTask(db state.StateDB, block uint64, tx int, recording *substate.Substate) error {
+
+	inputAlloc := recording.InputAlloc
+	inputEnv := recording.Env
+	inputMessage := recording.Message
+
+	outputAlloc := recording.OutputAlloc
+	outputResult := recording.Result
+
+	var (
+		vmConfig    vm.Config
+		chainConfig *params.ChainConfig
+	)
+
+	vmConfig = opera.DefaultVMConfig
+	vmConfig.NoBaseFee = true
+
+	// mainnet chain configuration
+	chainConfig = params.AllEthashProtocolChanges
+	chainConfig.ChainID = big.NewInt(int64(chainID))
+	chainConfig.LondonBlock = new(big.Int).SetUint64(37534833)
+	chainConfig.BerlinBlock = new(big.Int).SetUint64(37455223)
+
+	var hashError error
+	getHash := func(num uint64) common.Hash {
+		if inputEnv.BlockHashes == nil {
+			hashError = fmt.Errorf("getHash(%d) invoked, no blockhashes provided", num)
+			return common.Hash{}
+		}
+		h, ok := inputEnv.BlockHashes[num]
+		if !ok {
+			hashError = fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", num)
+		}
+		return h
+	}
+
+	// validate whether the input alloc is contained in the db
+	if err := validateStateDB(inputAlloc, db); err != nil {
+		msg := fmt.Sprintf("Block: %v Transaction: %v\n", block, tx)
+		return fmt.Errorf(msg+"Input alloc is not contained in the stateDB. %v", err)
+	}
+
+	// Apply Message
+	var (
+		gaspool = new(evmcore.GasPool)
+		//TODO check logs
+		//blockHash = common.Hash{0x01}
+		txHash  = common.Hash{0x02}
+		txIndex = tx
+	)
+
+	gaspool.AddGas(inputEnv.GasLimit)
+	blockCtx := vm.BlockContext{
+		CanTransfer: core.CanTransfer,
+		Transfer:    core.Transfer,
+		Coinbase:    inputEnv.Coinbase,
+		BlockNumber: new(big.Int).SetUint64(inputEnv.Number),
+		Time:        new(big.Int).SetUint64(inputEnv.Timestamp),
+		Difficulty:  inputEnv.Difficulty,
+		GasLimit:    inputEnv.GasLimit,
+		GetHash:     getHash,
+	}
+	// If currentBaseFee is defined, add it to the vmContext.
+	if inputEnv.BaseFee != nil {
+		blockCtx.BaseFee = new(big.Int).Set(inputEnv.BaseFee)
+	}
+
+	msg := inputMessage.AsMessage()
+
+	db.Prepare(txHash, txIndex)
+
+	txCtx := evmcore.NewEVMTxContext(msg)
+
+	evm := vm.NewEVM(blockCtx, txCtx, db, chainConfig, vmConfig)
+
+	snapshot := db.Snapshot()
+
+	msgResult, err := evmcore.ApplyMessage(evm, msg, gaspool)
+
+	if err != nil {
+		db.RevertToSnapshot(snapshot)
+		return err
+	}
+	if hashError != nil {
+		return hashError
+	}
+	if chainConfig.IsByzantium(blockCtx.BlockNumber) {
+		db.Finalise(true)
+	} else {
+		db.IntermediateRoot(chainConfig.IsEIP158(blockCtx.BlockNumber))
+	}
+
+	evmResult := &substate.SubstateResult{}
+	if msgResult.Failed() {
+		evmResult.Status = types.ReceiptStatusFailed
+	} else {
+		evmResult.Status = types.ReceiptStatusSuccessful
+	}
+
+	// TODO clear state execution context and validate logs
+	//evmResult.Logs = db.GetLogs(txHash, blockHash)
+	evmResult.Logs = outputResult.Logs
+	evmResult.Bloom = types.BytesToBloom(types.LogsBloom(evmResult.Logs))
+	if to := msg.To(); to == nil {
+		evmResult.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, msg.Nonce())
+	}
+	evmResult.GasUsed = msgResult.UsedGas
+
+	// check whether the outputAlloc substate is contained in the world-state db.
+	if err := validateStateDB(outputAlloc, db); err != nil {
+		msg := fmt.Sprintf("Block: %v Transaction: %v\n", block, tx)
+		return fmt.Errorf(msg+"Output alloc is not contained in the stateDB. %v", err)
+	}
+	r := outputResult.Equal(evmResult)
+	if !r {
+		fmt.Printf("Block: %v Transaction: %v\n", block, tx)
+		fmt.Printf("inconsistent output: result\n")
+		replay.PrintResultDiffSummary(outputResult, evmResult)
+		return fmt.Errorf("inconsistent output")
+	}
+	return nil
+}
+
+// runVM implements trace command for executing VM on a chosen storage system.
+func runVM(ctx *cli.Context) error {
+	var err error
+
+	cfg, argErr := NewTraceConfig(ctx)
+	if argErr != nil {
+		return argErr
+	}
+	profile = ctx.Bool(profileFlag.Name)
+
+	// Start CPU profiling if requested.
+	if profileFileName := ctx.String(cpuProfileFlag.Name); profileFileName != "" {
+		f, err := os.Create(profileFileName)
+		if err != nil {
+			return err
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
+	// process arguments
+	chainID = ctx.Int(chainIDFlag.Name)
+
+	// iterate through subsets in sequence
+	substate.SetSubstateFlags(ctx)
+	substate.OpenSubstateDBReadOnly()
+	defer substate.CloseSubstateDB()
+
+	fmt.Printf("trace replay: Load and advance worldstate to block %v\n", cfg.first-1)
+	ws, err := generateWorldState(cfg.worldStateDir, cfg.first-1, cfg.workers)
+	if err != nil {
+		return err
+	}
+
+	// create a directory for the store to place all its files.
+	stateDirectory, err := ioutil.TempDir("", "state_db_*")
+	if err != nil {
+		return err
+	}
+	// instantiate the state DB under testing
+	var db state.StateDB
+	db, err = makeStateDB(stateDirectory, cfg.impl, cfg.variant)
+	if err != nil {
+		return err
+	}
+	profileStateDB := tracer.NewProxyProfiler(db)
+	db = profileStateDB
+
+	// prime stateDB
+	fmt.Printf("trace replay: Prime stateDB\n")
+	if cfg.impl == "memory" {
+		db.PrepareSubstate(&ws)
+	} else {
+		primeStateDB(ws, db)
+	}
+	if cfg.enableValidation {
+		if err := validateStateDB(ws, db); err != nil {
+			return fmt.Errorf("Pre: World state is not contained in the stateDB. %v", err)
+		}
+	}
+
+	var (
+		start   time.Time
+		sec     float64
+		lastSec float64
+	)
+	if cfg.enableProgress {
+		start = time.Now()
+		sec = time.Since(start).Seconds()
+		lastSec = time.Since(start).Seconds()
+	}
+
+	iter := substate.NewSubstateIterator(cfg.first, cfg.workers)
+	defer iter.Release()
+	for iter.Next() {
+		tx := iter.Value()
+		// close off old block with an end-block operation
+		if tx.Block > cfg.last {
+			break
+		}
+		if err := runVMTask(db, tx.Block, tx.Transaction, tx.Substate); err != nil {
+			return fmt.Errorf("VM execution failed. %v", err)
+		}
+		if cfg.enableProgress {
+			// report progress
+			sec = time.Since(start).Seconds()
+			if sec-lastSec >= 15 {
+				fmt.Printf("trace record: Elapsed time: %.0f s, at block %v\n", sec, tx.Block)
+				lastSec = sec
+			}
+		}
+	}
+
+	if cfg.enableProgress {
+		sec = time.Since(start).Seconds()
+		fmt.Printf("trace record: Total elapsed time: %.3f s, processed %v blocks\n", sec, cfg.last-cfg.first+1)
+	}
+	if cfg.enableValidation {
+		advanceWorldState(ws, cfg.first, cfg.last, cfg.workers)
+		if err := validateStateDB(ws, db); err != nil {
+			return fmt.Errorf("World state is not contained in the stateDB. %v", err)
+		}
+	}
+	return err
+}

--- a/cmd/trace-cli/trace/validate.go
+++ b/cmd/trace-cli/trace/validate.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/substate"
 )
 
-// validateDatabase validates whether the world-state is contained in the db object
-// NB: We can only check what must be in the db (but cannot check whether db stores more)
+// validateStateDB validates whether the world-state is contained in the db object.
+// NB: We can only check what must be in the db (but cannot check whether db stores more).
 func validateStateDB(ws substate.SubstateAlloc, db state.StateDB) error {
 	for addr, account := range ws {
 		if !db.Exist(addr) {
@@ -43,7 +43,7 @@ func validateStateDB(ws substate.SubstateAlloc, db state.StateDB) error {
 }
 
 // compareSubstateStorage compares an output substate of a transaction with
-// a substate genereated from stateDB by the trace replayer
+// a substate genereated from stateDB by the trace replayer.
 func compareSubstateStorage(record, replay substate.SubstateAlloc) error {
 	for addr, recAcc := range record {
 		// addr exists in both substate

--- a/tracer/operation/mock_statedb.go
+++ b/tracer/operation/mock_statedb.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/substate"
 )
 
@@ -16,6 +17,10 @@ type MockStateDB struct {
 // NewMockStateDB creates a new mock StateDB object for testing execute
 func NewMockStateDB() *MockStateDB {
 	return &MockStateDB{}
+}
+
+func (s *MockStateDB) BeginBlockApply(root_hash common.Hash) error {
+	return nil
 }
 
 // GetSignature retrieves the call signature of the last call
@@ -113,6 +118,60 @@ func (s *MockStateDB) RevertToSnapshot(id int) {
 
 func (s *MockStateDB) Finalise(deleteEmptyObjects bool) {
 	s.msg = fmt.Sprintf("Finalise: %v", deleteEmptyObjects)
+}
+
+func (s *MockStateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	s.msg = fmt.Sprintf("IntermediateRoote: %v", deleteEmptyObjects)
+	return common.Hash{}
+}
+
+func (s *MockStateDB) Prepare(thash common.Hash, ti int) {
+	s.msg = fmt.Sprintf("Prepare: %v %v", thash, ti)
+}
+
+func (s *MockStateDB) AddRefund(gas uint64) {
+	s.msg = fmt.Sprintf("AddRefund: %v", gas)
+}
+
+func (s *MockStateDB) SubRefund(gas uint64) {
+	s.msg = fmt.Sprintf("SubRefund: %v", gas)
+}
+func (s *MockStateDB) GetRefund() uint64 {
+	s.msg = fmt.Sprintf("GetRefund:")
+	return uint64(0)
+}
+func (s *MockStateDB) PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	s.msg = fmt.Sprintf("PrepareAccessList %v %v %v %v", sender, dest, precompiles, txAccesses)
+}
+
+func (s *MockStateDB) AddressInAccessList(addr common.Address) bool {
+	s.msg = fmt.Sprintf("AddressInAccessList %v", addr)
+	return false
+}
+func (s *MockStateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	s.msg = fmt.Sprintf("SlotInAccessList %v %v", addr, slot)
+	return false, false
+}
+func (s *MockStateDB) AddAddressToAccessList(addr common.Address) {
+	s.msg = fmt.Sprintf("AddAddressToAccessList %v", addr)
+}
+func (s *MockStateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	s.msg = fmt.Sprintf("AddSlotToAccessList %v %v", addr, slot)
+}
+
+func (s *MockStateDB) AddLog(log *types.Log) {
+	s.msg = fmt.Sprintf("AddLog %v", log)
+}
+func (s *MockStateDB) AddPreimage(hash common.Hash, preimage []byte) {
+	s.msg = fmt.Sprintf("AddPreimage %v", hash)
+}
+func (s *MockStateDB) ForEachStorage(addr common.Address, cb func(common.Hash, common.Hash) bool) error {
+	s.msg = fmt.Sprintf("ForEachStorage %v", addr)
+	return nil
+}
+func (s *MockStateDB) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	s.msg = fmt.Sprintf("GetLog %v %v", hash, blockHash)
+	return nil
 }
 
 func (s *MockStateDB) PrepareSubstate(substate *substate.SubstateAlloc) {

--- a/tracer/operation/profile.go
+++ b/tracer/operation/profile.go
@@ -1,0 +1,78 @@
+package operation
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+var EnableProfiling = false
+
+// ProfileStats data structure contains statedb operation statistics.
+type ProfileStats struct {
+	opFrequency   [NumOperations]uint64        // operation frequency stats
+	opDuration    [NumOperations]time.Duration // accumulated operation duration
+	opMinDuration [NumOperations]time.Duration // min runtime observerd
+	opMaxDuration [NumOperations]time.Duration // max runtime observerd
+	opVariance    [NumOperations]float64       // duration variance
+}
+
+// Profiling records runtime and calculates statistics after
+// executing a state operation.
+func (ps *ProfileStats) Profile(id byte, elapsed time.Duration) {
+	n := ps.opFrequency[id]
+	duration := ps.opDuration[id]
+	// update min/max values
+	if n > 0 {
+		if ps.opMaxDuration[id] < elapsed {
+			ps.opMaxDuration[id] = elapsed
+		}
+		if ps.opMinDuration[id] > elapsed {
+			ps.opMinDuration[id] = elapsed
+		}
+	} else {
+		ps.opMinDuration[id] = elapsed
+		ps.opMaxDuration[id] = elapsed
+	}
+	// compute previous mean
+	prevMean := float64(0.0)
+	if n > 0 {
+		prevMean = float64(ps.opDuration[id]) / float64(n)
+	}
+	// update variance
+	newDuration := duration + elapsed
+	if n > 0 {
+		newMean := float64(newDuration) / float64(n+1)
+		ps.opVariance[id] = float64(n-1)*ps.opVariance[id]/float64(n) +
+			(newMean-prevMean)*(newMean-prevMean)/float64(n+1)
+	} else {
+		ps.opVariance[id] = 0.0
+	}
+
+	// update execution frequency
+	ps.opFrequency[id] = n + 1
+
+	// update accumulated duration and frequency
+	ps.opDuration[id] = newDuration
+}
+
+// PrintProfiling prints profiling information for executed operation.
+func (ps *ProfileStats) PrintProfiling() {
+	timeUnit := float64(time.Microsecond)
+	tuStr := "us"
+	fmt.Printf("id, n, mean(%v), std(%v), min(%v), max(%v)\n", tuStr, tuStr, tuStr, tuStr)
+	total := float64(0)
+	for id := byte(0); id < NumOperations; id++ {
+		n := ps.opFrequency[id]
+		mean := (float64(ps.opDuration[id]) / float64(n)) / timeUnit
+		std := math.Sqrt(ps.opVariance[id]) / timeUnit
+		min := float64(ps.opMinDuration[id]) / timeUnit
+		max := float64(ps.opMaxDuration[id]) / timeUnit
+		fmt.Printf("%v, %v, %v, %v, %v, %v\n", GetLabel(id), n, mean, std, min, max)
+
+		total += float64(ps.opDuration[id])
+	}
+	sec := total / float64(time.Second)
+	tps := float64(ps.opFrequency[EndTransactionID]) / sec
+	fmt.Printf("Total StateDB net execution time=%v (s) / ~%.1f Tx/s\n", sec, tps)
+}

--- a/tracer/proxy_profiler.go
+++ b/tracer/proxy_profiler.go
@@ -1,0 +1,250 @@
+package tracer
+
+import (
+	"github.com/Fantom-foundation/Aida/tracer/operation"
+	"github.com/Fantom-foundation/Aida/tracer/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/substate"
+	"math/big"
+	"time"
+)
+
+// ProxyProfiler data structure for capturing and recording
+// invoked StateDB operations.
+type ProxyProfiler struct {
+	db state.StateDB           // state db
+	ps *operation.ProfileStats // operation statistics
+}
+
+// NewProxyProfiler creates a new StateDB proxy.
+func NewProxyProfiler(db state.StateDB) *ProxyProfiler {
+	p := new(ProxyProfiler)
+	p.db = db
+	p.ps = new(operation.ProfileStats)
+	return p
+}
+
+// BeginBlockApply creates a new object copying state from
+// the old stateDB or clears execution state of stateDB
+func (p *ProxyProfiler) BeginBlockApply(root_hash common.Hash) error {
+	err := p.db.BeginBlockApply(root_hash)
+	return err
+}
+
+// CreateAccounts creates a new account.
+func (p *ProxyProfiler) CreateAccount(addr common.Address) {
+	start := time.Now()
+	p.db.CreateAccount(addr)
+	elapsed := time.Since(start)
+	p.ps.Profile(operation.CreateAccountID, elapsed)
+}
+
+// SubtractBalance subtracts amount from a contract address.
+func (p *ProxyProfiler) SubBalance(addr common.Address, amount *big.Int) {
+	start := time.Now()
+	p.db.SubBalance(addr, amount)
+	elapsed := time.Since(start)
+	p.ps.Profile(operation.SubBalanceID, elapsed)
+}
+
+// AddBalance adds amount to a contract address.
+func (p *ProxyProfiler) AddBalance(addr common.Address, amount *big.Int) {
+	start := time.Now()
+	p.db.AddBalance(addr, amount)
+	elapsed := time.Since(start)
+	p.ps.Profile(operation.AddBalanceID, elapsed)
+}
+
+// GetBalance retrieves the amount of a contract address.
+func (p *ProxyProfiler) GetBalance(addr common.Address) *big.Int {
+	start := time.Now()
+	balance := p.db.GetBalance(addr)
+	elapsed := time.Since(start)
+	p.ps.Profile(operation.GetBalanceID, elapsed)
+	return balance
+}
+
+// GetNonce retrieves the nonce of a contract address.
+func (p *ProxyProfiler) GetNonce(addr common.Address) uint64 {
+	start := time.Now()
+	nonce := p.db.GetNonce(addr)
+	elapsed := time.Since(start)
+	p.ps.Profile(operation.GetBalanceID, elapsed)
+	return nonce
+}
+
+// SetNonce sets the nonce of a contract address.
+func (p *ProxyProfiler) SetNonce(addr common.Address, nonce uint64) {
+	p.db.SetNonce(addr, nonce)
+}
+
+// GetCodeHash returns the hash of the EVM bytecode.
+func (p *ProxyProfiler) GetCodeHash(addr common.Address) common.Hash {
+	return p.db.GetCodeHash(addr)
+}
+
+// GetCode returns the EVM bytecode of a contract.
+func (p *ProxyProfiler) GetCode(addr common.Address) []byte {
+	return p.db.GetCode(addr)
+}
+
+// Setcode sets the EVM bytecode of a contract.
+func (p *ProxyProfiler) SetCode(addr common.Address, code []byte) {
+	p.db.SetCode(addr, code)
+}
+
+// GetCodeSize returns the EVM bytecode's size.
+func (p *ProxyProfiler) GetCodeSize(addr common.Address) int {
+	return p.db.GetCodeSize(addr)
+}
+
+// AddRefund adds gas to the refund counter.
+func (p *ProxyProfiler) AddRefund(gas uint64) {
+	p.db.AddRefund(gas)
+}
+
+// SubRefund subtracts gas to the refund counter.
+func (p *ProxyProfiler) SubRefund(gas uint64) {
+	p.db.SubRefund(gas)
+}
+
+// GetRefund returns the current value of the refund counter.
+func (p *ProxyProfiler) GetRefund() uint64 {
+	return p.db.GetRefund()
+}
+
+// GetCommittedState retrieves a value that is already committed.
+func (p *ProxyProfiler) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
+	return p.db.GetCommittedState(addr, key)
+}
+
+// GetState retrieves a value from the StateDB.
+func (p *ProxyProfiler) GetState(addr common.Address, key common.Hash) common.Hash {
+	return p.db.GetState(addr, key)
+}
+
+// SetState sets a value in the StateDB.
+func (p *ProxyProfiler) SetState(addr common.Address, key common.Hash, value common.Hash) {
+	p.db.SetState(addr, key, value)
+}
+
+// Suicide marks the given account as suicided. This clears the account balance.
+// The account is still available until the state is committed;
+// return a non-nil account after Suicide.
+func (p *ProxyProfiler) Suicide(addr common.Address) bool {
+	return p.db.Suicide(addr)
+}
+
+// HasSuicided checks whether a contract has been suicided.
+func (p *ProxyProfiler) HasSuicided(addr common.Address) bool {
+	return p.db.HasSuicided(addr)
+}
+
+// Exist checks whether the contract exists in the StateDB.
+// Notably this also returns true for suicided accounts.
+func (p *ProxyProfiler) Exist(addr common.Address) bool {
+	return p.db.Exist(addr)
+}
+
+// Empty checks whether the contract is either non-existent
+// or empty according to the EIP161 specification (balance = nonce = code = 0).
+func (p *ProxyProfiler) Empty(addr common.Address) bool {
+	return p.db.Empty(addr)
+}
+
+// PrepareAccessList handles the preparatory steps for executing a state transition with
+// regards to both EIP-2929 and EIP-2930:
+//
+// - Add sender to access list (2929)
+// - Add destination to access list (2929)
+// - Add precompiles to access list (2929)
+// - Add the contents of the optional tx access list (2930)
+//
+// This method should only be called if Berlin/2929+2930 is applicable at the current number.
+func (p *ProxyProfiler) PrepareAccessList(render common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	p.db.PrepareAccessList(render, dest, precompiles, txAccesses)
+}
+
+// AddAddressToAccessList adds an address to the access list.
+func (p *ProxyProfiler) AddAddressToAccessList(addr common.Address) {
+	p.db.AddAddressToAccessList(addr)
+}
+
+// AddressInAccessList checks whether an address is in the access list.
+func (p *ProxyProfiler) AddressInAccessList(addr common.Address) bool {
+	return p.db.AddressInAccessList(addr)
+}
+
+// SlotInAccessList checks whether the (address, slot)-tuple is in the access list.
+func (p *ProxyProfiler) SlotInAccessList(addr common.Address, slot common.Hash) (bool, bool) {
+	addressOk, slotOk := p.db.SlotInAccessList(addr, slot)
+	return addressOk, slotOk
+}
+
+// AddSlotToAccessList adds the given (address, slot)-tuple to the access list
+func (p *ProxyProfiler) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	p.db.AddSlotToAccessList(addr, slot)
+}
+
+// RevertToSnapshot reverts all state changes from a given revision.
+func (p *ProxyProfiler) RevertToSnapshot(snapshot int) {
+	p.db.RevertToSnapshot(snapshot)
+}
+
+// Snapshot returns an identifier for the current revision of the state.
+func (p *ProxyProfiler) Snapshot() int {
+	snapshot := p.db.Snapshot()
+	return snapshot
+}
+
+// AddLog adds a log entry.
+func (p *ProxyProfiler) AddLog(log *types.Log) {
+	p.db.AddLog(log)
+}
+
+// GetLogs retrieves log entries.
+func (p *ProxyProfiler) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	return p.db.GetLogs(hash, blockHash)
+}
+
+// AddPreimage adds a SHA3 preimage.
+func (p *ProxyProfiler) AddPreimage(addr common.Hash, image []byte) {
+	p.db.AddPreimage(addr, image)
+}
+
+// ForEachStorage performs a function over all storage locations in a contract.
+func (p *ProxyProfiler) ForEachStorage(addr common.Address, fn func(common.Hash, common.Hash) bool) error {
+	err := p.db.ForEachStorage(addr, fn)
+	return err
+}
+
+// Prepare sets the current transaction hash and index.
+func (p *ProxyProfiler) Prepare(thash common.Hash, ti int) {
+	p.db.Prepare(thash, ti)
+}
+
+// Finalise the state in StateDB.
+func (p *ProxyProfiler) Finalise(deleteEmptyObjects bool) {
+	p.db.Finalise(deleteEmptyObjects)
+}
+
+// IntermediateRoot computes the current hash of the StateDB.
+// It is called in between transactions to get the root hash that
+// goes into transaction receipts.
+func (p *ProxyProfiler) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	return p.db.IntermediateRoot(deleteEmptyObjects)
+}
+
+// GetSubstatePostAlloc gets substate post allocation.
+func (p *ProxyProfiler) GetSubstatePostAlloc() substate.SubstateAlloc {
+	return p.db.GetSubstatePostAlloc()
+}
+
+func (p *ProxyProfiler) PrepareSubstate(substate *substate.SubstateAlloc) {
+	p.db.PrepareSubstate(substate)
+}
+
+func (p *ProxyProfiler) Close() error {
+	return p.db.Close()
+}

--- a/tracer/state/carmen.go
+++ b/tracer/state/carmen.go
@@ -7,6 +7,7 @@ import (
 	cc "github.com/Fantom-foundation/Carmen/go/common"
 	carmen "github.com/Fantom-foundation/Carmen/go/state"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/substate"
 )
 
@@ -43,6 +44,10 @@ var getCodeCalled bool
 var getCodeSizeCalled bool
 var getCodeHashCalled bool
 var setCodeCalled bool
+
+func (s *carmenStateDB) BeginBlockApply(root_hash common.Hash) error {
+	return nil
+}
 
 func (s *carmenStateDB) CreateAccount(addr common.Address) {
 	s.db.CreateAccount(cc.Address(addr))
@@ -129,6 +134,15 @@ func (s *carmenStateDB) Finalise(deleteEmptyObjects bool) {
 	s.db.GetHash()
 }
 
+func (s *carmenStateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	s.db.EndTransaction()
+	return common.Hash(s.db.GetHash())
+}
+
+func (s *carmenStateDB) Prepare(thash common.Hash, ti int) {
+	//ignored
+}
+
 func (s *carmenStateDB) PrepareSubstate(substate *substate.SubstateAlloc) {
 	// ignored
 }
@@ -139,5 +153,57 @@ func (s *carmenStateDB) GetSubstatePostAlloc() substate.SubstateAlloc {
 
 func (s *carmenStateDB) Close() error {
 	// TODO: implement
+	return nil
+}
+
+func (s *carmenStateDB) AddRefund(uint64) {
+	// ignored
+}
+
+func (s *carmenStateDB) SubRefund(uint64) {
+	// ignored
+}
+
+func (s *carmenStateDB) GetRefund() uint64 {
+	// ignored
+	return uint64(0)
+}
+
+func (s *carmenStateDB) PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	// ignored
+}
+
+func (s *carmenStateDB) AddressInAccessList(addr common.Address) bool {
+	// ignored
+	return false
+}
+func (s *carmenStateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	// ignored
+	return false, false
+}
+func (s *carmenStateDB) AddAddressToAccessList(addr common.Address) {
+	// ignored
+}
+func (s *carmenStateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	// ignored
+}
+
+func (s *carmenStateDB) AddLog(*types.Log) {
+	// ignored
+}
+
+func (s *carmenStateDB) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	// ignored
+	return nil
+}
+
+func (s *carmenStateDB) AddPreimage(common.Hash, []byte) {
+	// ignored
+	panic("AddPreimage not implemented")
+}
+
+func (s *carmenStateDB) ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error {
+	// ignored
+	panic("ForEachStorage not implemented")
 	return nil
 }

--- a/tracer/state/geth_test.go
+++ b/tracer/state/geth_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	geth "github.com/ethereum/go-ethereum/core/state"
 )
 
 const N = 1000
@@ -24,7 +23,7 @@ func fillDb(t *testing.T, directory string) (common.Hash, error) {
 		db.SetState(address, key, value)
 	}
 
-	hash := db.(*gethStateDb).db.(*geth.StateDB).IntermediateRoot(true)
+	hash := db.IntermediateRoot(true)
 	//hash := db.(*gethStateDb).db.(*geth.StateDB).Commit(true)
 	if err = db.Close(); err != nil {
 		t.Fatalf("Failed to close DB: %v", err)

--- a/tracer/state/memory.go
+++ b/tracer/state/memory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	geth "github.com/Fantom-foundation/substate-cli/state"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/substate"
 )
 
@@ -11,18 +12,22 @@ func MakeGethInMemoryStateDB(variant string) (StateDB, error) {
 	if variant != "" {
 		return nil, fmt.Errorf("unkown variant: %v", variant)
 	}
-	return &gethInMemoryStateDb{}, nil
+	return &gethInMemoryStateDB{}, nil
 }
 
-type gethInMemoryStateDb struct {
-	gethStateDb
+type gethInMemoryStateDB struct {
+	gethStateDB
 }
 
-func (s *gethInMemoryStateDb) Close() error {
+func (s *gethInMemoryStateDB) BeginBlockApply(root_hash common.Hash) error {
+	return nil
+}
+
+func (s *gethInMemoryStateDB) Close() error {
 	// Nothing to do.
 	return nil
 }
 
-func (s *gethInMemoryStateDb) PrepareSubstate(substate *substate.SubstateAlloc) {
+func (s *gethInMemoryStateDB) PrepareSubstate(substate *substate.SubstateAlloc) {
 	s.db = geth.MakeInMemoryStateDB(substate)
 }

--- a/tracer/state/state.go
+++ b/tracer/state/state.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/substate"
 )
 
@@ -36,10 +37,30 @@ type BasicStateDB interface {
 	SetCode(common.Address, []byte)
 	GetCodeSize(common.Address) int
 
+	// Gas calculation
+	AddRefund(uint64)
+	SubRefund(uint64)
+	GetRefund() uint64
+
+	// Access list
+	PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
+	AddressInAccessList(addr common.Address) bool
+	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
+	AddAddressToAccessList(addr common.Address)
+	AddSlotToAccessList(addr common.Address, slot common.Hash)
+
 	// Transaction handling
 	Snapshot() int
 	RevertToSnapshot(int)
 	Finalise(bool)
+	IntermediateRoot(bool) common.Hash
+	Prepare(common.Hash, int)
+
+	AddLog(*types.Log)
+	GetLogs(common.Hash, common.Hash) []*types.Log
+	AddPreimage(common.Hash, []byte)
+
+	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
 
 	// Substate specific
 	GetSubstatePostAlloc() substate.SubstateAlloc
@@ -51,6 +72,9 @@ type StateDB interface {
 	// Requests the StateDB to flush all its content to secondary storage and shut down.
 	// After this call no more operations will be allowed on the state.
 	Close() error
+
+	// stateDB handler
+	BeginBlockApply(common.Hash) error
 
 	// ---- Optional Development & Debugging Features ----
 


### PR DESCRIPTION
This change contains an initial version of run-vm command which runs the EVM instead and executes StateDB operations issued by EVM on a chosen storage.New StateDB operations which are used during block processing (may be outside of EVM) have been added to StateDB interface.

./build/trace run-vm --db-impl <geth/carmen> 4564026 5000000

Note: this version only support execution from block 4564026.

This change also includes refactoring of command line flag handler and operation profiling.