### PR TITLE
Add support for limiting the number of processed transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ executes transactions from block 4,564,026 to 5,000,000. The tool initializes st
  - `--db-shadow-impl` if set, a shadow DB implementation of the given type is running in parallel to the primary StateDB
  - `--db-shadow-variant` the variant to be used for the shadow StateDB instance, if enabled
  - `--disable-progress` disable progress report. Default: `false`
+ - `--max-transactions` limit the maximum number of processed transactions, default: unlimited (`-1`)
  - `--memory-breakdown` display detailed memory usage breakdown after priming and after the EVM runs
  - `--prime-random` randomize order of accounts in StateDB priming.
  - `--prime-seed` set seed for randomizing priming.

--- a/cmd/trace-cli/trace/config.go
+++ b/cmd/trace-cli/trace/config.go
@@ -155,6 +155,11 @@ var (
 		Required: true,
 		Value:    0,
 	}
+	maxNumTransactionsFlag = cli.IntFlag{
+		Name:  "max-transactions",
+		Usage: "limit the maximum number of processed transactions, default: unlimited",
+		Value: -1,
+	}
 	stochasticMatrixFlag = cli.StringFlag{
 		Name:  "stochastic-matrix",
 		Usage: "set stochastic matrix file",
@@ -188,6 +193,7 @@ type TraceConfig struct {
 	epochLength        uint64 // length of an epoch in number of blocks
 	archiveMode        bool   // enable archive mode
 	hasDeletedAccounts bool   // true if deletedAccountDir is not empty; otherwise false
+	maxNumTransactions int    // the maximum number of processed transactions
 	memoryBreakdown    bool   // enable printing of memory breakdown
 	primeRandom        bool   // enable randomized priming
 	primeSeed          int64  // set random seed
@@ -285,6 +291,7 @@ func NewTraceConfig(ctx *cli.Context, mode ArgumentMode) (*TraceConfig, error) {
 		deletedAccountDir:  ctx.String(deletedAccountDirFlag.Name),
 		archiveMode:        ctx.Bool(archiveModeFlag.Name),
 		hasDeletedAccounts: true,
+		maxNumTransactions: ctx.Int(maxNumTransactionsFlag.Name),
 		memoryBreakdown:    ctx.Bool(memoryBreakdownFlag.Name),
 		primeRandom:        ctx.Bool(randomizePrimingFlag.Name),
 		primeSeed:          ctx.Int64(primeSeedFlag.Name),
@@ -307,6 +314,9 @@ func NewTraceConfig(ctx *cli.Context, mode ArgumentMode) (*TraceConfig, error) {
 	if cfg.enableProgress {
 		log.Printf("Run config:\n")
 		log.Printf("\tBlock range: %v to %v\n", cfg.first, cfg.last)
+		if cfg.maxNumTransactions >= 0 {
+			log.Printf("\tTransaction limit: %d\n", cfg.maxNumTransactions)
+		}
 		log.Printf("\tChain id: %v (record & run-vm only)\n", cfg.chainID)
 		log.Printf("\tEpoch length: %v\n", cfg.epochLength)
 		if cfg.shadowImpl == "" {

--- a/cmd/trace-cli/trace/run_vm.go
+++ b/cmd/trace-cli/trace/run_vm.go
@@ -43,6 +43,7 @@ var RunVMCommand = cli.Command{
 		&deletedAccountDirFlag,
 		&disableProgressFlag,
 		&epochLengthFlag,
+		&maxNumTransactionsFlag,
 		&memoryBreakdownFlag,
 		&memProfileFlag,
 		&primeSeedFlag,
@@ -372,6 +373,9 @@ func runVM(ctx *cli.Context) error {
 			curBlock = tx.Block
 			db.BeginBlock(curBlock)
 			db.BeginBlockApply()
+		}
+		if cfg.maxNumTransactions >= 0 && txCount >= cfg.maxNumTransactions {
+			break
 		}
 
 		// run VM


### PR DESCRIPTION
With this flag, equally-sized transaction samples can be taken from various block heights.