### PR TITLE
Reenable support for substate based DB in run-vm command

### DIFF
--- a/cmd/trace-cli/trace/run_vm.go
+++ b/cmd/trace-cli/trace/run_vm.go
@@ -235,11 +235,6 @@ func runVM(ctx *cli.Context) error {
 		return argErr
 	}
 
-	// process run-vm specific arguments
-	if cfg.dbImpl == "memory" {
-		return fmt.Errorf("db-impl memory is not supported")
-	}
-
 	// start CPU profiling if requested.
 	if profileFileName := ctx.String(cpuProfileFlag.Name); profileFileName != "" {
 		f, err := os.Create(profileFileName)
@@ -355,6 +350,7 @@ func runVM(ctx *cli.Context) error {
 		}
 
 		// run VM
+		db.PrepareSubstate(&tx.Substate.InputAlloc)
 		db.BeginTransaction(uint32(tx.Transaction))
 		result, err := runVMTask(db, cfg, tx.Block, tx.Transaction, tx.Substate)
 		if err != nil {

--- a/tracer/state/memory.go
+++ b/tracer/state/memory.go
@@ -2,8 +2,10 @@ package state
 
 import (
 	"fmt"
+	"math/big"
 
 	geth "github.com/Fantom-foundation/substate-cli/state"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/substate"
 )
 
@@ -29,4 +31,35 @@ func (s *gethInMemoryStateDB) Close() error {
 
 func (s *gethInMemoryStateDB) PrepareSubstate(substate *substate.SubstateAlloc) {
 	s.db = geth.MakeInMemoryStateDB(substate)
+}
+
+func (s *gethInMemoryStateDB) StartBulkLoad() BulkLoad {
+	return &gethInMemoryBulkLoad{}
+}
+
+type gethInMemoryBulkLoad struct{}
+
+func (l *gethInMemoryBulkLoad) CreateAccount(addr common.Address) {
+	// ignored
+}
+
+func (l *gethInMemoryBulkLoad) SetBalance(addr common.Address, value *big.Int) {
+	// ignored
+}
+
+func (l *gethInMemoryBulkLoad) SetNonce(addr common.Address, nonce uint64) {
+	// ignored
+}
+
+func (l *gethInMemoryBulkLoad) SetState(addr common.Address, key common.Hash, value common.Hash) {
+	// ignored
+}
+
+func (l *gethInMemoryBulkLoad) SetCode(addr common.Address, code []byte) {
+	// ignored
+}
+
+func (l *gethInMemoryBulkLoad) Close() error {
+	// ignored
+	return nil
 }


### PR DESCRIPTION
Reenables support for the substate-based in-memory DB implementation to support mirroring the substate-cli command for debugging.

This fixes #109