### PR TITLE
Add reporting of processing speed based on block numbers

### DIFF
--- a/cmd/trace-cli/trace/run_vm.go
+++ b/cmd/trace-cli/trace/run_vm.go
@@ -377,7 +377,7 @@ func runVM(ctx *cli.Context) error {
 				d := new(big.Int).Sub(gasCount, lastGasCount)
 				g := new(big.Float).Quo(new(big.Float).SetInt(d), new(big.Float).SetFloat64(sec-lastSec))
 
-				txRate := float64(txCount-lastTxCount)/(sec-lastSec)
+				txRate := float64(txCount-lastTxCount) / (sec - lastSec)
 
 				fmt.Printf("run-vm: Elapsed time: %.0f s, at block %v (~ %.1f Tx/s, ~ %.1f Gas/s)\n", sec, tx.Block, txRate, g)
 				lastSec = sec


### PR DESCRIPTION
Example output:
```
2022/12/15 16:43:38 Run VM
run-vm: Elapsed time: 15 s, at block 4577491 (~ 1941.8 Tx/s, ~ 647432729.1 Gas/s)
run-vm: Elapsed time: 30 s, at block 4592225 (~ 2318.5 Tx/s, ~ 810221667.4 Gas/s)
run-vm: Reached block 4600000, last interval rate ~ 2088.3 Tx/s, ~ 750022233.5 Gas/s
run-vm: Elapsed time: 45 s, at block 4603025 (~ 1943.4 Tx/s, ~ 837059638.4 Gas/s)
run-vm: Elapsed time: 60 s, at block 4613759 (~ 1680.5 Tx/s, ~ 881663876.5 Gas/s)
run-vm: Elapsed time: 75 s, at block 4623408 (~ 1867.1 Tx/s, ~ 801620586.4 Gas/s)
run-vm: Elapsed time: 90 s, at block 4635195 (~ 1817.1 Tx/s, ~ 872988956.5 Gas/s)
run-vm: Elapsed time: 105 s, at block 4648155 (~ 1656.4 Tx/s, ~ 866681205.3 Gas/s)
run-vm: Elapsed time: 120 s, at block 4659740 (~ 1509.2 Tx/s, ~ 847120272.9 Gas/s)
run-vm: Elapsed time: 135 s, at block 4671316 (~ 1620.6 Tx/s, ~ 860908320.5 Gas/s)
run-vm: Elapsed time: 150 s, at block 4681345 (~ 1655.4 Tx/s, ~ 763774830.6 Gas/s)
run-vm: Elapsed time: 165 s, at block 4692261 (~ 2134.1 Tx/s, ~ 716550049.6 Gas/s)
run-vm: Elapsed time: 180 s, at block 4699839 (~ 1973.1 Tx/s, ~ 736178173.1 Gas/s)
run-vm: Reached block 4700000, last interval rate ~ 1772.6 Tx/s, ~ 819220682.5 Gas/s
```