### PR TITLE
Run git actions on a self-hosted runner

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3


### PR DESCRIPTION
A workaround for hitting monthly limit. Use a self-hosted runner (profiling-III server) instead of a git server.