### PR TITLE
Matej/operation tests

### DIFF
--- a/tracer/operation/addbalance.go
+++ b/tracer/operation/addbalance.go
@@ -60,5 +60,5 @@ func (op *AddBalance) Execute(db state.StateDB, ctx *dict.DictionaryContext) tim
 
 // Debug prints a debug message for the add-balance operation.
 func (op *AddBalance) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(AddBalanceID), ctx.DecodeContract(op.ContractIndex), new(big.Int).SetBytes(op.Amount[:]))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex), new(big.Int).SetBytes(op.Amount[:]))
 }

--- a/tracer/operation/addbalance_test.go
+++ b/tracer/operation/addbalance_test.go
@@ -40,9 +40,7 @@ func TestAddBalanceReadWrite(t *testing.T) {
 // TestAddBalanceDebug creates a new AddBalance object and checks its Debug message.
 func TestAddBalanceDebug(t *testing.T) {
 	dict, op, addr, value := initAddBalance(t)
-	testOperationDebug(t, dict, op, AddBalanceID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, value)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, value))
 }
 
 // TestAddBalanceExecute

--- a/tracer/operation/beginblock.go
+++ b/tracer/operation/beginblock.go
@@ -45,5 +45,5 @@ func (op *BeginBlock) Execute(db state.StateDB, ctx *dict.DictionaryContext) tim
 
 // Debug prints a debug message for the begin-block operation.
 func (op *BeginBlock) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %d\n", GetLabel(BeginBlockID), op.BlockNumber)
+	fmt.Print(op.BlockNumber)
 }

--- a/tracer/operation/beginblock_test.go
+++ b/tracer/operation/beginblock_test.go
@@ -38,9 +38,7 @@ func TestBeginBlockReadWrite(t *testing.T) {
 // TestBeginBlockDebug creates a new BeginBlock object and checks its Debug message.
 func TestBeginBlockDebug(t *testing.T) {
 	dict, op, value := initBeginBlock(t)
-	testOperationDebug(t, dict, op, BeginBlockID, func(label string) string {
-		return fmt.Sprintf("\t%s: %d\n", label, value)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(value))
 }
 
 // TestBeginBlockExecute

--- a/tracer/operation/createaccount.go
+++ b/tracer/operation/createaccount.go
@@ -48,5 +48,5 @@ func (op *CreateAccount) Execute(db state.StateDB, ctx *dict.DictionaryContext) 
 
 // Debug prints a debug message for the create-account operation.
 func (op *CreateAccount) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(CreateAccountID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/createaccount_test.go
+++ b/tracer/operation/createaccount_test.go
@@ -36,9 +36,8 @@ func TestCreateAccountReadWrite(t *testing.T) {
 // TestCreateAccountDebug creates a new CreateAccount object and checks its Debug message.
 func TestCreateAccountDebug(t *testing.T) {
 	dict, op, addr := initCreateAccount(t)
-	testOperationDebug(t, dict, op, CreateAccountID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
+
 }
 
 // TestCreateAccountExecute

--- a/tracer/operation/empty.go
+++ b/tracer/operation/empty.go
@@ -48,5 +48,5 @@ func (op *Empty) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Dur
 
 // Debug prints a debug message for the Empty operation.
 func (op *Empty) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(EmptyID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/empty_test.go
+++ b/tracer/operation/empty_test.go
@@ -36,9 +36,7 @@ func TestEmptyReadWrite(t *testing.T) {
 // TestEmptyDebug creates a new Empty object and checks its Debug message.
 func TestEmptyDebug(t *testing.T) {
 	dict, op, addr := initEmpty(t)
-	testOperationDebug(t, dict, op, EmptyID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestEmptyExecute

--- a/tracer/operation/endblock.go
+++ b/tracer/operation/endblock.go
@@ -1,7 +1,6 @@
 package operation
 
 import (
-	"fmt"
 	"io"
 	"time"
 
@@ -40,5 +39,4 @@ func (op *EndBlock) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.
 
 // Debug prints a debug message for the end-block operation.
 func (op *EndBlock) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s\n", GetLabel(EndBlockID))
 }

--- a/tracer/operation/endblock_test.go
+++ b/tracer/operation/endblock_test.go
@@ -1,7 +1,6 @@
 package operation
 
 import (
-	"fmt"
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"testing"
 )
@@ -33,9 +32,7 @@ func TestEndBlockReadWrite(t *testing.T) {
 // TestEndBlockDebug creates a new EndBlock object and checks its Debug message.
 func TestEndBlockDebug(t *testing.T) {
 	dict, op := initEndBlock(t)
-	testOperationDebug(t, dict, op, EndBlockID, func(label string) string {
-		return fmt.Sprintf("\t%s\n", label)
-	})
+	testOperationDebug(t, dict, op, "")
 }
 
 // TestEndBlockExecute

--- a/tracer/operation/endtransaction.go
+++ b/tracer/operation/endtransaction.go
@@ -2,7 +2,6 @@ package operation
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"time"
 
@@ -43,5 +42,4 @@ func (op *EndTransaction) Execute(db state.StateDB, ctx *dict.DictionaryContext)
 
 // Debug prints a debug message for the end-transaction operation.
 func (op *EndTransaction) Debug(*dict.DictionaryContext) {
-	fmt.Printf("\t%s\n", GetLabel(EndTransactionID))
 }

--- a/tracer/operation/endtransaction_test.go
+++ b/tracer/operation/endtransaction_test.go
@@ -1,7 +1,6 @@
 package operation
 
 import (
-	"fmt"
 	"github.com/Fantom-foundation/Aida/tracer/dict"
 	"testing"
 )
@@ -33,9 +32,7 @@ func TestEndTransactionReadWrite(t *testing.T) {
 // TestEndTransactionDebug creates a new EndTransaction object and checks its Debug message.
 func TestEndTransactionDebug(t *testing.T) {
 	dict, op := initEndTransaction(t)
-	testOperationDebug(t, dict, op, EndTransactionID, func(label string) string {
-		return fmt.Sprintf("\t%s\n", label)
-	})
+	testOperationDebug(t, dict, op, "")
 }
 
 // TestEndTransactionExecute

--- a/tracer/operation/exist.go
+++ b/tracer/operation/exist.go
@@ -48,5 +48,5 @@ func (op *Exist) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.Dur
 
 // Debug prints a debug message for the exist operation.
 func (op *Exist) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(ExistID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/exist_test.go
+++ b/tracer/operation/exist_test.go
@@ -36,9 +36,7 @@ func TestExistReadWrite(t *testing.T) {
 // TestExistDebug creates a new Exist object and checks its Debug message.
 func TestExistDebug(t *testing.T) {
 	dict, op, addr := initExist(t)
-	testOperationDebug(t, dict, op, ExistID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestExistExecute

--- a/tracer/operation/finalise.go
+++ b/tracer/operation/finalise.go
@@ -47,5 +47,5 @@ func (op *Finalise) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.
 
 // Debug prints a debug message for the finalise operation.
 func (op *Finalise) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %t\n", GetLabel(FinaliseID), op.DeleteEmptyObjects)
+	fmt.Print(op.DeleteEmptyObjects)
 }

--- a/tracer/operation/finalise_test.go
+++ b/tracer/operation/finalise_test.go
@@ -37,9 +37,7 @@ func TestFinaliseReadWrite(t *testing.T) {
 // TestFinaliseDebug creates a new Finalise object and checks its Debug message.
 func TestFinaliseDebug(t *testing.T) {
 	dict, op, deleteEmpty := initFinalise(t)
-	testOperationDebug(t, dict, op, FinaliseID, func(label string) string {
-		return fmt.Sprintf("\t%s: %t\n", label, deleteEmpty)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(deleteEmpty))
 }
 
 // TestFinaliseExecute

--- a/tracer/operation/getbalance.go
+++ b/tracer/operation/getbalance.go
@@ -48,5 +48,5 @@ func (op *GetBalance) Execute(db state.StateDB, ctx *dict.DictionaryContext) tim
 
 // Debug prints a debug message for the get-balance operation.
 func (op *GetBalance) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(GetBalanceID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/getbalance_test.go
+++ b/tracer/operation/getbalance_test.go
@@ -36,9 +36,7 @@ func TestGetBalanceReadWrite(t *testing.T) {
 // TestGetBalanceDebug creates a new GetBalance object and checks its Debug message.
 func TestGetBalanceDebug(t *testing.T) {
 	dict, op, addr := initGetBalance(t)
-	testOperationDebug(t, dict, op, GetBalanceID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestGetBalanceExecute

--- a/tracer/operation/getcode.go
+++ b/tracer/operation/getcode.go
@@ -48,5 +48,5 @@ func (op *GetCode) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.D
 
 // Debug prints a debug message for the get-code operation.
 func (op *GetCode) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(GetCodeID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/getcode_test.go
+++ b/tracer/operation/getcode_test.go
@@ -35,9 +35,7 @@ func TestGetCodeReadWrite(t *testing.T) {
 // TestGetCodeDebug creates a new GetCode object and checks its Debug message.
 func TestGetCodeDebug(t *testing.T) {
 	dict, op, addr := initGetCode(t)
-	testOperationDebug(t, dict, op, GetCodeID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestGetCodeExecute creates a new GetCode object and checks its execution signature.

--- a/tracer/operation/getcodehash.go
+++ b/tracer/operation/getcodehash.go
@@ -48,5 +48,5 @@ func (op *GetCodeHash) Execute(db state.StateDB, ctx *dict.DictionaryContext) ti
 
 // Debug prints a debug message for the get-code-hash operation.
 func (op *GetCodeHash) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(GetCodeHashID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/getcodehash_lc.go
+++ b/tracer/operation/getcodehash_lc.go
@@ -49,5 +49,5 @@ func (op *GetCodeHashLc) Execute(db state.StateDB, ctx *dict.DictionaryContext) 
 // Debug prints a debug message for the get-code-hash-lc operation.
 func (op *GetCodeHashLc) Debug(ctx *dict.DictionaryContext) {
 	contract := ctx.LastContractAddress()
-	fmt.Printf("\t%s: %s\n", GetLabel(GetCodeHashLcID), contract)
+	fmt.Print(contract)
 }

--- a/tracer/operation/getcodehash_lc_test.go
+++ b/tracer/operation/getcodehash_lc_test.go
@@ -37,9 +37,7 @@ func TestGetCodeHashLcReadWrite(t *testing.T) {
 // TestGetCodeHashLcDebug creates a new GetCodeHashLc object and checks its Debug message.
 func TestGetCodeHashLcDebug(t *testing.T) {
 	dict, op, addr := initGetCodeHashLc(t)
-	testOperationDebug(t, dict, op, GetCodeHashLcID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestGetCodeHashLcExecute

--- a/tracer/operation/getcodehash_test.go
+++ b/tracer/operation/getcodehash_test.go
@@ -36,9 +36,7 @@ func TestGetCodeHashReadWrite(t *testing.T) {
 // TestGetCodeHashDebug creates a new GetCodeHash object and checks its Debug message.
 func TestGetCodeHashDebug(t *testing.T) {
 	dict, op, addr := initGetCodeHash(t)
-	testOperationDebug(t, dict, op, GetCodeHashID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestGetCodeHashExecute

--- a/tracer/operation/getcodesize.go
+++ b/tracer/operation/getcodesize.go
@@ -48,5 +48,5 @@ func (op *GetCodeSize) Execute(db state.StateDB, ctx *dict.DictionaryContext) ti
 
 // Debug prints a debug message for get-code-size.
 func (op *GetCodeSize) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(GetCodeSizeID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/getcodesize_test.go
+++ b/tracer/operation/getcodesize_test.go
@@ -36,9 +36,7 @@ func TestGetCodeSizeReadWrite(t *testing.T) {
 // TestGetCodeSizeDebug creates a new GetCodeSize object and checks its Debug message.
 func TestGetCodeSizeDebug(t *testing.T) {
 	dict, op, addr := initGetCodeSize(t)
-	testOperationDebug(t, dict, op, GetCodeSizeID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestGetCodeSizeExecute creates a new GetCodeSize object and checks its execution signature.

--- a/tracer/operation/getcommittedstate.go
+++ b/tracer/operation/getcommittedstate.go
@@ -50,5 +50,5 @@ func (op *GetCommittedState) Execute(db state.StateDB, ctx *dict.DictionaryConte
 
 // Debug prints debug message for the get-committed-state operation.
 func (op *GetCommittedState) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(GetCommittedStateID), ctx.DecodeContract(op.ContractIndex), ctx.DecodeStorage(op.StorageIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex), ctx.DecodeStorage(op.StorageIndex))
 }

--- a/tracer/operation/getcommittedstate_lcls.go
+++ b/tracer/operation/getcommittedstate_lcls.go
@@ -52,5 +52,5 @@ func (op *GetCommittedStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryC
 func (op *GetCommittedStateLcls) Debug(ctx *dict.DictionaryContext) {
 	contract := ctx.LastContractAddress()
 	storage := ctx.ReadStorage(0)
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(GetCommittedStateLclsID), contract, storage)
+	fmt.Print(contract, storage)
 }

--- a/tracer/operation/getcommittedstate_lcls_test.go
+++ b/tracer/operation/getcommittedstate_lcls_test.go
@@ -40,9 +40,7 @@ func TestGetCommittedStateLclsReadWrite(t *testing.T) {
 // TestGetCommittedStateLclsDebug creates a new GetCommittedStateLcls object and checks its Debug message.
 func TestGetCommittedStateLclsDebug(t *testing.T) {
 	dict, op, addr, storage := initGetCommittedStateLcls(t)
-	testOperationDebug(t, dict, op, GetCommittedStateLclsID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, storage)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, storage))
 }
 
 // TestGetCommittedStateLclsExecute

--- a/tracer/operation/getcommittedstate_test.go
+++ b/tracer/operation/getcommittedstate_test.go
@@ -38,9 +38,7 @@ func TestGetCommittedStateReadWrite(t *testing.T) {
 // TestGetCommittedStateDebug creates a new GetCommittedState object and checks its Debug message.
 func TestGetCommittedStateDebug(t *testing.T) {
 	dict, op, addr, storage := initGetCommittedState(t)
-	testOperationDebug(t, dict, op, GetCommittedStateID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, storage)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, storage))
 }
 
 // TestGetCommittedStateExecute

--- a/tracer/operation/getnonce.go
+++ b/tracer/operation/getnonce.go
@@ -48,5 +48,5 @@ func (op *GetNonce) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.
 
 // Debug prints a debug message for the get-nonce operation.
 func (op *GetNonce) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(GetNonceID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/getnonce_test.go
+++ b/tracer/operation/getnonce_test.go
@@ -36,9 +36,7 @@ func TestGetNonceReadWrite(t *testing.T) {
 // TestGetNonceDebug creates a new GetNonce object and checks its Debug message.
 func TestGetNonceDebug(t *testing.T) {
 	dict, op, addr := initGetNonce(t)
-	testOperationDebug(t, dict, op, GetNonceID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestGetNonceExecute

--- a/tracer/operation/getstate.go
+++ b/tracer/operation/getstate.go
@@ -50,5 +50,5 @@ func (op *GetState) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.
 
 // Debug prints a debug message for the get-state operation.
 func (op *GetState) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(GetStateID), ctx.DecodeContract(op.ContractIndex), ctx.DecodeStorage(op.StorageIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex), ctx.DecodeStorage(op.StorageIndex))
 }

--- a/tracer/operation/getstate_lc.go
+++ b/tracer/operation/getstate_lc.go
@@ -56,5 +56,5 @@ func (op *GetStateLc) Execute(db state.StateDB, ctx *dict.DictionaryContext) tim
 func (op *GetStateLc) Debug(ctx *dict.DictionaryContext) {
 	contract := ctx.LastContractAddress()
 	storage := ctx.DecodeStorage(op.StorageIndex)
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(GetStateLcID), contract, storage)
+	fmt.Print(contract, storage)
 }

--- a/tracer/operation/getstate_lc_test.go
+++ b/tracer/operation/getstate_lc_test.go
@@ -40,9 +40,7 @@ func TestGetStateLcReadWrite(t *testing.T) {
 // TestGetStateLcDebug creates a new GetStateLc object and checks its Debug message.
 func TestGetStateLcDebug(t *testing.T) {
 	dict, op, addr, storage := initGetStateLc(t)
-	testOperationDebug(t, dict, op, GetStateLcID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, storage)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, storage))
 }
 
 // TestGetStateLcExecute

--- a/tracer/operation/getstate_lccs.go
+++ b/tracer/operation/getstate_lccs.go
@@ -61,5 +61,5 @@ func (op *GetStateLccs) Execute(db state.StateDB, ctx *dict.DictionaryContext) t
 func (op *GetStateLccs) Debug(ctx *dict.DictionaryContext) {
 	contract := ctx.LastContractAddress()
 	storage := ctx.ReadStorage(int(op.StoragePosition))
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(GetStateLccsID), contract, storage)
+	fmt.Print(contract, storage)
 }

--- a/tracer/operation/getstate_lccs_test.go
+++ b/tracer/operation/getstate_lccs_test.go
@@ -47,9 +47,7 @@ func TestGetStateLccsReadWrite(t *testing.T) {
 // TestGetStateLccsDebug creates a new GetStateLccs object and checks its Debug message.
 func TestGetStateLccsDebug(t *testing.T) {
 	dict, op, addr, storage, _ := initGetStateLccs(t)
-	testOperationDebug(t, dict, op, GetStateLccsID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, storage)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, storage))
 }
 
 // TestGetStateLccsExecute

--- a/tracer/operation/getstate_lcls.go
+++ b/tracer/operation/getstate_lcls.go
@@ -52,5 +52,5 @@ func (op *GetStateLcls) Execute(db state.StateDB, ctx *dict.DictionaryContext) t
 func (op *GetStateLcls) Debug(ctx *dict.DictionaryContext) {
 	contract := ctx.LastContractAddress()
 	storage := ctx.ReadStorage(0)
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(GetStateLclsID), contract, storage)
+	fmt.Print(contract, storage)
 }

--- a/tracer/operation/getstate_lcls_test.go
+++ b/tracer/operation/getstate_lcls_test.go
@@ -40,9 +40,7 @@ func TestGetStateLclsReadWrite(t *testing.T) {
 // TestGetStateLclsDebug creates a new GetStateLcls object and checks its Debug message.
 func TestGetStateLclsDebug(t *testing.T) {
 	dict, op, addr, storage := initGetStateLcls(t)
-	testOperationDebug(t, dict, op, GetStateLclsID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, storage)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, storage))
 }
 
 // TestGetStateLclsExecute

--- a/tracer/operation/getstate_test.go
+++ b/tracer/operation/getstate_test.go
@@ -39,9 +39,7 @@ func TestGetStateReadWrite(t *testing.T) {
 // TestGetStateDebug creates a new GetState object and checks its Debug message.
 func TestGetStateDebug(t *testing.T) {
 	dict, op, addr, storage := initGetState(t)
-	testOperationDebug(t, dict, op, GetStateID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, storage)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, storage))
 }
 
 // TestGetStateExecute

--- a/tracer/operation/hassuicided.go
+++ b/tracer/operation/hassuicided.go
@@ -47,5 +47,5 @@ func (op *HasSuicided) Execute(db state.StateDB, ctx *dict.DictionaryContext) ti
 
 // Debug prints a debug message for the HasSuicided operation.
 func (op *HasSuicided) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(HasSuicidedID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/hassuicided_test.go
+++ b/tracer/operation/hassuicided_test.go
@@ -36,9 +36,7 @@ func TestHasSuicidedReadWrite(t *testing.T) {
 // TestHasSuicidedDebug creates a new HasSuicided object and checks its Debug message.
 func TestHasSuicidedDebug(t *testing.T) {
 	dict, op, addr := initHasSuicided(t)
-	testOperationDebug(t, dict, op, HasSuicidedID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestHasSuicidedExecute

--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -181,6 +181,7 @@ func PrintProfiling() {
 
 // Debug prints debug information of an operation.
 func Debug(ctx *dict.DictionaryContext, op Operation) {
-	fmt.Printf("%v:\n", GetLabel(op.GetId()))
+	fmt.Printf("\t%s: ", GetLabel(op.GetId()))
 	op.Debug(ctx)
+	fmt.Println()
 }

--- a/tracer/operation/operation_test.go
+++ b/tracer/operation/operation_test.go
@@ -266,14 +266,14 @@ func testOperationReadWrite(t *testing.T, op1 Operation, opRead func(file io.Rea
 	}
 }
 
-func testOperationDebug(t *testing.T, dict *dict.DictionaryContext, op Operation, opID byte, s func(label string) string) {
+func testOperationDebug(t *testing.T, dict *dict.DictionaryContext, op Operation, args string) {
 	// divert stdout to a buffer
 	old := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
 	// print debug message
-	op.Debug(dict)
+	Debug(dict, op)
 
 	// restore stdout
 	w.Close()
@@ -282,11 +282,11 @@ func testOperationDebug(t *testing.T, dict *dict.DictionaryContext, op Operation
 	io.Copy(&buf, r)
 
 	// check debug message
-	label := GetLabel(opID)
+	label := GetLabel(op.GetId())
 
-	expected := s(label)
+	expected := "\t" + label + ": " + args + "\n"
 
 	if buf.String() != expected {
-		t.Fatalf("wrong debug message: %s", buf.String())
+		t.Fatalf("wrong debug message: %s vs %s; %d vs %d", buf.String(), expected, len(buf.String()), len(expected))
 	}
 }

--- a/tracer/operation/reverttosnapshot.go
+++ b/tracer/operation/reverttosnapshot.go
@@ -48,5 +48,5 @@ func (op *RevertToSnapshot) Execute(db state.StateDB, ctx *dict.DictionaryContex
 
 // Debug prints a debug message for the revert-to-snapshot operation.
 func (op *RevertToSnapshot) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %d\n", GetLabel(RevertToSnapshotID), op.SnapshotID)
+	fmt.Print(op.SnapshotID)
 }

--- a/tracer/operation/reverttosnapshot_test.go
+++ b/tracer/operation/reverttosnapshot_test.go
@@ -46,9 +46,7 @@ func TestRevertToSnapshotReadWrite(t *testing.T) {
 // TestRevertToSnapshotDebug creates a new RevertToSnapshot object and checks its Debug message.
 func TestRevertToSnapshotDebug(t *testing.T) {
 	dict, _, op2, value, _ := initRevertToSnapshot(t)
-	testOperationDebug(t, dict, op2, RevertToSnapshotID, func(label string) string {
-		return fmt.Sprintf("\t%s: %d\n", label, value)
-	})
+	testOperationDebug(t, dict, op2, fmt.Sprint(value))
 }
 
 // TestRevertToSnapshotExecute

--- a/tracer/operation/setcode.go
+++ b/tracer/operation/setcode.go
@@ -50,5 +50,5 @@ func (op *SetCode) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.D
 
 // Debug prints a debug message for the set-code operation.
 func (op *SetCode) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(SetCodeID), ctx.DecodeContract(op.ContractIndex), ctx.DecodeCode(op.CodeIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex), ctx.DecodeCode(op.CodeIndex))
 }

--- a/tracer/operation/setcode_test.go
+++ b/tracer/operation/setcode_test.go
@@ -43,9 +43,7 @@ func TestSetCodeReadWrite(t *testing.T) {
 // TestSetCodeDebug creates a new SetCode object and checks its Debug message.
 func TestSetCodeDebug(t *testing.T) {
 	dict, op, addr, value := initSetCode(t)
-	testOperationDebug(t, dict, op, SetCodeID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, value)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, value))
 }
 
 // TestSetCodeExecute

--- a/tracer/operation/setnonce.go
+++ b/tracer/operation/setnonce.go
@@ -49,5 +49,5 @@ func (op *SetNonce) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.
 
 // Debug prints a debug message for the set-nonce operation.
 func (op *SetNonce) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s, %d\n", GetLabel(SetNonceID), ctx.DecodeContract(op.ContractIndex), op.Nonce)
+	fmt.Print(ctx.DecodeContract(op.ContractIndex), op.Nonce)
 }

--- a/tracer/operation/setnonce_test.go
+++ b/tracer/operation/setnonce_test.go
@@ -41,9 +41,7 @@ func TestSetNonceReadWrite(t *testing.T) {
 // TestSetNonceDebug creates a new SetNonce object and checks its Debug message.
 func TestSetNonceDebug(t *testing.T) {
 	dict, op, addr, value := initSetNonce(t)
-	testOperationDebug(t, dict, op, SetNonceID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %d\n", label, addr, value)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, value))
 }
 
 // TestSetNonceExecute

--- a/tracer/operation/setstate.go
+++ b/tracer/operation/setstate.go
@@ -52,5 +52,5 @@ func (op *SetState) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.
 
 // Debug prints a debug message for the set-state operation.
 func (op *SetState) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s, %s, %s\n", GetLabel(SetStateID), ctx.DecodeContract(op.ContractIndex), ctx.DecodeStorage(op.StorageIndex), ctx.DecodeValue(op.ValueIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex), ctx.DecodeStorage(op.StorageIndex), ctx.DecodeValue(op.ValueIndex))
 }

--- a/tracer/operation/setstate_lcls.go
+++ b/tracer/operation/setstate_lcls.go
@@ -57,5 +57,5 @@ func (op *SetStateLcls) Debug(ctx *dict.DictionaryContext) {
 	contract := ctx.LastContractAddress()
 	storage := ctx.ReadStorage(0)
 	value := ctx.DecodeValue(op.ValueIndex)
-	fmt.Printf("\t%s: %s, %s, %s\n", GetLabel(SetStateLclsID), contract, storage, value)
+	fmt.Print(contract, storage, value)
 }

--- a/tracer/operation/setstate_lcls_test.go
+++ b/tracer/operation/setstate_lcls_test.go
@@ -43,9 +43,7 @@ func TestSetStateLclsReadWrite(t *testing.T) {
 // TestSetStateLclsDebug creates a new SetStateLcls object and checks its Debug message.
 func TestSetStateLclsDebug(t *testing.T) {
 	dict, op, addr, storage, value := initSetStateLcls(t)
-	testOperationDebug(t, dict, op, SetStateLclsID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s, %s\n", label, addr, storage, value)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, storage, value))
 }
 
 // TestSetStateLclsExecute

--- a/tracer/operation/setstate_test.go
+++ b/tracer/operation/setstate_test.go
@@ -41,9 +41,7 @@ func TestSetStateReadWrite(t *testing.T) {
 // TestSetStateDebug creates a new SetState object and checks its Debug message.
 func TestSetStateDebug(t *testing.T) {
 	dict, op, addr, storage, value := initSetState(t)
-	testOperationDebug(t, dict, op, SetStateID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s, %s\n", label, addr, storage, value)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, storage, value))
 }
 
 // TestSetStateExecute

--- a/tracer/operation/snapshot.go
+++ b/tracer/operation/snapshot.go
@@ -54,5 +54,5 @@ func (op *Snapshot) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.
 
 // Debug prints the details for the snapshot operation.
 func (op *Snapshot) Debug(*dict.DictionaryContext) {
-	fmt.Printf("\t%s: %d\n", GetLabel(SnapshotID), op.SnapshotID)
+	fmt.Print(op.SnapshotID)
 }

--- a/tracer/operation/snapshot_test.go
+++ b/tracer/operation/snapshot_test.go
@@ -33,9 +33,7 @@ func TestSnapshotReadWrite(t *testing.T) {
 // TestSnapshotDebug creates a new Snapshot object and checks its Debug message.
 func TestSnapshotDebug(t *testing.T) {
 	dict, op, snapID := initSnapshot(t)
-	testOperationDebug(t, dict, op, SnapshotID, func(label string) string {
-		return fmt.Sprintf("\t%s: %d\n", label, snapID)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(snapID))
 }
 
 // TestSnapshotExecute

--- a/tracer/operation/subbalance.go
+++ b/tracer/operation/subbalance.go
@@ -60,5 +60,5 @@ func (op *SubBalance) Execute(db state.StateDB, ctx *dict.DictionaryContext) tim
 
 // Debug prints a debug message for the sub-balance operation.
 func (op *SubBalance) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s, %s\n", GetLabel(SubBalanceID), ctx.DecodeContract(op.ContractIndex), new(big.Int).SetBytes(op.Amount[:]))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex), new(big.Int).SetBytes(op.Amount[:]))
 }

--- a/tracer/operation/subbalance_test.go
+++ b/tracer/operation/subbalance_test.go
@@ -40,9 +40,7 @@ func TestSubBalanceReadWrite(t *testing.T) {
 // TestSubBalanceDebug creates a new SubBalance object and checks its Debug message.
 func TestSubBalanceDebug(t *testing.T) {
 	dict, op, addr, value := initSubBalance(t)
-	testOperationDebug(t, dict, op, SubBalanceID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s, %s\n", label, addr, value)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr, value))
 }
 
 // TestSubBalanceExecute

--- a/tracer/operation/suicide.go
+++ b/tracer/operation/suicide.go
@@ -48,5 +48,5 @@ func (op *Suicide) Execute(db state.StateDB, ctx *dict.DictionaryContext) time.D
 
 // Debug prints a debug message for the suicide operation.
 func (op *Suicide) Debug(ctx *dict.DictionaryContext) {
-	fmt.Printf("\t%s: %s\n", GetLabel(SuicideID), ctx.DecodeContract(op.ContractIndex))
+	fmt.Print(ctx.DecodeContract(op.ContractIndex))
 }

--- a/tracer/operation/suicide_test.go
+++ b/tracer/operation/suicide_test.go
@@ -36,9 +36,7 @@ func TestSuicideReadWrite(t *testing.T) {
 // TestSuicideDebug creates a new Suicide object and checks its Debug message.
 func TestSuicideDebug(t *testing.T) {
 	dict, op, addr := initSuicide(t)
-	testOperationDebug(t, dict, op, SuicideID, func(label string) string {
-		return fmt.Sprintf("\t%s: %s\n", label, addr)
-	})
+	testOperationDebug(t, dict, op, fmt.Sprint(addr))
 }
 
 // TestSuicideExecute


### PR DESCRIPTION
Adding HasSuicided and Empty operations along with first version of operation tests.

Known issues: 
- generalisation of common functions needed
- getstate_lccs_test.go  and reverttosnapshot_test.go need to be corrected

