### PR TITLE
Only wrap StateDB profiler arround StateDB when enabled

### DIFF
--- a/cmd/trace-cli/trace/run_vm.go
+++ b/cmd/trace-cli/trace/run_vm.go
@@ -239,10 +239,6 @@ func runVM(ctx *cli.Context) error {
 	sec = time.Since(start).Seconds()
 	log.Printf("\tElapsed time: %.2f s, accounts: %v\n", sec, len(ws))
 
-	// wrap stateDB for profiling
-	profileStateDB, stats := tracer.NewProxyProfiler(db, cfg.debug)
-	db = profileStateDB
-
 	// prime stateDB
 	log.Printf("Prime stateDB\n")
 	start = time.Now()


### PR DESCRIPTION
This PR ensures that the proxy-profiler is only used when profiling is enabled.