### PR TITLE
Remove deleted accounts after priming

### DIFF
--- a/cmd/trace-cli/trace/config.go
+++ b/cmd/trace-cli/trace/config.go
@@ -37,6 +37,10 @@ var (
 		Name:  "cpuprofile",
 		Usage: "enables CPU profiling",
 	}
+	deletedAccountDirFlag = cli.StringFlag{
+		Name:  "deleted-account-dir",
+		Usage: "sets the directory containing deleted accounts database",
+	}
 	memProfileFlag = cli.StringFlag{
 		Name:  "memprofile",
 		Usage: "enables memory allocation profiling",
@@ -170,9 +174,10 @@ type TraceConfig struct {
 	dbImpl             string // storage implementation
 	dbVariant          string // database variant
 	dbLogging          bool   // set to true if all DB operations should be logged
+	deletedAccountDir  string // directory of deleted account database
 	enableProgress     bool   // enable progress report flag
 	epochLength        uint64 // length of an epoch in number of blocks
-	archiveMode        bool
+	archiveMode        bool   // enable archive mode
 	memoryBreakdown    bool   // enable printing of memory breakdown
 	primeRandom        bool   // enable randomized priming
 	primeSeed          int64  // set random seed
@@ -257,6 +262,7 @@ func NewTraceConfig(ctx *cli.Context) (*TraceConfig, error) {
 		dbImpl:             ctx.String(stateDbImplementationFlag.Name),
 		dbVariant:          ctx.String(stateDbVariantFlag.Name),
 		dbLogging:          ctx.Bool(stateDbLoggingFlag.Name),
+		deletedAccountDir:  ctx.String(deletedAccountDirFlag.Name),
 		archiveMode:        ctx.Bool(archiveModeFlag.Name),
 		memoryBreakdown:    ctx.Bool(memoryBreakdownFlag.Name),
 		primeRandom:        ctx.Bool(randomizePrimingFlag.Name),

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221213025631-be0fbc00fb48
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221216100227-218059686983
 
 replace github.com/Fantom-foundation/go-opera => github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20221124030310-9d06e1f98a18
 

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221213025631-be0fbc00fb48 h1:Y/GV06FzbgFSbNriHhmYKYYVr5JsYPPhtdf9by1EZUo=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221213025631-be0fbc00fb48/go.mod h1:mEJqEShOolRbUDJYmmTz7kf8sLhLIOPp9JIOtQ7yM6A=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221216100227-218059686983 h1:XHGwgZcFmjPB+UQOica0rFKCPMrcX0XUsy9mYLlCtH8=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20221216100227-218059686983/go.mod h1:mEJqEShOolRbUDJYmmTz7kf8sLhLIOPp9JIOtQ7yM6A=
 github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20221124030310-9d06e1f98a18 h1:eZpyhVrAMlC95oNlzJM+y4R1QbpMmA1stMx9wBI4fs4=
 github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20221124030310-9d06e1f98a18/go.mod h1:kSFbFmV6w+yy3Jfn9gzku9l0m1OsqnYT87uJMZ76oSI=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20220103160934-6b4931c60582/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=

--- a/tracer/state/memory.go
+++ b/tracer/state/memory.go
@@ -13,7 +13,7 @@ func MakeGethInMemoryStateDB(variant string) (StateDB, error) {
 	if variant != "" {
 		return nil, fmt.Errorf("unkown variant: %v", variant)
 	}
-	return &gethInMemoryStateDB{}, nil
+	return &gethInMemoryStateDB{gethStateDB{db: geth.MakeInMemoryStateDB(&substate.SubstateAlloc{})}}, nil
 }
 
 type gethInMemoryStateDB struct {


### PR DESCRIPTION
This PR introduces a support for removing destroyed accounts after priming

--deleted-account-dir set directory which contains deleted account databse

Co-authored-by: Herbert Jordan