### PR TITLE
Remove world state after loading if not needed for validation

### DIFF
--- a/cmd/trace-cli/trace/run_vm.go
+++ b/cmd/trace-cli/trace/run_vm.go
@@ -324,6 +324,9 @@ func runVM(ctx *cli.Context) error {
 		if err := validateStateDB(ws, db, false); err != nil {
 			return fmt.Errorf("Pre: World state is not contained in the stateDB. %v", err)
 		}
+	} else {
+		// Release world state to free memory.
+		ws = substate.SubstateAlloc{}
 	}
 
 	if cfg.enableProgress {


### PR DESCRIPTION
This PR cleans up the world state after it was used for priming the database and it is no longer needed for world state validation. This reduces the memory footprint of the `run-vm` command while processing transactions by 20+ GB (depending on the targeted block), allowing more instances to run concurrently.