### PR TITLE
Add shadow and logging StateDB support as a debugging tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ reads the recorded traces and re-executes state operations from block 5,050,000 
  - `--cpuprofile` records a CPU profile for the replay to be inspected using `pprof`
  - `--db-impl` select between `geth` and `carmen`. Default: `geth`
  - `--db-variant` select between implementation specific sub-variants, e.g. `go-ldb` or `cpp-file`
+ - `--db-logging` enables the logging of each StateDB operation
+ - `--db-shadow-impl` if set, a shadow DB implementation of the given type is running in parallel to the primary StateDB
+ - `--db-shadow-variant` the variant to be used for the shadow StateDB instance, if enabled
  - `--disable-progress` disable progress report. Default: `false`
  - `--prime-random` randomize order of accounts in StateDB priming.
  - `--prime-seed` set seed for randomizing priming.
@@ -114,6 +117,9 @@ reads the recorded traces and re-executes state operations from block 5,050,000 
  - `--db-impl` select between `geth` and `carmen`. Default: `geth`
  - `--db-variant` select between implementation specific sub-variants, e.g. `go-ldb` or `cpp-file`
  - `--db-tmp-dir` the directory to use for the temporary StateDB, uses system default if empty
+ - `--db-logging` enables the logging of each StateDB operation
+ - `--db-shadow-impl` if set, a shadow DB implementation of the given type is running in parallel to the primary StateDB
+ - `--db-shadow-variant` the variant to be used for the shadow StateDB instance, if enabled
  - `--disable-progress` disable progress report. Default: `false`
  - `--prime-random` randomize order of accounts in StateDB priming.
  - `--prime-seed` set seed for randomizing priming.
@@ -139,6 +145,9 @@ executes transactions from block 4,564,026 to 5,000,000. The tool initializes st
  - `--db-impl` select between `geth` and `carmen`. Default: `geth`
  - `--db-variant` select between implementation specific sub-variants, e.g. `go-ldb` or `cpp-file`
  - `--db-tmp-dir` the directory to use for the temporary StateDB, uses system default if empty
+ - `--db-logging` enables the logging of each StateDB operation
+ - `--db-shadow-impl` if set, a shadow DB implementation of the given type is running in parallel to the primary StateDB
+ - `--db-shadow-variant` the variant to be used for the shadow StateDB instance, if enabled
  - `--disable-progress` disable progress report. Default: `false`
  - `--memory-breakdown` display detailed memory usage breakdown after priming and after the EVM runs
  - `--prime-random` randomize order of accounts in StateDB priming.

--- a/cmd/trace-cli/trace/replay.go
+++ b/cmd/trace-cli/trace/replay.go
@@ -33,6 +33,9 @@ var TraceReplayCommand = cli.Command{
 		&stateDbImplementationFlag,
 		&stateDbVariantFlag,
 		&stateDbTempDirFlag,
+		&stateDbLoggingFlag,
+		&shadowDbImplementationFlag,
+		&shadowDbVariantFlag,
 		&substate.SubstateDirFlag,
 		&substate.WorkersFlag,
 		&traceDirectoryFlag,
@@ -81,7 +84,7 @@ func traceReplayTask(cfg *TraceConfig) error {
 	}
 	defer os.RemoveAll(stateDirectory)
 	log.Printf("\tTemporary state DB directory: %v\n", stateDirectory)
-	db, err := makeStateDB(stateDirectory, cfg.impl, cfg.variant)
+	db, err := MakeStateDB(stateDirectory, cfg)
 	if err != nil {
 		return err
 	}
@@ -208,7 +211,7 @@ func traceReplayAction(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if cfg.impl == "memory" {
+	if cfg.dbImpl == "memory" {
 		return fmt.Errorf("db-impl memory is not supported")
 	}
 

--- a/cmd/trace-cli/trace/replay_substate.go
+++ b/cmd/trace-cli/trace/replay_substate.go
@@ -29,6 +29,9 @@ var TraceReplaySubstateCommand = cli.Command{
 		&profileFlag,
 		&stateDbImplementationFlag,
 		&stateDbVariantFlag,
+		&stateDbLoggingFlag,
+		&shadowDbImplementationFlag,
+		&shadowDbVariantFlag,
 		&substate.SubstateDirFlag,
 		&substate.WorkersFlag,
 		&traceDirectoryFlag,
@@ -65,7 +68,7 @@ func traceReplaySubstateTask(cfg *TraceConfig) error {
 	defer os.RemoveAll(stateDirectory)
 
 	// Instantiate the state DB under testing
-	db, err := makeStateDB(stateDirectory, cfg.impl, cfg.variant)
+	db, err := MakeStateDB(stateDirectory, cfg)
 	if err != nil {
 		return err
 	}
@@ -106,7 +109,7 @@ func traceReplaySubstateTask(cfg *TraceConfig) error {
 			break
 		}
 
-		if cfg.impl == "memory" {
+		if cfg.dbImpl == "memory" {
 			db.PrepareSubstate(&tx.Substate.InputAlloc)
 		} else {
 			primeStateDB(tx.Substate.InputAlloc, db, cfg)

--- a/cmd/trace-cli/trace/run_vm.go
+++ b/cmd/trace-cli/trace/run_vm.go
@@ -48,6 +48,9 @@ var RunVMCommand = cli.Command{
 		&stateDbImplementationFlag,
 		&stateDbVariantFlag,
 		&stateDbTempDirFlag,
+		&stateDbLoggingFlag,
+		&shadowDbImplementationFlag,
+		&shadowDbVariantFlag,
 		&substate.WorkersFlag,
 		&substate.SubstateDirFlag,
 		&traceDebugFlag,
@@ -230,7 +233,7 @@ func runVM(ctx *cli.Context) error {
 	}
 
 	// process run-vm specific arguments
-	if cfg.impl == "memory" {
+	if cfg.dbImpl == "memory" {
 		return fmt.Errorf("db-impl memory is not supported")
 	}
 	vmImpl := ctx.String(vmImplementation.Name)
@@ -261,7 +264,7 @@ func runVM(ctx *cli.Context) error {
 
 	// instantiate the state DB under testing
 	var db state.StateDB
-	db, err = makeStateDB(stateDirectory, cfg.impl, cfg.variant)
+	db, err = MakeStateDB(stateDirectory, cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/trace-cli/trace/stochastic_replay.go
+++ b/cmd/trace-cli/trace/stochastic_replay.go
@@ -3,7 +3,6 @@ package trace
 import (
 	"bufio"
 	"fmt"
-	"github.com/Fantom-foundation/Aida/tracer/simulation"
 	"io"
 	"io/ioutil"
 	"log"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Fantom-foundation/Aida/tracer/simulation"
 
 	"github.com/Fantom-foundation/Aida/tracer"
 	"github.com/Fantom-foundation/Aida/tracer/dict"
@@ -33,6 +34,9 @@ var StochasticReplayCommand = cli.Command{
 		&profileFlag,
 		&stateDbImplementationFlag,
 		&stateDbVariantFlag,
+		&stateDbLoggingFlag,
+		&shadowDbImplementationFlag,
+		&shadowDbVariantFlag,
 		&substate.WorkersFlag,
 		&traceDirectoryFlag,
 		&traceDebugFlag,
@@ -58,7 +62,7 @@ func traceStochasticReplayTask(cfg *TraceConfig) error {
 	if err != nil {
 		return err
 	}
-	db, err := makeStateDB(stateDirectory, cfg.impl, cfg.variant)
+	db, err := MakeStateDB(stateDirectory, cfg)
 	if err != nil {
 		return err
 	}

--- a/tracer/state/logger.go
+++ b/tracer/state/logger.go
@@ -1,0 +1,274 @@
+package state
+
+import (
+	"log"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/substate"
+)
+
+// MakeLoggingStateDB wrapps the given StateDB instance into a logging wrapper causing
+// every StateDB operation (except BulkLoading) to be logged for debugging.
+func MakeLoggingStateDB(db StateDB) StateDB {
+	return &loggingStateDB{db}
+}
+
+type loggingStateDB struct {
+	db StateDB
+}
+
+func (s *loggingStateDB) BeginBlockApply() error {
+	log.Printf("BeginBlockApply\n")
+	return s.db.BeginBlockApply()
+}
+
+func (s *loggingStateDB) CreateAccount(addr common.Address) {
+	log.Printf("CreateAccont, %v\n", addr)
+	s.db.CreateAccount(addr)
+}
+
+func (s *loggingStateDB) Exist(addr common.Address) bool {
+	res := s.db.Exist(addr)
+	log.Printf("Exist, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) Empty(addr common.Address) bool {
+	res := s.db.Empty(addr)
+	log.Printf("Empty, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) Suicide(addr common.Address) bool {
+	res := s.db.Suicide(addr)
+	log.Printf("Suicide, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) HasSuicided(addr common.Address) bool {
+	res := s.db.HasSuicided(addr)
+	log.Printf("HasSuicided, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) GetBalance(addr common.Address) *big.Int {
+	res := s.db.GetBalance(addr)
+	log.Printf("GetBalance, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) AddBalance(addr common.Address, value *big.Int) {
+	s.db.AddBalance(addr, value)
+	log.Printf("AddBalance, %v, %v, %v\n", addr, value, s.db.GetBalance(addr))
+}
+
+func (s *loggingStateDB) SubBalance(addr common.Address, value *big.Int) {
+	s.db.SubBalance(addr, value)
+	log.Printf("SubBalance, %v, %v, %v\n", addr, value, s.db.GetBalance(addr))
+}
+
+func (s *loggingStateDB) GetNonce(addr common.Address) uint64 {
+	res := s.db.GetNonce(addr)
+	log.Printf("GetNonce, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) SetNonce(addr common.Address, value uint64) {
+	s.db.SetNonce(addr, value)
+	log.Printf("SetNonce, %v, %v\n", addr, value)
+}
+
+func (s *loggingStateDB) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
+	res := s.db.GetCommittedState(addr, key)
+	log.Printf("GetCommittedState, %v, %v, %v\n", addr, key, res)
+	return res
+}
+
+func (s *loggingStateDB) GetState(addr common.Address, key common.Hash) common.Hash {
+	res := s.db.GetState(addr, key)
+	log.Printf("GetState, %v, %v, %v\n", addr, key, res)
+	return res
+}
+
+func (s *loggingStateDB) SetState(addr common.Address, key common.Hash, value common.Hash) {
+	s.db.SetState(addr, key, value)
+	log.Printf("SetState, %v, %v, %v\n", addr, key, value)
+}
+
+func (s *loggingStateDB) GetCode(addr common.Address) []byte {
+	res := s.db.GetCode(addr)
+	log.Printf("GetCode, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) GetCodeSize(addr common.Address) int {
+	res := s.db.GetCodeSize(addr)
+	log.Printf("GetCodeSize, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) GetCodeHash(addr common.Address) common.Hash {
+	res := s.db.GetCodeHash(addr)
+	log.Printf("GetCodeHash, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) SetCode(addr common.Address, code []byte) {
+	s.db.SetCode(addr, code)
+	log.Printf("SetCode, %v, %v\n", addr, code)
+}
+
+func (s *loggingStateDB) Snapshot() int {
+	res := s.db.Snapshot()
+	log.Printf("Snapshot, %v\n", res)
+	return res
+}
+
+func (s *loggingStateDB) RevertToSnapshot(id int) {
+	s.db.RevertToSnapshot(id)
+	log.Printf("RevertToSnapshot, %v\n", id)
+}
+
+func (s *loggingStateDB) BeginTransaction(tx uint32) {
+	log.Printf("BeginTransaction, %v\n", tx)
+	s.db.BeginTransaction(tx)
+}
+
+func (s *loggingStateDB) EndTransaction() {
+	log.Printf("EndTransaction\n")
+	s.db.EndTransaction()
+}
+
+func (s *loggingStateDB) BeginBlock(blk uint64) {
+	log.Printf("BeginBlock, %v\n", blk)
+	s.db.BeginBlock(blk)
+}
+
+func (s *loggingStateDB) EndBlock() {
+	log.Printf("EndBlock\n")
+	s.db.EndBlock()
+}
+
+func (s *loggingStateDB) BeginEpoch(number uint64) {
+	log.Printf("BeginEpoch, %v\n", number)
+	s.db.BeginEpoch(number)
+}
+
+func (s *loggingStateDB) EndEpoch() {
+	log.Printf("EndEpoch\n")
+	s.db.EndEpoch()
+}
+
+func (s *loggingStateDB) Close() error {
+	res := s.db.Close()
+	log.Printf("EndEpoch, %v\n", res)
+	return res
+}
+
+func (s *loggingStateDB) AddRefund(amount uint64) {
+	s.db.AddRefund(amount)
+	log.Printf("AddRefund, %v, %v\n", amount, s.db.GetRefund())
+}
+
+func (s *loggingStateDB) SubRefund(amount uint64) {
+	s.db.SubRefund(amount)
+	log.Printf("SubRefund, %v, %v\n", amount, s.db.GetRefund())
+}
+
+func (s *loggingStateDB) GetRefund() uint64 {
+	res := s.db.GetRefund()
+	log.Printf("GetRefund, %v\n", res)
+	return res
+}
+
+func (s *loggingStateDB) PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	log.Printf("PrepareAccessList, %v, %v, %v, %v\n", sender, dest, precompiles, txAccesses)
+	s.db.PrepareAccessList(sender, dest, precompiles, txAccesses)
+}
+
+func (s *loggingStateDB) AddressInAccessList(addr common.Address) bool {
+	res := s.db.AddressInAccessList(addr)
+	log.Printf("AddressInAccessList, %v, %v\n", addr, res)
+	return res
+}
+
+func (s *loggingStateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	a, b := s.db.SlotInAccessList(addr, slot)
+	log.Printf("SlotInAccessList, %v, %v, %v, %v\n", addr, slot, a, b)
+	return a, b
+}
+
+func (s *loggingStateDB) AddAddressToAccessList(addr common.Address) {
+	log.Printf("AddAddressToAccessList, %v\n", addr)
+	s.db.AddAddressToAccessList(addr)
+}
+
+func (s *loggingStateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	log.Printf("AddSlotToAccessList, %v, %v\n", addr, slot)
+	s.db.AddSlotToAccessList(addr, slot)
+}
+
+func (s *loggingStateDB) AddLog(entry *types.Log) {
+	log.Printf("AddLog, %v\n", entry)
+	s.db.AddLog(entry)
+}
+
+func (s *loggingStateDB) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	res := s.db.GetLogs(hash, blockHash)
+	log.Printf("GetLogs, %v, %v, %v\n", hash, blockHash, res)
+	return res
+}
+
+func (s *loggingStateDB) Finalise(deleteEmptyObjects bool) {
+	log.Printf("Finalise, %v\n", deleteEmptyObjects)
+	s.db.Finalise(deleteEmptyObjects)
+}
+
+func (s *loggingStateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	res := s.db.IntermediateRoot(deleteEmptyObjects)
+	log.Printf("IntermediateRoot, %v, %v\n", deleteEmptyObjects, res)
+	return res
+}
+
+func (s *loggingStateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
+	hash, err := s.db.Commit(deleteEmptyObjects)
+	log.Printf("Commit, %v, %v, %v\n", deleteEmptyObjects, hash, err)
+	return hash, err
+}
+
+func (s *loggingStateDB) Prepare(thash common.Hash, ti int) {
+	s.db.Prepare(thash, ti)
+	log.Printf("Prepare, %v, %v\n", thash, ti)
+}
+
+func (s *loggingStateDB) PrepareSubstate(substate *substate.SubstateAlloc) {
+	s.db.PrepareSubstate(substate)
+	log.Printf("PrepareSubstate, %v\n", substate)
+}
+
+func (s *loggingStateDB) GetSubstatePostAlloc() substate.SubstateAlloc {
+	res := s.db.GetSubstatePostAlloc()
+	log.Printf("GetSubstatePostAlloc, %v\n", res)
+	return res
+}
+
+func (s *loggingStateDB) AddPreimage(hash common.Hash, data []byte) {
+	s.db.AddPreimage(hash, data)
+	log.Printf("AddPreimage, %v, %v\n", hash, data)
+}
+
+func (s *loggingStateDB) ForEachStorage(addr common.Address, op func(common.Hash, common.Hash) bool) error {
+	// no loggin in this case
+	return s.db.ForEachStorage(addr, op)
+}
+
+func (s *loggingStateDB) StartBulkLoad() BulkLoad {
+	// no loggin in this case
+	return s.db.StartBulkLoad()
+}
+func (s *loggingStateDB) GetMemoryUsage() *MemoryUsage {
+	// no loggin in this case
+	return s.db.GetMemoryUsage()
+}

--- a/tracer/state/shadow.go
+++ b/tracer/state/shadow.go
@@ -1,0 +1,384 @@
+package state
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/substate"
+)
+
+// MakeShadowStateDB creates a StateDB instance bundeling two other instances and running each
+// operation on both of them, cross checking results. If the results are not equal, an error
+// is logged and the result of the primary instance is returned.
+func MakeShadowStateDB(prime, shadow StateDB) StateDB {
+	return &shadowStateDB{
+		prime:     prime,
+		shadow:    shadow,
+		snapshots: []snapshotPair{},
+	}
+}
+
+type shadowStateDB struct {
+	prime     StateDB
+	shadow    StateDB
+	snapshots []snapshotPair
+}
+
+type snapshotPair struct {
+	prime, shadow int
+}
+
+func (s *shadowStateDB) BeginBlockApply() error {
+	return s.getError("BeginBlockApply", func(s StateDB) error { return s.BeginBlockApply() })
+}
+
+func (s *shadowStateDB) CreateAccount(addr common.Address) {
+	s.run("CreateAccount", func(s StateDB) { s.CreateAccount(addr) })
+}
+
+func (s *shadowStateDB) Exist(addr common.Address) bool {
+	return s.getBool("Exist", func(s StateDB) bool { return s.Exist(addr) }, addr)
+}
+
+func (s *shadowStateDB) Empty(addr common.Address) bool {
+	return s.getBool("Empty", func(s StateDB) bool { return s.Empty(addr) }, addr)
+}
+
+func (s *shadowStateDB) Suicide(addr common.Address) bool {
+	return s.getBool("Suicide", func(s StateDB) bool { return s.Suicide(addr) }, addr)
+}
+
+func (s *shadowStateDB) HasSuicided(addr common.Address) bool {
+	return s.getBool("HasSuicided", func(s StateDB) bool { return s.HasSuicided(addr) }, addr)
+}
+
+func (s *shadowStateDB) GetBalance(addr common.Address) *big.Int {
+	return s.getBigInt("GetBalance", func(s StateDB) *big.Int { return s.GetBalance(addr) }, addr)
+}
+
+func (s *shadowStateDB) AddBalance(addr common.Address, value *big.Int) {
+	s.run("AddBalance", func(s StateDB) { s.AddBalance(addr, value) })
+}
+
+func (s *shadowStateDB) SubBalance(addr common.Address, value *big.Int) {
+	s.run("SubBalance", func(s StateDB) { s.SubBalance(addr, value) })
+}
+
+func (s *shadowStateDB) GetNonce(addr common.Address) uint64 {
+	return s.getUint64("GetNonce", func(s StateDB) uint64 { return s.GetNonce(addr) }, addr)
+}
+
+func (s *shadowStateDB) SetNonce(addr common.Address, value uint64) {
+	s.run("SetNonce", func(s StateDB) { s.SetNonce(addr, value) })
+}
+
+func (s *shadowStateDB) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
+	return s.getHash("GetCommittedState", func(s StateDB) common.Hash { return s.GetCommittedState(addr, key) }, addr, key)
+}
+
+func (s *shadowStateDB) GetState(addr common.Address, key common.Hash) common.Hash {
+	return s.getHash("GetState", func(s StateDB) common.Hash { return s.GetState(addr, key) }, addr, key)
+}
+
+func (s *shadowStateDB) SetState(addr common.Address, key common.Hash, value common.Hash) {
+	s.run("SetState", func(s StateDB) { s.SetState(addr, key, value) })
+}
+
+func (s *shadowStateDB) GetCode(addr common.Address) []byte {
+	return s.getBytes("GetCode", func(s StateDB) []byte { return s.GetCode(addr) }, addr)
+}
+
+func (s *shadowStateDB) GetCodeSize(addr common.Address) int {
+	return s.getInt("GetCodeSize", func(s StateDB) int { return s.GetCodeSize(addr) }, addr)
+}
+
+func (s *shadowStateDB) GetCodeHash(addr common.Address) common.Hash {
+	return s.getHash("GetCodeHash", func(s StateDB) common.Hash { return s.GetCodeHash(addr) }, addr)
+}
+
+func (s *shadowStateDB) SetCode(addr common.Address, code []byte) {
+	s.run("SetCode", func(s StateDB) { s.SetCode(addr, code) })
+}
+
+func (s *shadowStateDB) Snapshot() int {
+	pair := snapshotPair{
+		s.prime.Snapshot(),
+		s.shadow.Snapshot(),
+	}
+	s.snapshots = append(s.snapshots, pair)
+	return len(s.snapshots) - 1
+}
+
+func (s *shadowStateDB) RevertToSnapshot(id int) {
+	if id < 0 || len(s.snapshots) <= id {
+		panic(fmt.Sprintf("invalid snapshot id: %v, max: %v", id, len(s.snapshots)))
+	}
+	s.prime.RevertToSnapshot(s.snapshots[id].prime)
+	s.shadow.RevertToSnapshot(s.snapshots[id].shadow)
+}
+
+func (s *shadowStateDB) BeginTransaction(tx uint32) {
+	s.snapshots = s.snapshots[0:0]
+	s.run("BeginTransaction", func(s StateDB) { s.BeginTransaction(tx) })
+}
+
+func (s *shadowStateDB) EndTransaction() {
+	s.run("EndTransaction", func(s StateDB) { s.EndTransaction() })
+}
+
+func (s *shadowStateDB) BeginBlock(blk uint64) {
+	s.run("BeginBlock", func(s StateDB) { s.BeginBlock(blk) })
+}
+
+func (s *shadowStateDB) EndBlock() {
+	s.run("EndBlock", func(s StateDB) { s.EndBlock() })
+}
+
+func (s *shadowStateDB) BeginEpoch(number uint64) {
+	s.run("BeginEpoch", func(s StateDB) { s.BeginEpoch(number) })
+}
+
+func (s *shadowStateDB) EndEpoch() {
+	s.run("EndEpoch", func(s StateDB) { s.EndEpoch() })
+}
+
+func (s *shadowStateDB) Close() error {
+	return s.getError("Close", func(s StateDB) error { return s.Close() })
+}
+
+func (s *shadowStateDB) AddRefund(amount uint64) {
+	s.run("AddRefund", func(s StateDB) { s.AddRefund(amount) })
+	// check that the update value is the same
+	s.getUint64("AddRefund", func(s StateDB) uint64 { return s.GetRefund() })
+}
+
+func (s *shadowStateDB) SubRefund(amount uint64) {
+	s.run("SubRefund", func(s StateDB) { s.SubRefund(amount) })
+	// check that the update value is the same
+	s.getUint64("SubRefund", func(s StateDB) uint64 { return s.GetRefund() })
+}
+
+func (s *shadowStateDB) GetRefund() uint64 {
+	return s.getUint64("GetRefund", func(s StateDB) uint64 { return s.GetRefund() })
+}
+
+func (s *shadowStateDB) PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	s.run("PrepareAccessList", func(s StateDB) { s.PrepareAccessList(sender, dest, precompiles, txAccesses) })
+}
+
+func (s *shadowStateDB) AddressInAccessList(addr common.Address) bool {
+	return s.getBool("AddressInAccessList", func(s StateDB) bool { return s.AddressInAccessList(addr) }, addr)
+}
+
+func (s *shadowStateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	return s.getBoolBool("SlotInAccessList", func(s StateDB) (bool, bool) { return s.SlotInAccessList(addr, slot) }, addr, slot)
+}
+
+func (s *shadowStateDB) AddAddressToAccessList(addr common.Address) {
+	s.run("AddAddressToAccessList", func(s StateDB) { s.AddAddressToAccessList(addr) })
+}
+
+func (s *shadowStateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	s.run("AddSlotToAccessList", func(s StateDB) { s.AddSlotToAccessList(addr, slot) })
+}
+
+func (s *shadowStateDB) AddLog(log *types.Log) {
+	s.run("AddLog", func(s StateDB) { s.AddLog(log) })
+}
+
+func (s *shadowStateDB) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	// ignored
+	return nil
+}
+
+func (s *shadowStateDB) Finalise(deleteEmptyObjects bool) {
+	s.run("Finalise", func(s StateDB) { s.Finalise(deleteEmptyObjects) })
+}
+
+func (s *shadowStateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	// Do not check hashes for equivalents.
+	s.shadow.IntermediateRoot(deleteEmptyObjects)
+	return s.prime.IntermediateRoot(deleteEmptyObjects)
+}
+
+func (s *shadowStateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
+	// Do not check hashes for equivalents.
+	s.shadow.Commit(deleteEmptyObjects)
+	return s.prime.Commit(deleteEmptyObjects)
+}
+
+func (s *shadowStateDB) Prepare(thash common.Hash, ti int) {
+	s.run("Prepare", func(s StateDB) { s.Prepare(thash, ti) })
+}
+
+func (s *shadowStateDB) PrepareSubstate(substate *substate.SubstateAlloc) {
+	s.run("PrepareSubstate", func(s StateDB) { s.PrepareSubstate(substate) })
+}
+
+func (s *shadowStateDB) GetSubstatePostAlloc() substate.SubstateAlloc {
+	// Skip comparing those results.
+	s.shadow.GetSubstatePostAlloc()
+	return s.prime.GetSubstatePostAlloc()
+}
+
+func (s *shadowStateDB) AddPreimage(hash common.Hash, plain []byte) {
+	s.run("AddPreimage", func(s StateDB) { s.AddPreimage(hash, plain) })
+}
+
+func (s *shadowStateDB) ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error {
+	// ignored
+	panic("ForEachStorage not implemented")
+	return nil
+}
+
+func (s *shadowStateDB) StartBulkLoad() BulkLoad {
+	return &shadowBulkLoad{s.prime.StartBulkLoad(), s.shadow.StartBulkLoad()}
+}
+
+type stringStringer struct {
+	str string
+}
+
+func (s stringStringer) String() string {
+	return s.str
+}
+
+func (s *shadowStateDB) GetMemoryUsage() *MemoryUsage {
+	resP := s.prime.GetMemoryUsage()
+	resS := s.shadow.GetMemoryUsage()
+	return &MemoryUsage{
+		UsedBytes: resP.UsedBytes + resS.UsedBytes,
+		Breakdown: stringStringer{fmt.Sprintf("Primary:\n%v\nShadow:\n%v\n", resP.Breakdown, resS.Breakdown)},
+	}
+}
+
+type shadowBulkLoad struct {
+	prime  BulkLoad
+	shadow BulkLoad
+}
+
+func (l *shadowBulkLoad) CreateAccount(addr common.Address) {
+	l.prime.CreateAccount(addr)
+	l.shadow.CreateAccount(addr)
+}
+
+func (l *shadowBulkLoad) SetBalance(addr common.Address, value *big.Int) {
+	l.prime.SetBalance(addr, value)
+	l.shadow.SetBalance(addr, value)
+}
+
+func (l *shadowBulkLoad) SetNonce(addr common.Address, value uint64) {
+	l.prime.SetNonce(addr, value)
+	l.shadow.SetNonce(addr, value)
+}
+
+func (l *shadowBulkLoad) SetState(addr common.Address, key common.Hash, value common.Hash) {
+	l.prime.SetState(addr, key, value)
+	l.shadow.SetState(addr, key, value)
+}
+
+func (l *shadowBulkLoad) SetCode(addr common.Address, code []byte) {
+	l.prime.SetCode(addr, code)
+	l.shadow.SetCode(addr, code)
+}
+
+func (l *shadowBulkLoad) Close() error {
+	if err := l.prime.Close(); err != nil {
+		return err
+	}
+	if err := l.shadow.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *shadowStateDB) run(opName string, op func(s StateDB)) {
+	op(s.prime)
+	op(s.shadow)
+}
+
+func (s *shadowStateDB) getBool(opName string, op func(s StateDB) bool, args ...any) bool {
+	resP := op(s.prime)
+	resS := op(s.shadow)
+	if resP != resS {
+		logIssue(opName, resP, resS, args)
+	}
+	return resP
+}
+
+func (s *shadowStateDB) getBoolBool(opName string, op func(s StateDB) (bool, bool), args ...any) (bool, bool) {
+	resP1, resP2 := op(s.prime)
+	resS1, resS2 := op(s.shadow)
+	if resP1 != resS1 || resP2 != resS2 {
+		logIssue(opName, fmt.Sprintf("(%v,%v)", resP1, resP2), fmt.Sprintf("(%v,%v)", resS1, resS2), args)
+	}
+	return resP1, resP2
+}
+
+func (s *shadowStateDB) getInt(opName string, op func(s StateDB) int, args ...any) int {
+	resP := op(s.prime)
+	resS := op(s.shadow)
+	if resP != resS {
+		logIssue(opName, resP, resS, args)
+	}
+	return resP
+}
+
+func (s *shadowStateDB) getUint64(opName string, op func(s StateDB) uint64, args ...any) uint64 {
+	resP := op(s.prime)
+	resS := op(s.shadow)
+	if resP != resS {
+		logIssue(opName, resP, resS, args)
+	}
+	return resP
+}
+
+func (s *shadowStateDB) getHash(opName string, op func(s StateDB) common.Hash, args ...any) common.Hash {
+	resP := op(s.prime)
+	resS := op(s.shadow)
+	if resP != resS {
+		logIssue(opName, resP, resS, args)
+	}
+	return resP
+}
+
+func (s *shadowStateDB) getBigInt(opName string, op func(s StateDB) *big.Int, args ...any) *big.Int {
+	resP := op(s.prime)
+	resS := op(s.shadow)
+	if resP.Cmp(resS) != 0 {
+		logIssue(opName, resP, resS, args)
+	}
+	return resP
+}
+
+func (s *shadowStateDB) getBytes(opName string, op func(s StateDB) []byte, args ...any) []byte {
+	resP := op(s.prime)
+	resS := op(s.shadow)
+	if bytes.Compare(resP, resS) != 0 {
+		logIssue(opName, resP, resS, args)
+	}
+	return resP
+}
+
+func (s *shadowStateDB) getError(opName string, op func(s StateDB) error, args ...any) error {
+	resP := op(s.prime)
+	resS := op(s.shadow)
+	if resP != resS {
+		logIssue(opName, resP, resS, args)
+	}
+	return resP
+}
+
+func logIssue(opName string, prime, shadow any, args ...any) {
+	log.Printf("Diff for %v(", opName)
+	for _, arg := range args {
+		log.Printf("\t%v", arg)
+	}
+	log.Printf(")\n")
+	log.Printf("\tPrimary: %v\n", prime)
+	log.Printf("\tShadow:  %v\n", shadow)
+}


### PR DESCRIPTION
Adds support for
 - running a shadow DB validating the actions of the primary DB
 - enabling StateDB logging, printing debug logs for DB interactions