### PR TITLE
Report storage usage and improve validation cli

### DIFF
--- a/cmd/trace-cli/trace/gen_update_set.go
+++ b/cmd/trace-cli/trace/gen_update_set.go
@@ -19,7 +19,7 @@ var GenUpdateSetCommand = cli.Command{
 		&substate.WorkersFlag,
 		&substate.SubstateDirFlag,
 		&updateDBDirFlag,
-		&validateEndState,
+		&validateFlag,
 		&worldStateDirFlag,
 	},
 	Description: `
@@ -48,7 +48,7 @@ func genUpdateSet(ctx *cli.Context) error {
 		return ferr
 	}
 	workers := ctx.Int(substate.WorkersFlag.Name)
-	validate := ctx.Bool(validateEndState.Name)
+	validate := ctx.Bool(validateFlag.Name)
 	updateDir := ctx.String(updateDBDirFlag.Name)
 	worldStateDir := ctx.String(worldStateDirFlag.Name)
 

--- a/cmd/trace-cli/trace/replay.go
+++ b/cmd/trace-cli/trace/replay.go
@@ -36,7 +36,8 @@ var TraceReplayCommand = cli.Command{
 		&traceDirectoryFlag,
 		&traceDebugFlag,
 		&updateDBDirFlag,
-		&validateEndState,
+		&validateFlag,
+		&validateWorldStateFlag,
 	},
 	Description: `
 The trace replay command requires two arguments:
@@ -149,7 +150,7 @@ func traceReplayTask(cfg *TraceConfig) error {
 	log.Printf("Finished replaying storage operations on StateDB database")
 
 	// validate stateDB
-	if cfg.enableValidation {
+	if cfg.validateWorldState {
 		log.Printf("Validate final state")
 		// advance the world state from the first block to the last block
 		advanceWorldState(ws, cfg.first, cfg.last, cfg.workers)

--- a/cmd/trace-cli/trace/replay_substate.go
+++ b/cmd/trace-cli/trace/replay_substate.go
@@ -33,7 +33,8 @@ var TraceReplaySubstateCommand = cli.Command{
 		&substate.WorkersFlag,
 		&traceDirectoryFlag,
 		&traceDebugFlag,
-		&validateEndState,
+		&validateFlag,
+		&validateWorldStateFlag,
 	},
 	Description: `
 The trace replay-substate command requires two arguments:
@@ -122,7 +123,7 @@ func traceReplaySubstateTask(cfg *TraceConfig) error {
 		}
 
 		// Validate stateDB and OuputAlloc
-		if cfg.enableValidation {
+		if cfg.validateWorldState {
 			if err := validateStateDB(tx.Substate.OutputAlloc, db, false); err != nil {
 				return fmt.Errorf("Validation failed. Block %v Tx %v\n\t%v\n", tx.Block, tx.Transaction, err)
 			}


### PR DESCRIPTION
This PR
 - report storage usage on exit
 - add an option to validate stateDB before/after transaction
 - add an option to validate stateDB before/after executed block range
 - keep --validate option which enables the above two validation options
 - implictly enable tx state validation if --continue-on-failure flag is used