### PR TITLE
Add block number flag to dump command

### DIFF
--- a/cmd/gen-world-state/flags/flags.go
+++ b/cmd/gen-world-state/flags/flags.go
@@ -68,12 +68,12 @@ var (
 		Usage:   "ending block ID",
 	}
 
-	// TargetBlock represents the ID of target block to be reached by state evolve process
+	// TargetBlock represents the ID of target block to be reached by state evolve process or in dump state
 	TargetBlock = cli.IntFlag{
-		Name:     "target",
-		Aliases:  []string{"block", "blk"},
-		Usage:    "target block ID",
-		Required: true,
+		Name:    "target",
+		Aliases: []string{"block", "blk"},
+		Usage:   "target block ID",
+		Value:   0,
 	}
 
 	// TrieRootHash represents a hash of a state trie root to be decoded

--- a/cmd/gen-world-state/state/evolve.go
+++ b/cmd/gen-world-state/state/evolve.go
@@ -75,6 +75,10 @@ func getEvolutionBlockRange(ctx *cli.Context, stateDB *snapshot.StateDB, log *lo
 	// evolution until given target block
 	targetBlock := ctx.Uint64(flags.TargetBlock.Name)
 
+	if targetBlock == 0 {
+		return 0, 0, fmt.Errorf("supplied target block can't be %d", targetBlock)
+	}
+
 	// retrieving block number from world state database
 	currentBlock, err := stateDB.GetBlockNumber()
 	if err != nil {

--- a/cmd/gen-world-state/state/root.go
+++ b/cmd/gen-world-state/state/root.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"github.com/Fantom-foundation/Aida/cmd/gen-world-state/flags"
 	"github.com/Fantom-foundation/Aida/world-state/db/opera"
 	"github.com/urfave/cli/v2"
@@ -35,6 +36,12 @@ func root(ctx *cli.Context) error {
 	log := Logger(ctx, "root")
 
 	targetBlock := ctx.Uint64(flags.TargetBlock.Name)
+
+	if targetBlock == 0 {
+		err = fmt.Errorf("supplied target block can't be %d", targetBlock)
+		log.Error(err)
+		return err
+	}
 
 	//look up root hash from block number
 	rootHash, err := opera.RootByBlockNumber(store, targetBlock)


### PR DESCRIPTION
Root and block number flags are now optional in dump command.

Variants of calls:
- root, block (fastest) - no need to load any additional informations from opera
- block (fast) - root is looked up in opera same functionality as root command
- root (slowest) - block number search in parallel. Search is by iterating block sequentially from latest - if searching for historic block the search can take hours.
- neither (fast) - dumping is done for latest block in opera database