### PR TITLE
 Store Dictionaries in Compressed Format

### DIFF
--- a/tracer/dict/code_dictionary.go
+++ b/tracer/dict/code_dictionary.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"math"
 	"os"
+
+	"github.com/dsnet/compress/bzip2"
 )
 
 // CodeDictionaryLimit sets the size of the code dictionary.
@@ -58,31 +60,40 @@ func (d *CodeDictionary) Decode(idx uint32) ([]byte, error) {
 // Write dictionary to a binary file.
 func (d *CodeDictionary) Write(filename string) error {
 	// open code dictionary file for writing
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		return err
+		return fmt.Errorf("Cannot open code-dictionary file. Error: %v", err)
 	}
-	defer func() {
-		f.Close()
-	}()
-
+	zfile, err := bzip2.NewWriter(file, &bzip2.WriterConfig{Level: 9})
+	if err != nil {
+		return fmt.Errorf("Cannot open bzip2 stream for code-dictionary. Error: %v", err)
+	}
+	// write magic number
+	magic := uint64(4711)
+	if err := binary.Write(zfile, binary.LittleEndian, &magic); err != nil {
+		return fmt.Errorf("Error writing magic number. Error: %v", err)
+	}
 	// write all dictionary entries
 	for _, code := range d.idxToCode {
-
 		// write length of code block
 		if len(code) >= math.MaxUint32 {
 			return fmt.Errorf("Code is too large to write")
 		}
 		length := uint32(len(code))
-		err := binary.Write(f, binary.LittleEndian, &length)
-		if err != nil {
+		if err := binary.Write(zfile, binary.LittleEndian, length); err != nil {
 			return fmt.Errorf("Error writing code length. Error: %v", err)
 		}
-
 		// write code
-		if _, err := f.Write([]byte(code)); err != nil {
+		if err := binary.Write(zfile, binary.LittleEndian, []byte(code)); err != nil {
 			return fmt.Errorf("Error writing byte-code. Error: %v", err)
 		}
+	}
+	// close file
+	if err := zfile.Close(); err != nil {
+		return fmt.Errorf("Cannot close bzip2 stream of code-dictionary. Error: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("Cannot close code-dictionary file. Error: %v", err)
 	}
 	return nil
 }
@@ -91,45 +102,48 @@ func (d *CodeDictionary) Write(filename string) error {
 func (d *CodeDictionary) Read(filename string) error {
 	// clear code dictionary
 	d.Init()
-
-	// open code dictionary file for reading
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0644)
+	// open code dictionary file for reading, read buffer, and gzip stream
+	file, err := os.Open(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("Cannot open code-dictionary file. Error: %v", err)
 	}
-	defer func() {
-		f.Close()
-	}()
-
+	zfile, err := bzip2.NewReader(file, &bzip2.ReaderConfig{})
+	if err != nil {
+		return fmt.Errorf("Cannot open bzip2 stream of code-dictionary. Error: %v", err)
+	}
+	// read and check magic number
+	var magic uint64
+	if err := binary.Read(zfile, binary.LittleEndian, &magic); err != nil && magic != uint64(4711) {
+		return fmt.Errorf("Cannot read magic number; code-dictionary is corrupted. Error: %v", err)
+	}
 	// read entries from file
 	for ctr := uint32(0); true; ctr++ {
-		// read next entry
-
-		// read length
+		// read length of byte-code
 		var length uint32
-		err := binary.Read(f, binary.LittleEndian, &length)
+		err := binary.Read(zfile, binary.LittleEndian, &length)
 		if err == io.EOF {
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("Code dictionary file/reading is corrupted. Error: %v", err)
 		}
-
-		// read byte code
+		// read byte-code
 		code := make([]byte, length)
-		n, err := f.Read(code)
-		if err != nil {
+		if err := binary.Read(zfile, binary.LittleEndian, code); err != nil {
 			return fmt.Errorf("Error reading code length/file is corrupted. Error: %v", err)
-		} else if n != int(length) {
-			return fmt.Errorf("Error reading code length/wrong size")
 		}
-
-		// encode entry
+		// encode byte-code entry
 		idx, err := d.Encode(code)
 		if err != nil {
 			return fmt.Errorf("Failed to encode byte-code while reading. Error: %v", err)
 		} else if idx != ctr {
 			return fmt.Errorf("Corrupted code dictionary file entries")
 		}
+	}
+	if err := zfile.Close(); err != nil {
+		return fmt.Errorf("Cannot close bzip2 stream of code-dictionary. Error: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("Cannot close code-dictionary file. Error: %v", err)
 	}
 	return nil
 }

--- a/tracer/dict/code_dictionary_test.go
+++ b/tracer/dict/code_dictionary_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 )
 
-// TestPositiveCodeDictionarySimple1 encodes byte-code, and compares whether the
+// TestCodeDictionarySimple1 encodes byte-code, and compares whether the
 // decoded bytecode is the same, and its index is zero.
-func TestPositiveCodeDictionarySimple1(t *testing.T) {
+func TestCodeDictionarySimple1(t *testing.T) {
 	encodedCode := []byte{0x1, 0x0, 0x02, 0x5, 0x7}
 	dict := NewCodeDictionary()
 	idx, err1 := dict.Encode(encodedCode)
@@ -20,9 +20,9 @@ func TestPositiveCodeDictionarySimple1(t *testing.T) {
 	}
 }
 
-// TestPositiveCodeDictionarySimple2 encoded two byte-codes, and compare whether the decoded
+// TestCodeDictionarySimple2 encoded two byte-codes, and compare whether the decoded
 // bytecode are not the same, and their indices are zero and one.
-func TestPositiveCodeDictionarySimple2(t *testing.T) {
+func TestCodeDictionarySimple2(t *testing.T) {
 	encodedCode1 := []byte{0x1, 0x0, 0x2, 0x0, 0x5}
 	encodedCode2 := []byte{0x1, 0x0, 0x2}
 	dict := NewCodeDictionary()
@@ -38,9 +38,9 @@ func TestPositiveCodeDictionarySimple2(t *testing.T) {
 	}
 }
 
-// TestPositiveCodeDictionarySimple3 encodes the same byte code twice and check that it
+// TestCodeDictionarySimple3 encodes the same byte code twice and check that it
 // is encoded only once, and its index is zero.
-func TestPositiveCodeDictionarySimple3(t *testing.T) {
+func TestCodeDictionarySimple3(t *testing.T) {
 	encodedCode := []byte{0x1, 0x02, 0x3, 0x4}
 	dict := NewCodeDictionary()
 	idx1, err1 := dict.Encode(encodedCode)
@@ -55,8 +55,8 @@ func TestPositiveCodeDictionarySimple3(t *testing.T) {
 	}
 }
 
-// TestNegativeCodeDictionaryOverflow checks whether dictionary overflows can be captured.
-func TestNegativeCodeDictionaryOverflow(t *testing.T) {
+// TestCodeDictionaryOverflow checks whether dictionary overflows can be captured.
+func TestCodeDictionaryOverflow(t *testing.T) {
 	encodedCode1 := []byte{0x1, 0x0, 0x2, 0x0, 0x5}
 	encodedCode2 := []byte{0x1, 0x0, 0x2}
 	dict := NewCodeDictionary()
@@ -74,9 +74,9 @@ func TestNegativeCodeDictionaryOverflow(t *testing.T) {
 	CodeDictionaryLimit = math.MaxUint32
 }
 
-// TestNegativeCodeDictionaryDecodingFailure1 checks whether invalid index for Decode() can be captured.
+// TestCodeDictionaryDecodingFailure1 checks whether invalid index for Decode() can be captured.
 // (Retrieving index 0 on an empty dictionary)
-func TestNegativeCodeDictionaryDecodingFailure1(t *testing.T) {
+func TestCodeDictionaryDecodingFailure1(t *testing.T) {
 	dict := NewCodeDictionary()
 	_, err := dict.Decode(0)
 	if err == nil {
@@ -84,9 +84,9 @@ func TestNegativeCodeDictionaryDecodingFailure1(t *testing.T) {
 	}
 }
 
-// TestNegativeCodeDictionaryDecodingFailure2 checks whether invalid index for Decode() can be captured.
+// TestCodeDictionaryDecodingFailure2 checks whether invalid index for Decode() can be captured.
 // (Retrieving index MaxUint32 on an empty dictionary)
-func TestNegativeCodeDictionaryDecodingFailure2(t *testing.T) {
+func TestCodeDictionaryDecodingFailure2(t *testing.T) {
 	dict := NewCodeDictionary()
 	_, err := dict.Decode(math.MaxUint32)
 	if err == nil {
@@ -94,8 +94,8 @@ func TestNegativeCodeDictionaryDecodingFailure2(t *testing.T) {
 	}
 }
 
-// TestNegativeCodeDictionaryReadFailure creates corrupted file and read file as dictionary.
-func TestNegativeCodeDictionaryReadFailure(t *testing.T) {
+// TestCodeDictionaryReadFailure creates corrupted file and read file as dictionary.
+func TestCodeDictionaryReadFailure(t *testing.T) {
 	filename := "./test.dict"
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -118,10 +118,10 @@ func TestNegativeCodeDictionaryReadFailure(t *testing.T) {
 	os.Remove(filename)
 }
 
-// TestPositiveCodeDictionaryReadWrite encodes two byte codes, writes them to file,
+// TestCodeDictionaryReadWrite encodes two byte codes, writes them to file,
 // and reads them from file. Check whether the newly created dictionary (read from
 // file) is identical.
-func TestPositiveCodeDictionaryReadWrite(t *testing.T) {
+func TestCodeDictionaryReadWrite(t *testing.T) {
 	filename := "./test.dict"
 	encodedCode1 := []byte{0x1, 0x0, 0x2, 0x0, 0x5}
 	encodedCode2 := []byte{0x1, 0x0, 0x2}

--- a/tracer/dict/contract_dictionary.go
+++ b/tracer/dict/contract_dictionary.go
@@ -1,10 +1,13 @@
 package dict
 
 import (
+	"encoding/binary"
 	"fmt"
+	"io"
 	"math"
 	"os"
 
+	"github.com/dsnet/compress/bzip2"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -57,20 +60,31 @@ func (cDict *ContractDictionary) Decode(idx uint32) (common.Address, error) {
 // Write dictionary to a binary file.
 func (cDict *ContractDictionary) Write(filename string) error {
 	// open contract dictionary file for writing
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		return fmt.Errorf("Failed opening dictionary file. Error:%v", err)
+		return fmt.Errorf("Cannot open contract-dictionary file. Error: %v", err)
 	}
-	defer func() {
-		f.Close()
-	}()
-
+	zfile, err := bzip2.NewWriter(file, &bzip2.WriterConfig{Level: 9})
+	if err != nil {
+		return fmt.Errorf("Cannot open bzip2 stream of contract-dictionary. Error: %v", err)
+	}
+	// write magic number
+	magic := uint64(4712)
+	if err := binary.Write(zfile, binary.LittleEndian, &magic); err != nil {
+		return fmt.Errorf("Error writing magic number. Error: %v", err)
+	}
 	// write all dictionary entries
 	for _, addr := range cDict.idxToContract {
-		data := addr.Bytes()
-		if _, err := f.Write(data); err != nil {
+		if err := binary.Write(zfile, binary.LittleEndian, addr); err != nil {
 			return err
 		}
+	}
+	// close bzip2 stream and file
+	if err := zfile.Close(); err != nil {
+		return fmt.Errorf("Cannot close bzip2 stream of contract-dictionary. Error: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("Cannot close contract-dictionary file. Error: %v", err)
 	}
 	return nil
 }
@@ -79,36 +93,44 @@ func (cDict *ContractDictionary) Write(filename string) error {
 func (cDict *ContractDictionary) Read(filename string) error {
 	// clear contract dictionary
 	cDict.Init()
-
-	// open contract dictionary file for reading
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0644)
+	// open code dictionary file for reading, read buffer, and bzip2 stream
+	file, err := os.Open(filename)
 	if err != nil {
-		return fmt.Errorf("Failed to open dictionary file. Error:%v", err)
+		return fmt.Errorf("Cannot open contract-dictionary file. Error: %v", err)
 	}
-	defer func() {
-		f.Close()
-	}()
-
+	zfile, err := bzip2.NewReader(file, &bzip2.ReaderConfig{})
+	if err != nil {
+		return fmt.Errorf("Cannot open bzip2 stream of contract-dictionary. Error: %v", err)
+	}
+	// read and check magic number
+	var magic uint64
+	if err := binary.Read(zfile, binary.LittleEndian, &magic); err != nil && magic != uint64(4712) {
+		return fmt.Errorf("Cannot read magic number; code-dictionary is corrupted. Error: %v", err)
+	}
 	// read entries from file
-	data := common.Address{}.Bytes()
+	data := common.Address{}
 	for ctr := uint32(0); true; ctr++ {
 		// read next entry
-		n, err := f.Read(data)
-		if n == 0 {
-			break
-		} else if n < len(data) {
-			return fmt.Errorf("Error reading address/wrong size")
-		} else if err != nil {
-			return fmt.Errorf("Error reading address. Error:%v", err)
+		if err := binary.Read(zfile, binary.LittleEndian, &data); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("Error reading storage address. Error: %v", err)
 		}
-
 		// encode entry
-		idx, err := cDict.Encode(common.BytesToAddress(data))
+		idx, err := cDict.Encode(data)
 		if err != nil {
 			return fmt.Errorf("Error encoding address. Error:%v", err)
 		} else if idx != ctr {
 			return fmt.Errorf("Corrupted contract dictionary file entries")
 		}
+	}
+	// close file
+	if err := zfile.Close(); err != nil {
+		return fmt.Errorf("Cannot close bzip2 stream of contract-dictionary. Error: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("Cannot close contract-dictionary file. Error: %v", err)
 	}
 	return nil
 }

--- a/tracer/dict/contract_dictionary_test.go
+++ b/tracer/dict/contract_dictionary_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 )
 
-// TestPositiveContractDictionarySimple1 encodes an address, and compares whether the decoded
+// TestContractDictionarySimple1 encodes an address, and compares whether the decoded
 // address is the same, and its index is zero.
-func TestPositiveContractDictionarySimple1(t *testing.T) {
+func TestContractDictionarySimple1(t *testing.T) {
 	encodedAddr := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	dict := NewContractDictionary()
 	idx, err1 := dict.Encode(encodedAddr)
@@ -19,9 +19,9 @@ func TestPositiveContractDictionarySimple1(t *testing.T) {
 	}
 }
 
-// TestPositiveContractDictionarySimple2 encodes two addresses, and compares whether
+// TestContractDictionarySimple2 encodes two addresses, and compares whether
 // the decoded addresses are the same, and their dictionary indices are zero and one.
-func TestPositiveContractDictionarySimple2(t *testing.T) {
+func TestContractDictionarySimple2(t *testing.T) {
 	encodedAddr1 := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedAddr2 := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")
 	dict := NewContractDictionary()
@@ -37,9 +37,9 @@ func TestPositiveContractDictionarySimple2(t *testing.T) {
 	}
 }
 
-// TestPositiveContractDictionarySimple3 encodes one address twice and check that its address
+// TestContractDictionarySimple3 encodes one address twice and check that its address
 // is encoded only once, and its index is zero.
-func TestPositiveContractDictionarySimple3(t *testing.T) {
+func TestContractDictionarySimple3(t *testing.T) {
 	encodedAddr1 := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	dict := NewContractDictionary()
 	idx1, err1 := dict.Encode(encodedAddr1)
@@ -54,8 +54,8 @@ func TestPositiveContractDictionarySimple3(t *testing.T) {
 	}
 }
 
-// TestNegativeContractDictionaryOverflow checks whether dictionary overflows can be captured.
-func TestNegativeContractDictionaryOverflow(t *testing.T) {
+// TestContractDictionaryOverflow checks whether dictionary overflows can be captured.
+func TestContractDictionaryOverflow(t *testing.T) {
 	encodedAddr1 := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedAddr2 := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")
 	dict := NewContractDictionary()
@@ -73,9 +73,9 @@ func TestNegativeContractDictionaryOverflow(t *testing.T) {
 	ContractDictionaryLimit = math.MaxUint32
 }
 
-// TestNegativeContractDictionaryDecodingFailure1 checks whether invalid index for Decode()
+// TestContractDictionaryDecodingFailure1 checks whether invalid index for Decode()
 // can be captured (retrieving index 0 on an empty dictionary).
-func TestNegativeContractDictionaryDecodingFailure1(t *testing.T) {
+func TestContractDictionaryDecodingFailure1(t *testing.T) {
 	dict := NewContractDictionary()
 	_, err := dict.Decode(0)
 	if err == nil {
@@ -83,9 +83,9 @@ func TestNegativeContractDictionaryDecodingFailure1(t *testing.T) {
 	}
 }
 
-// TestNegativeContractDictionaryDecodingFailure2 checks whether invalid index for
+// TestContractDictionaryDecodingFailure2 checks whether invalid index for
 // Decode() can be captured (retrieving index MaxUint32 on an empty dictionary).
-func TestNegativeContractDictionaryDecodingFailure2(t *testing.T) {
+func TestContractDictionaryDecodingFailure2(t *testing.T) {
 	dict := NewContractDictionary()
 	_, err := dict.Decode(math.MaxUint32)
 	if err == nil {
@@ -93,8 +93,8 @@ func TestNegativeContractDictionaryDecodingFailure2(t *testing.T) {
 	}
 }
 
-// TestNegativeContractDictionaryReadFailure creates corrupted file and read file as dictionary.
-func TestNegativeContractDictionaryReadFailure(t *testing.T) {
+// TestContractDictionaryReadFailure creates corrupted file and read file as dictionary.
+func TestContractDictionaryReadFailure(t *testing.T) {
 	filename := "./test.dict"
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -117,10 +117,10 @@ func TestNegativeContractDictionaryReadFailure(t *testing.T) {
 	}
 }
 
-// TestPositiveContractDictionaryReadWrite encodes two addresses, write them to file,
+// TestContractDictionaryReadWrite encodes two addresses, write them to file,
 // and read them from file. Check whether the newly created dictionary (read from
 // file) is identical.
-func TestPositiveContractDictionaryReadWrite(t *testing.T) {
+func TestContractDictionaryReadWrite(t *testing.T) {
 	filename := "./test.dict"
 	encodedAddr1 := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedAddr2 := common.HexToAddress("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")

--- a/tracer/dict/snapshot_index_test.go
+++ b/tracer/dict/snapshot_index_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-// TestPositiveSnapshotIndexAdd adds a new set of mappings and compares the size of index map.
-func TestPositiveSnapshotIndexAdd(t *testing.T) {
+// TestSnapshotIndexAdd adds a new set of mappings and compares the size of index map.
+func TestSnapshotIndexAdd(t *testing.T) {
 	var recordedID1 int32 = 1
 	var recordedID2 int32 = 2
 	var replayedID1 int32 = 0
@@ -20,8 +20,8 @@ func TestPositiveSnapshotIndexAdd(t *testing.T) {
 	}
 }
 
-// TestPositiveSnapshotIndexAddDuplicateID adds an ID twice, and checks index result.
-func TestPositiveSnapshotIndexAddDuplicateID(t *testing.T) {
+// TestSnapshotIndexAddDuplicateID adds an ID twice, and checks index result.
+func TestSnapshotIndexAddDuplicateID(t *testing.T) {
 	var recordedID int32 = 1
 	var replayedID int32 = 0
 	snapshotIdx := NewSnapshotIndex()
@@ -39,8 +39,8 @@ func TestPositiveSnapshotIndexAddDuplicateID(t *testing.T) {
 	}
 }
 
-// TestPositiveSnapshotIndexGet adds ID to SnapshotIndex and compares with index result.
-func TestPositiveSnapshotIndexGet(t *testing.T) {
+// TestSnapshotIndexGet adds ID to SnapshotIndex and compares with index result.
+func TestSnapshotIndexGet1(t *testing.T) {
 	var recordedID int32 = 1
 	var replayedID int32 = 8
 	snapshotIdx := NewSnapshotIndex()
@@ -54,8 +54,8 @@ func TestPositiveSnapshotIndexGet(t *testing.T) {
 	}
 }
 
-// TestPositiveSnapshotIndexGet checks ID of Get mismatches.
-func TestNegativeSnapshotIndexGet(t *testing.T) {
+// TestSnapshotIndexGet checks ID of Get mismatches.
+func TestSnapshotIndexGet2(t *testing.T) {
 	var recordedID int32 = 1
 	var replayedID int32 = 8
 	snapshotIdx := NewSnapshotIndex()

--- a/tracer/dict/storage_dictionary.go
+++ b/tracer/dict/storage_dictionary.go
@@ -1,10 +1,14 @@
 package dict
 
 import (
+	"encoding/binary"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
+	"io"
 	"math"
 	"os"
+
+	"github.com/dsnet/compress/bzip2"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // StorageDictionaryLimit sets the size of storage dictionary.
@@ -18,9 +22,9 @@ type StorageDictionary struct {
 }
 
 // Init initializes or clears a storage dictionary.
-func (sDict *StorageDictionary) Init() {
-	sDict.storageToIdx = map[common.Hash]uint32{}
-	sDict.idxToStorage = []common.Hash{}
+func (d *StorageDictionary) Init() {
+	d.storageToIdx = map[common.Hash]uint32{}
+	d.idxToStorage = []common.Hash{}
 }
 
 // NewStorageDictionary creates a new storage dictionary.
@@ -31,84 +35,103 @@ func NewStorageDictionary() *StorageDictionary {
 }
 
 // Encode an storage address to an index.
-func (sDict *StorageDictionary) Encode(addr common.Hash) (uint32, error) {
+func (d *StorageDictionary) Encode(addr common.Hash) (uint32, error) {
 	// find storage address
-	idx, ok := sDict.storageToIdx[addr]
+	idx, ok := d.storageToIdx[addr]
 	if !ok {
-		idx = uint32(len(sDict.idxToStorage))
+		idx = uint32(len(d.idxToStorage))
 		if idx >= StorageDictionaryLimit {
 			return 0, fmt.Errorf("Storage dictionary exhausted")
 		}
-		sDict.storageToIdx[addr] = idx
-		sDict.idxToStorage = append(sDict.idxToStorage, addr)
+		d.storageToIdx[addr] = idx
+		d.idxToStorage = append(d.idxToStorage, addr)
 	}
 	return idx, nil
 }
 
 // Decode a dictionary index to an address.
-func (sDict *StorageDictionary) Decode(idx uint32) (common.Hash, error) {
-	if idx < uint32(len(sDict.idxToStorage)) {
-		return sDict.idxToStorage[idx], nil
+func (d *StorageDictionary) Decode(idx uint32) (common.Hash, error) {
+	if idx < uint32(len(d.idxToStorage)) {
+		return d.idxToStorage[idx], nil
 	} else {
 		return common.Hash{}, fmt.Errorf("Index out-of-bound")
 	}
 }
 
 // Write dictionary to a binary file.
-func (sDict *StorageDictionary) Write(filename string) error {
+func (d *StorageDictionary) Write(filename string) error {
 	// open storage dictionary file for writing
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		return err
+		return fmt.Errorf("Cannot open storage-dictionary file. Error: %v", err)
 	}
-	defer func() {
-		f.Close()
-	}()
-
+	zfile, err := bzip2.NewWriter(file, &bzip2.WriterConfig{Level: 9})
+	if err != nil {
+		return fmt.Errorf("Cannot open bzip2 stream for storage-dictionary. Error: %v", err)
+	}
+	// write magic number
+	magic := uint64(4713)
+	if err := binary.Write(zfile, binary.LittleEndian, &magic); err != nil {
+		return fmt.Errorf("Error writing magic number. Error: %v", err)
+	}
 	// write all dictionary entries
-	for _, addr := range sDict.idxToStorage {
-		data := addr.Bytes()
-		if _, err := f.Write(data); err != nil {
+	for _, addr := range d.idxToStorage {
+		if err := binary.Write(zfile, binary.LittleEndian, addr); err != nil {
 			return err
 		}
+	}
+	// close file
+	if err := zfile.Close(); err != nil {
+		return fmt.Errorf("Cannot close bzip2 stream of storage-dictionary. Error: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("Cannot close storage-dictionary file. Error: %v", err)
 	}
 	return nil
 }
 
 // Read dictionary from a binary file.
-func (sDict *StorageDictionary) Read(filename string) error {
+func (d *StorageDictionary) Read(filename string) error {
 	// clear storage dictionary
-	sDict.Init()
-
-	// open storage dictionary file for reading
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0644)
+	d.Init()
+	// open code dictionary file for reading, read buffer, and bzip2 stream
+	file, err := os.Open(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("Cannot open storage-dictionary file. Error: %v", err)
 	}
-	defer func() {
-		f.Close()
-	}()
-
+	zfile, err := bzip2.NewReader(file, &bzip2.ReaderConfig{})
+	if err != nil {
+		return fmt.Errorf("Cannot open bzip2 stream of storage-dictionary. Error: %v", err)
+	}
+	// read and check magic number
+	var magic uint64
+	if err := binary.Read(zfile, binary.LittleEndian, &magic); err != nil && magic != uint64(4713) {
+		return fmt.Errorf("Cannot read magic number; code-dictionary is corrupted. Error: %v", err)
+	}
 	// read entries from file
-	data := common.Hash{}.Bytes()
+	data := common.Hash{}
 	for ctr := uint32(0); true; ctr++ {
 		// read next entry
-		n, err := f.Read(data)
-		if n == 0 {
-			break
-		} else if n < len(data) {
-			return fmt.Errorf("Error reading storage address/wrong size.")
-		} else if err != nil {
+		if err := binary.Read(zfile, binary.LittleEndian, &data); err != nil {
+			if err == io.EOF {
+				break
+			}
 			return fmt.Errorf("Error reading storage address. Error: %v", err)
 		}
-
 		// encode entry
-		idx, err := sDict.Encode(common.BytesToHash(data))
+		idx, err := d.Encode(data)
 		if err != nil {
 			return err
 		} else if idx != ctr {
 			return fmt.Errorf("Corrupted storage dictionary file entries")
 		}
+	}
+	// close file
+	if err := zfile.Close(); err != nil {
+		return fmt.Errorf("Cannot close bzip2 stream of storage-dictionary. Error: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("Cannot close storage-dictionary file. Error: %v", err)
 	}
 	return nil
 }

--- a/tracer/dict/storage_dictionary_test.go
+++ b/tracer/dict/storage_dictionary_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 )
 
-// TestPositiveStorageDictionarySimple1 encodes an address, and compares whether
+// TestStorageDictionarySimple1 encodes an address, and compares whether
 // the decoded address is the same, and its index is zero.
-func TestPositiveStorageDictionarySimple1(t *testing.T) {
+func TestStorageDictionarySimple1(t *testing.T) {
 	encodedAddr := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	dict := NewStorageDictionary()
 	idx, err1 := dict.Encode(encodedAddr)
@@ -19,9 +19,9 @@ func TestPositiveStorageDictionarySimple1(t *testing.T) {
 	}
 }
 
-// TestPositiveStorageDictionarySimple2 encodes two addresses, and compares whether
+// TestStorageDictionarySimple2 encodes two addresses, and compares whether
 // the decoded addresses are the same, and their dictionary indices are zero and one.
-func TestPositiveStorageDictionarySimple2(t *testing.T) {
+func TestStorageDictionarySimple2(t *testing.T) {
 	encodedAddr1 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedAddr2 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")
 	dict := NewStorageDictionary()
@@ -37,9 +37,9 @@ func TestPositiveStorageDictionarySimple2(t *testing.T) {
 	}
 }
 
-// TestPositiveStorageDictionarySimple3 encodes one address twice and check that its address
+// TestStorageDictionarySimple3 encodes one address twice and check that its address
 // is encoded only once, and its index is zero.
-func TestPositiveStorageDictionarySimple3(t *testing.T) {
+func TestStorageDictionarySimple3(t *testing.T) {
 	encodedAddr1 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	dict := NewStorageDictionary()
 	idx1, err1 := dict.Encode(encodedAddr1)
@@ -54,8 +54,8 @@ func TestPositiveStorageDictionarySimple3(t *testing.T) {
 	}
 }
 
-// TestNegativeStorageDictionaryOverflow checks whether dictionary overflows can be captured.
-func TestNegativeStorageDictionaryOverflow(t *testing.T) {
+// TestStorageDictionaryOverflow checks whether dictionary overflows can be captured.
+func TestStorageDictionaryOverflow(t *testing.T) {
 	encodedAddr1 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedAddr2 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")
 	dict := NewStorageDictionary()
@@ -73,9 +73,9 @@ func TestNegativeStorageDictionaryOverflow(t *testing.T) {
 	StorageDictionaryLimit = math.MaxUint32
 }
 
-// TestNegativeStorageDictionaryDecodingFailure1 checks whether invalid index for Decode()
+// TestStorageDictionaryDecodingFailure1 checks whether invalid index for Decode()
 // can be captured (retrieving index 0 on an empty dictionary).
-func TestNegativeStorageDictionaryDecodingFailure1(t *testing.T) {
+func TestStorageDictionaryDecodingFailure1(t *testing.T) {
 	dict := NewStorageDictionary()
 	_, err := dict.Decode(0)
 	if err == nil {
@@ -83,10 +83,10 @@ func TestNegativeStorageDictionaryDecodingFailure1(t *testing.T) {
 	}
 }
 
-// TestNegativeStorageDictionaryDecodingFailure2 checks whether invalid
+// TestStorageDictionaryDecodingFailure2 checks whether invalid
 // index for Decode() can be captured (retrieving index MaxUint32 on an
 // empty dictionary).
-func TestNegativeStorageDictionaryDecodingFailure2(t *testing.T) {
+func TestStorageDictionaryDecodingFailure2(t *testing.T) {
 	dict := NewStorageDictionary()
 	_, err := dict.Decode(math.MaxUint32)
 	if err == nil {
@@ -94,9 +94,9 @@ func TestNegativeStorageDictionaryDecodingFailure2(t *testing.T) {
 	}
 }
 
-// TestNegativeStorageDictionaryReadFailure creates corrupted file and
+// TestStorageDictionaryReadFailure creates corrupted file and
 // reads file as dictionary.
-func TestNegativeStorageDictionaryReadFailure(t *testing.T) {
+func TestStorageDictionaryReadFailure(t *testing.T) {
 	filename := "./test.dict"
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -119,10 +119,10 @@ func TestNegativeStorageDictionaryReadFailure(t *testing.T) {
 	os.Remove(filename)
 }
 
-// TestPositiveStorageDictionaryReadWrite encodes two addresses, writes them to file,
+// TestStorageDictionaryReadWrite encodes two addresses, writes them to file,
 // and reads them from file. Check whether the newly created dictionary read from
 // file is identical.
-func TestPositiveStorageDictionaryReadWrite(t *testing.T) {
+func TestStorageDictionaryReadWrite(t *testing.T) {
 	filename := "./test.dict"
 	encodedAddr1 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedAddr2 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")

--- a/tracer/dict/value_dictionary_test.go
+++ b/tracer/dict/value_dictionary_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 )
 
-// TestPositiveValueDictionarySimple1 encodes an value, and compares whether the
+// TestValueDictionarySimple1 encodes an value, and compares whether the
 // decoded value is the same, and its index is zero.
-func TestPositiveValueDictionarySimple1(t *testing.T) {
+func TestValueDictionarySimple1(t *testing.T) {
 	encodedValue := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	dict := NewValueDictionary()
 	idx, err1 := dict.Encode(encodedValue)
@@ -19,9 +19,9 @@ func TestPositiveValueDictionarySimple1(t *testing.T) {
 	}
 }
 
-// TestPositiveValueDictionarySimple2 encodes two valuees, and compares whether the
+// TestValueDictionarySimple2 encodes two valuees, and compares whether the
 // decoded valuees are the same, and their dictionary indices are zero and one.
-func TestPositiveValueDictionarySimple2(t *testing.T) {
+func TestValueDictionarySimple2(t *testing.T) {
 	encodedValue1 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedValue2 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")
 	dict := NewValueDictionary()
@@ -37,9 +37,9 @@ func TestPositiveValueDictionarySimple2(t *testing.T) {
 	}
 }
 
-// TestPositiveValueDictionarySimple3 encodes one value twice and checks that its value
+// TestValueDictionarySimple3 encodes one value twice and checks that its value
 // is encoded only once, and its index is zero.
-func TestPositiveValueDictionarySimple3(t *testing.T) {
+func TestValueDictionarySimple3(t *testing.T) {
 	encodedValue1 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	dict := NewValueDictionary()
 	idx1, err1 := dict.Encode(encodedValue1)
@@ -54,8 +54,8 @@ func TestPositiveValueDictionarySimple3(t *testing.T) {
 	}
 }
 
-// TestNegativeValueDictionaryOverflow checks whether dictionary overflows can be captured.
-func TestNegativeValueDictionaryOverflow(t *testing.T) {
+// TestValueDictionaryOverflow checks whether dictionary overflows can be captured.
+func TestValueDictionaryOverflow(t *testing.T) {
 	encodedValue1 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedValue2 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")
 	dict := NewValueDictionary()
@@ -73,9 +73,9 @@ func TestNegativeValueDictionaryOverflow(t *testing.T) {
 	ValueDictionaryLimit = math.MaxUint32
 }
 
-// TestNegativeValueDictionaryDecodingFailure1 checks whether invalid index for
+// TestValueDictionaryDecodingFailure1 checks whether invalid index for
 // Decode() can be captured (retrieving index 0 on an empty dictionary).
-func TestNegativeValueDictionaryDecodingFailure1(t *testing.T) {
+func TestValueDictionaryDecodingFailure1(t *testing.T) {
 	dict := NewValueDictionary()
 	_, err := dict.Decode(0)
 	if err == nil {
@@ -83,9 +83,9 @@ func TestNegativeValueDictionaryDecodingFailure1(t *testing.T) {
 	}
 }
 
-// TestNegativeValueDictionaryDecodingFailure2 checks whether invalid index for
+// TestValueDictionaryDecodingFailure2 checks whether invalid index for
 // Decode() can be captured (retrieving index MaxUint32 on an empty dictionary).
-func TestNegativeValueDictionaryDecodingFailure2(t *testing.T) {
+func TestValueDictionaryDecodingFailure2(t *testing.T) {
 	dict := NewValueDictionary()
 	_, err := dict.Decode(math.MaxUint32)
 	if err == nil {
@@ -93,8 +93,8 @@ func TestNegativeValueDictionaryDecodingFailure2(t *testing.T) {
 	}
 }
 
-// TestNegativeValueDictionaryReadFailure creates corrupted file and read file as dictionary.
-func TestNegativeValueDictionaryReadFailure(t *testing.T) {
+// TestValueDictionaryReadFailure creates corrupted file and read file as dictionary.
+func TestValueDictionaryReadFailure(t *testing.T) {
 	filename := "./test.dict"
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -117,9 +117,9 @@ func TestNegativeValueDictionaryReadFailure(t *testing.T) {
 	os.Remove(filename)
 }
 
-// TestPositiveValueDictionaryReadWrite encodes two valuees, write them to file, and
+// TestValueDictionaryReadWrite encodes two valuees, write them to file, and
 // read them from file. Check whether the newly created dictionary read from file is identical.
-func TestPositiveValueDictionaryReadWrite(t *testing.T) {
+func TestValueDictionaryReadWrite(t *testing.T) {
 	filename := "./test.dict"
 	encodedValue1 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F272")
 	encodedValue2 := common.HexToHash("0xdEcAf0562A19C9fFf21c9cEB476B2858E6f1F273")


### PR DESCRIPTION
The dictionaries have been stored in an uncompressed byte format. Especially for value dictionaries, this has been too bloated. This pull request changes the file format of the dictionaries to a bzip2 file format.

In addition, we have magic numbers at the beginning of each dictionary to identify the file format for each dictionary.

Test cases for dictionaries have been renamed to standard format.