### PR TITLE
Fix code copy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221129035610-00d8726371c8
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221130042521-e53291d1d472
 
 replace github.com/Fantom-foundation/go-opera => github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20221124030310-9d06e1f98a18
 

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221129035610-00d8726371c8 h1:nNwgE7f+L8irUjBBDs4FPFtjDXbInxvAlC+N3oLse4g=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221129035610-00d8726371c8/go.mod h1:mEJqEShOolRbUDJYmmTz7kf8sLhLIOPp9JIOtQ7yM6A=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221130042521-e53291d1d472 h1:y4tUN5gFOjZAj79zKqTj1OPc2LPe+YAAtcPihaif9y8=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221130042521-e53291d1d472/go.mod h1:mEJqEShOolRbUDJYmmTz7kf8sLhLIOPp9JIOtQ7yM6A=
 github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20221124030310-9d06e1f98a18 h1:eZpyhVrAMlC95oNlzJM+y4R1QbpMmA1stMx9wBI4fs4=
 github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20221124030310-9d06e1f98a18/go.mod h1:kSFbFmV6w+yy3Jfn9gzku9l0m1OsqnYT87uJMZ76oSI=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20220103160934-6b4931c60582/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=


### PR DESCRIPTION
This PR updates go.mod referring to the latest version of go-ethereum-substate which has code copy fix.