### PR TITLE
Add CommitID for profiling

### DIFF
--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -20,6 +20,7 @@ const (
 	BeginEpochID
 	BeginTransactionID
 	CreateAccountID
+	CommitID
 	EmptyID
 	EndBlockID
 	EndEpochID
@@ -81,13 +82,14 @@ type OperationDictionary struct {
 // opDict relates an operation's id with its label and read-function.
 var opDict = map[byte]OperationDictionary{
 	AddBalanceID:            {label: "AddBalance", readfunc: ReadAddBalance},
-	BeginEpochID:            {label: "BeginEpoch", readfunc: ReadBeginEpoch},
-	EndEpochID:              {label: "EndEpoch", readfunc: ReadEndEpoch},
 	BeginBlockID:            {label: "BeginBlock", readfunc: ReadBeginBlock},
-	EndBlockID:              {label: "EndBlock", readfunc: ReadEndBlock},
+	BeginEpochID:            {label: "BeginEpoch", readfunc: ReadBeginEpoch},
+	BeginTransactionID:      {label: "BeginTransaction", readfunc: ReadBeginTransaction},
+	CommitID:                {label: "Commit", readfunc: ReadPanic},
 	CreateAccountID:         {label: "CreateAccount", readfunc: ReadCreateAccount},
 	EmptyID:                 {label: "Empty", readfunc: ReadEmpty},
-	BeginTransactionID:      {label: "BeginTransaction", readfunc: ReadBeginTransaction},
+	EndBlockID:              {label: "EndBlock", readfunc: ReadEndBlock},
+	EndEpochID:              {label: "EndEpoch", readfunc: ReadEndEpoch},
 	EndTransactionID:        {label: "EndTransaction", readfunc: ReadEndTransaction},
 	ExistID:                 {label: "Exist", readfunc: ReadExist},
 	FinaliseID:              {label: "Finalise", readfunc: ReadFinalise},

--- a/tracer/operation/operation_test.go
+++ b/tracer/operation/operation_test.go
@@ -173,7 +173,7 @@ func (s *MockStateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 }
 
 func (s *MockStateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
-	s.recording = append(s.recording, Record{EndBlockID, []any{}})
+	s.recording = append(s.recording, Record{CommitID, []any{deleteEmptyObjects}})
 	return common.Hash{}, nil
 }
 

--- a/tracer/proxy_profiler.go
+++ b/tracer/proxy_profiler.go
@@ -375,9 +375,7 @@ func (p *ProxyProfiler) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	start := time.Now()
 	hash, err := p.db.Commit(deleteEmptyObjects)
 	elapsed := time.Since(start)
-	// To align operation ID with the id used in record/replay.
-	// Commit is called by EndBlock operation.
-	p.ps.Profile(operation.EndBlockID, elapsed)
+	p.ps.Profile(operation.CommitID, elapsed)
 	return hash, err
 }
 


### PR DESCRIPTION
Change profiling ID of commit operation from EndBlockID to CommitID.