### PR TITLE
Add continue-on-failure and update-on-failure to run-vm

### DIFF
--- a/cmd/trace-cli/trace/config.go
+++ b/cmd/trace-cli/trace/config.go
@@ -24,6 +24,10 @@ var (
 		Usage: "ChainID for replayer",
 		Value: 250,
 	}
+	continueOnFailureFlag = cli.BoolFlag{
+		Name:  "continue-on-failure",
+		Usage: "continue execute after validation failure detected",
+	}
 	cpuProfileFlag = cli.StringFlag{
 		Name:  "cpuprofile",
 		Usage: "enables CPU profiling",
@@ -99,18 +103,19 @@ type TraceConfig struct {
 	first uint64 // first block
 	last  uint64 // last block
 
-	debug            bool   // enable trace debug flag
-	enableValidation bool   // enable validation flag
-	enableProgress   bool   // enable progress report flag
-	epochLength      uint64 // length of an epoch in number of blocks
-	impl             string // storage implementation
-	primeRandom      bool   // enable randomized priming
-	primeSeed        int64  // set random seed
-	primeThreshold   int    // set account threshold before commit
-	profile          bool   // enable micro profiling
-	updateDBDir      string // update-set directory
-	variant          string // database variant
-	workers          int    // number of worker threads
+	debug             bool   // enable trace debug flag
+	continueOnFailure bool   // continue validation when an error detected
+	enableValidation  bool   // enable validation flag
+	enableProgress    bool   // enable progress report flag
+	epochLength       uint64 // length of an epoch in number of blocks
+	impl              string // storage implementation
+	primeRandom       bool   // enable randomized priming
+	primeSeed         int64  // set random seed
+	primeThreshold    int    // set account threshold before commit
+	profile           bool   // enable micro profiling
+	updateDBDir       string // update-set directory
+	variant           string // database variant
+	workers           int    // number of worker threads
 }
 
 // NewTraceConfig creates and initializes TraceConfig with commandline arguments.
@@ -128,18 +133,19 @@ func NewTraceConfig(ctx *cli.Context) (*TraceConfig, error) {
 		first: first,
 		last:  last,
 
-		debug:            ctx.Bool(traceDebugFlag.Name),
-		enableValidation: ctx.Bool(validateEndState.Name),
-		enableProgress:   !ctx.Bool(disableProgressFlag.Name),
-		epochLength:      ctx.Uint64(epochLengthFlag.Name),
-		impl:             ctx.String(stateDbImplementation.Name),
-		primeRandom:      ctx.Bool(randomizePrimingFlag.Name),
-		primeSeed:        ctx.Int64(primeSeedFlag.Name),
-		primeThreshold:   ctx.Int(primeThresholdFlag.Name),
-		profile:          ctx.Bool(profileFlag.Name),
-		updateDBDir:      ctx.String(updateDBDirFlag.Name),
-		variant:          ctx.String(stateDbVariant.Name),
-		workers:          ctx.Int(substate.WorkersFlag.Name),
+		debug:             ctx.Bool(traceDebugFlag.Name),
+		continueOnFailure: ctx.Bool(continueOnFailureFlag.Name),
+		enableValidation:  ctx.Bool(validateEndState.Name),
+		enableProgress:    !ctx.Bool(disableProgressFlag.Name),
+		epochLength:       ctx.Uint64(epochLengthFlag.Name),
+		impl:              ctx.String(stateDbImplementation.Name),
+		primeRandom:       ctx.Bool(randomizePrimingFlag.Name),
+		primeSeed:         ctx.Int64(primeSeedFlag.Name),
+		primeThreshold:    ctx.Int(primeThresholdFlag.Name),
+		profile:           ctx.Bool(profileFlag.Name),
+		updateDBDir:       ctx.String(updateDBDirFlag.Name),
+		variant:           ctx.String(stateDbVariant.Name),
+		workers:           ctx.Int(substate.WorkersFlag.Name),
 	}
 
 	if cfg.epochLength <= 0 {

--- a/cmd/trace-cli/trace/gen_update_set.go
+++ b/cmd/trace-cli/trace/gen_update_set.go
@@ -37,7 +37,7 @@ func genUpdateSet(ctx *cli.Context) error {
 	var err error
 	// process arguments and flags
 	if ctx.Args().Len() != 3 {
-		return fmt.Errorf("trace command requires exactly 2 arguments")
+		return fmt.Errorf("trace command requires exactly 3 arguments")
 	}
 	first, last, argErr := SetBlockRange(ctx.Args().Get(0), ctx.Args().Get(1))
 	if argErr != nil {

--- a/cmd/trace-cli/trace/replay.go
+++ b/cmd/trace-cli/trace/replay.go
@@ -152,7 +152,7 @@ func traceReplayTask(cfg *TraceConfig) error {
 		log.Printf("Validate final state")
 		// advance the world state from the first block to the last block
 		advanceWorldState(ws, cfg.first, cfg.last, cfg.workers)
-		if err := validateStateDB(ws, db); err != nil {
+		if err := validateStateDB(ws, db, false); err != nil {
 			return fmt.Errorf("Validation failed. %v\n", err)
 		}
 	}

--- a/cmd/trace-cli/trace/replay_substate.go
+++ b/cmd/trace-cli/trace/replay_substate.go
@@ -122,7 +122,7 @@ func traceReplaySubstateTask(cfg *TraceConfig) error {
 
 		// Validate stateDB and OuputAlloc
 		if cfg.enableValidation {
-			if err := validateStateDB(tx.Substate.OutputAlloc, db); err != nil {
+			if err := validateStateDB(tx.Substate.OutputAlloc, db, false); err != nil {
 				return fmt.Errorf("Validation failed. Block %v Tx %v\n\t%v\n", tx.Block, tx.Transaction, err)
 			}
 		}

--- a/cmd/trace-cli/trace/run_vm.go
+++ b/cmd/trace-cli/trace/run_vm.go
@@ -25,6 +25,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const MaxErrorCount = 50
+
+var errCount int
+
 // runVMCommand data structure for the record app
 var RunVMCommand = cli.Command{
 	Action:    runVM,
@@ -33,6 +37,7 @@ var RunVMCommand = cli.Command{
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		&chainIDFlag,
+		&continueOnFailureFlag,
 		&cpuProfileFlag,
 		&epochLengthFlag,
 		&disableProgressFlag,
@@ -97,9 +102,15 @@ func runVMTask(db state.StateDB, cfg *TraceConfig, block uint64, tx int, recordi
 
 	// validate whether the input alloc is contained in the db
 	if cfg.enableValidation {
-		if err := validateStateDB(inputAlloc, db); err != nil {
-			msg := fmt.Sprintf("Block: %v Transaction: %v\n", block, tx)
-			return fmt.Errorf(msg+"Input alloc is not contained in the stateDB. %v", err)
+		if err := validateStateDB(inputAlloc, db, true); err != nil {
+			errCount++
+			errMsg := fmt.Sprintf("Block: %v Transaction: %v\n", block, tx)
+			errMsg += fmt.Sprintf("  Input alloc is not contained in the stateDB.\n%v", err)
+			if cfg.continueOnFailure {
+				fmt.Println(errMsg)
+			} else {
+				return fmt.Errorf(errMsg)
+			}
 		}
 	}
 
@@ -139,7 +150,12 @@ func runVMTask(db state.StateDB, cfg *TraceConfig, block uint64, tx int, recordi
 	// if transaction fails, revert to the first snapshot.
 	if err != nil {
 		db.RevertToSnapshot(snapshot)
-		return fmt.Errorf("Block: %v Transaction: %v\n%v", block, tx, err)
+		errCount++
+		if cfg.continueOnFailure {
+			fmt.Printf("Block: %v Transaction: %v\n%v", block, tx, err)
+		} else {
+			return fmt.Errorf("Block: %v Transaction: %v\n%v", block, tx, err)
+		}
 	}
 	if hashError != nil {
 		return hashError
@@ -168,17 +184,31 @@ func runVMTask(db state.StateDB, cfg *TraceConfig, block uint64, tx int, recordi
 
 	// check whether the outputAlloc substate is contained in the world-state db.
 	if cfg.enableValidation {
-		if err := validateStateDB(outputAlloc, db); err != nil {
-			msg := fmt.Sprintf("Block: %v Transaction: %v\n", block, tx)
-			return fmt.Errorf(msg+"Output alloc is not contained in the stateDB. %v", err)
+		if err := validateStateDB(outputAlloc, db, false); err != nil {
+			errCount++
+			errMsg := fmt.Sprintf("Block: %v Transaction: %v\n", block, tx)
+			errMsg += fmt.Sprintf("  Output alloc is not contained in the stateDB. %v\n", err)
+			if cfg.continueOnFailure {
+				fmt.Println(errMsg)
+			} else {
+				return fmt.Errorf(errMsg)
+			}
 		}
 		r := outputResult.Equal(evmResult)
 		if !r {
-			fmt.Printf("Block: %v Transaction: %v\n", block, tx)
-			fmt.Printf("inconsistent output: result\n")
+			errCount++
+			errMsg := fmt.Sprintf("Block: %v Transaction: %v\n", block, tx)
+			errMsg += fmt.Sprintf("  Inconsistent output result.\n")
 			replay.PrintResultDiffSummary(outputResult, evmResult)
-			return fmt.Errorf("inconsistent output")
+			if cfg.continueOnFailure {
+				fmt.Println(errMsg)
+			} else {
+				return fmt.Errorf(errMsg)
+			}
 		}
+	}
+	if errCount > MaxErrorCount {
+		return fmt.Errorf("Too many errors.")
 	}
 	return nil
 }
@@ -254,13 +284,13 @@ func runVM(ctx *cli.Context) error {
 
 	// wrap stateDB for profiling
 	var stats *operation.ProfileStats
-	if cfg.profile {
+	if cfg.profile || cfg.debug {
 		db, stats = tracer.NewProxyProfiler(db, cfg.debug)
 	}
 
 	if cfg.enableValidation {
 		fmt.Printf("WARNING: validation enabled, reducing Tx throughput\n")
-		if err := validateStateDB(ws, db); err != nil {
+		if err := validateStateDB(ws, db, false); err != nil {
 			return fmt.Errorf("Pre: World state is not contained in the stateDB. %v", err)
 		}
 	}
@@ -340,7 +370,7 @@ func runVM(ctx *cli.Context) error {
 
 	if cfg.enableValidation {
 		advanceWorldState(ws, cfg.first, cfg.last, cfg.workers)
-		if err := validateStateDB(ws, db); err != nil {
+		if err := validateStateDB(ws, db, false); err != nil {
 			return fmt.Errorf("World state is not contained in the stateDB. %v", err)
 		}
 	}


### PR DESCRIPTION
This pr introduces new functionalities:
 - continue execution after encountering an error. A new flag --continue-on-failure allow run-vm to continue after an error is detected.
 - update value on validation error. This only applies when input. substate is not contianed in stateDB. The stateDb is updated with input substate value.