### PR TITLE
Fix Github CI cache for OSX (fixes #148)

### DIFF
--- a/.github/workflows/CI_OSX.yaml
+++ b/.github/workflows/CI_OSX.yaml
@@ -10,6 +10,8 @@ jobs:
 
   build:
     runs-on: macos-latest
+    env:
+      TEST_TMPDIR: "/Users/runner/.cache/bazel"
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3
@@ -28,8 +30,8 @@ jobs:
       - name: Mount bazel cache
         uses: actions/cache@v3
         with:
-         path: "~/.cache/bazel"
-         key: bazel
+         path: "/Users/runner/.cache/bazel"
+         key: bazel-osx
 
       - name: Build
         run: make


### PR DESCRIPTION
Fixes issue #148 - using Bazel cache in CI in MacOS enviroment.
Note: `~/.cache/bazel` is default bazel cache path on linux, I reference it here by absolute path `/Users/runner/.cache/bazel` because `env` in the yaml does not interpret `~` correctly.