### PR TITLE
Add memprofile parameter into replay/run-vm

### DIFF
--- a/cmd/trace-cli/trace/config.go
+++ b/cmd/trace-cli/trace/config.go
@@ -34,6 +34,10 @@ var (
 		Name:  "cpuprofile",
 		Usage: "enables CPU profiling",
 	}
+	memProfileFlag = cli.StringFlag{
+		Name:  "memprofile",
+		Usage: "enables memory allocation profiling",
+	}
 	epochLengthFlag = cli.IntFlag{
 		Name:  "epochlength",
 		Usage: "defines the number of blocks per epoch",


### PR DESCRIPTION
Adds support for memory allocation profiling into `trace replay` and `trace run-vm` - helps to find causes of time-intensive garberage collection (30-40% of run-vm run on my last try).