### PR TITLE
Refactor runvm as a standalone command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GOPROXY ?= "https://proxy.golang.org,direct"
 
 .PHONY: all clean help test
 
-all: gen-world-state trace aida-stochastic
+all: gen-world-state aida-trace aida-runvm aida-stochastic
 
 gen-world-state:
 	@go build \
@@ -39,15 +39,25 @@ aida-stochastic:
        	-o $(GO_BIN)/aida-stochastic \
 	./cmd/stochastic-cli
 
-trace:
+aida-trace:
 	@cd carmen/go/lib ; \
 	./build_libcarmen.sh ; \
 	cd ../../.. ; \
 	GOPROXY=$(GOPROXY) \
 	GOPRIVATE=github.com/Fantom-foundation/Carmen,github.com/Fantom-foundation/go-opera-fvm \
 	go build -ldflags "-s -w -X 'github.com/Fantom-foundation/Aida/utils.GitCommit=$(BUILD_COMMIT)'" \
-       	-o $(GO_BIN)/trace \
+	-o $(GO_BIN)/aida-trace \
 	./cmd/trace-cli
+
+aida-runvm:
+	@cd carmen/go/lib ; \
+	./build_libcarmen.sh ; \
+	cd ../../.. ; \
+	GOPROXY=$(GOPROXY) \
+	GOPRIVATE=github.com/Fantom-foundation/Carmen,github.com/Fantom-foundation/go-opera-fvm \
+	go build -ldflags "-s -w -X 'github.com/Fantom-foundation/Aida/utils.GitCommit=$(BUILD_COMMIT)'" \
+	-o $(GO_BIN)/aida-runvm \
+	./cmd/runvm-cli
 
 test:
 	@go test ./...

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Trace cli tool provides storage trace recording and replaying functionality.
 ### Trace Record
 **Run**
 
-`./build/trace record 5000000 5100000`
+`./build/aida-trace record 5000000 5100000`
 simulates transaction execution from block 5,000,000 to (and including) block 5,100,000 using [substate](github.com/Fantom-foundation/substate-cli). Storage operations executed during transaction processing are recorded into a compressed file format.
 
 **Options**
@@ -81,7 +81,7 @@ simulates transaction execution from block 5,000,000 to (and including) block 5,
 
 **Run**
 
-`./build/trace replay --worldstatedir path/to/world-state 5050000 5100000`
+`./build/aida-trace replay --worldstatedir path/to/world-state 5050000 5100000`
 reads the recorded traces and re-executes state operations from block 5,050,000 to 5,100,000. The tool initializes stateDB with accounts in the world state from option `--worldstatedir`. The storage operations are executed and update the stateDB sequentially in the order they were recorded.
 
 **Options**
@@ -108,7 +108,7 @@ reads the recorded traces and re-executes state operations from block 5,050,000 
 
 **Run**
 
-`./build/trace replay-substate 5050000 5100000`
+`./build/aida-trace replay-substate 5050000 5100000`
 reads the recorded traces and re-executes state operations from block 5,050,000 to 5,100,000. The storage operations are executed sequentially in the order they were recorded. The tool iterates through substates to construct a partial stateDB such that the replayed storage operations can simulate read/write with actual data.
 
 **Options**
@@ -136,7 +136,7 @@ reads the recorded traces and re-executes state operations from block 5,050,000 
 
 **Run**
 
-`./build/trace run-vm --updatedir path/to/updatedb --db-impl [geth/carmen/memory/flat] 4564026 5000000`
+`./build/aida-runvm --updatedir path/to/updatedb --db-impl [geth/carmen/memory/flat] 4564026 5000000`
 executes transactions from block 4,564,026 to 5,000,000. The tool initializes stateDB with accounts in the world state from option `--worldstatedir`. Each transaction calls VM which issues a series of StateDB operations to a selected storage system.
 
 **Options**
@@ -169,7 +169,7 @@ executes transactions from block 4,564,026 to 5,000,000. The tool initializes st
 
 **Run**
 
-`./build/trace gen-update-set --worldstatedir path/to/world-state --updatedir path/to/updatedb 4564026 41000000 1000000`
+`./build/aida-trace gen-update-set --worldstatedir path/to/world-state --updatedir path/to/updatedb 4564026 41000000 1000000`
 generates piecewise update-sets (merges of output substates) at every 1000000 blocks starting from block 4564026 to block 41000000 and stores them in updateDB. SubstateAlloc of block 4564025 from the world state is reocrded as the first update-set if --worldstatedir is provided. The subsequence update-sets happen at block 5000000 and every 1000000 blocks afterwards. 
 
 **Options**

--- a/cmd/runvm-cli/main.go
+++ b/cmd/runvm-cli/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Fantom-foundation/Aida/cmd/runvm-cli/runvm"
+	"github.com/Fantom-foundation/Aida/utils"
+	"github.com/ethereum/go-ethereum/substate"
+	"github.com/urfave/cli/v2"
+)
+
+// RunVMApp data structure
+var RunVMApp = cli.App{
+	Action:    runvm.RunVM,
+	Name:      "Aida Storage Run VM Manager",
+	HelpName:  "runvm",
+	Usage:     "run VM on the world-state",
+	Copyright: "(c) 2022 Fantom Foundation",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	Flags: []cli.Flag{
+		&substate.WorkersFlag,
+		&substate.SubstateDirFlag,
+		&utils.ArchiveModeFlag,
+		&utils.ChainIDFlag,
+		&utils.ContinueOnFailureFlag,
+		&utils.CpuProfileFlag,
+		&utils.DeletedAccountDirFlag,
+		&utils.DisableProgressFlag,
+		&utils.EpochLengthFlag,
+		&utils.MaxNumTransactionsFlag,
+		&utils.MemoryBreakdownFlag,
+		&utils.MemProfileFlag,
+		&utils.PrimeSeedFlag,
+		&utils.PrimeThresholdFlag,
+		&utils.ProfileFlag,
+		&utils.RandomizePrimingFlag,
+		&utils.SkipPrimingFlag,
+		&utils.StateDbImplementationFlag,
+		&utils.StateDbVariantFlag,
+		&utils.StateDbTempDirFlag,
+		&utils.StateDbLoggingFlag,
+		&utils.ShadowDbImplementationFlag,
+		&utils.ShadowDbVariantFlag,
+		&utils.UpdateDBDirFlag,
+		&utils.ValidateTxStateFlag,
+		&utils.ValidateWorldStateFlag,
+		&utils.ValidateFlag,
+		&utils.VmImplementation,
+	},
+	Description: `
+The run-vm command requires two arguments: <blockNumFirst> <blockNumLast>
+
+<blockNumFirst> and <blockNumLast> are the first and last block of
+the inclusive range of blocks.`,
+}
+
+// main implements runvm cli.
+func main() {
+	if err := RunVMApp.Run(os.Args); err != nil {
+		code := 1
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(code)
+	}
+}

--- a/cmd/runvm-cli/runvm/proxy_profiler.go
+++ b/cmd/runvm-cli/runvm/proxy_profiler.go
@@ -1,4 +1,4 @@
-package tracer
+package runvm
 
 import (
 	"math/big"

--- a/cmd/runvm-cli/runvm/runvm.go
+++ b/cmd/runvm-cli/runvm/runvm.go
@@ -1,4 +1,4 @@
-package trace
+package runvm
 
 import (
 	"fmt"
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Fantom-foundation/Aida/state"
 
-	"github.com/Fantom-foundation/Aida/tracer"
 	"github.com/Fantom-foundation/Aida/tracer/operation"
 	"github.com/Fantom-foundation/Aida/utils"
 	"github.com/Fantom-foundation/go-opera/evmcore"
@@ -26,55 +25,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const MaxErrorCount = 50
-
-var errCount int
-
-// runVMCommand data structure for the record app
-var RunVMCommand = cli.Command{
-	Action:    runVM,
-	Name:      "run-vm",
-	Usage:     "run VM on the world-state",
-	ArgsUsage: "<blockNumFirst> <blockNumLast>",
-	Flags: []cli.Flag{
-		&utils.ArchiveModeFlag,
-		&utils.ChainIDFlag,
-		&utils.ContinueOnFailureFlag,
-		&utils.CpuProfileFlag,
-		&utils.DeletedAccountDirFlag,
-		&utils.DisableProgressFlag,
-		&utils.EpochLengthFlag,
-		&utils.KeepStateDBFlag,
-		&utils.MaxNumTransactionsFlag,
-		&utils.MemoryBreakdownFlag,
-		&utils.MemProfileFlag,
-		&utils.PrimeSeedFlag,
-		&utils.PrimeThresholdFlag,
-		&utils.ProfileFlag,
-		&utils.RandomizePrimingFlag,
-		&utils.SkipPrimingFlag,
-		&utils.StateDbImplementationFlag,
-		&utils.StateDbVariantFlag,
-		&utils.StateDbSrcDirFlag,
-		&utils.StateDbTempDirFlag,
-		&utils.StateDbLoggingFlag,
-		&utils.ShadowDbImplementationFlag,
-		&utils.ShadowDbVariantFlag,
-		&substate.WorkersFlag,
-		&substate.SubstateDirFlag,
-		&utils.UpdateDBDirFlag,
-		&utils.ValidateTxStateFlag,
-		&utils.ValidateWorldStateFlag,
-		&utils.ValidateFlag,
-		&utils.VmImplementation,
-	},
-	Description: `
-The trace run-vm command requires two arguments:
-<blockNumFirst> <blockNumLast>
-
-<blockNumFirst> and <blockNumLast> are the first and
-last block of the inclusive range of blocks to trace transactions.`,
-}
+const MaxErrorCount = 50 // maximum number of errors before terminating program
+var errCount int         // number of errors encountered
 
 // runVMTask executes VM on a chosen storage system.
 func runVMTask(db state.StateDB, cfg *utils.Config, block uint64, tx int, recording *substate.Substate) (*substate.SubstateResult, error) {
@@ -223,8 +175,8 @@ func runVMTask(db state.StateDB, cfg *utils.Config, block uint64, tx int, record
 	return evmResult, nil
 }
 
-// runVM implements trace command for executing VM on a chosen storage system.
-func runVM(ctx *cli.Context) error {
+// RunVM implements trace command for executing VM on a chosen storage system.
+func RunVM(ctx *cli.Context) error {
 	const progressReportBlockInterval uint64 = 100_000
 	var (
 		err          error
@@ -318,7 +270,7 @@ func runVM(ctx *cli.Context) error {
 	// wrap stateDB for profiling
 	var stats *operation.ProfileStats
 	if cfg.Profile {
-		db, stats = tracer.NewProxyProfiler(db)
+		db, stats = NewProxyProfiler(db)
 	}
 
 	if cfg.ValidateWorldState {

--- a/cmd/trace-cli/main.go
+++ b/cmd/trace-cli/main.go
@@ -18,7 +18,6 @@ func initTraceApp() *cli.App {
 		Flags:     []cli.Flag{},
 		Commands: []*cli.Command{
 			&trace.GenUpdateSetCommand,
-			&trace.RunVMCommand,
 			&trace.TraceCompareLogCommand,
 			&trace.TraceRecordCommand,
 			&trace.TraceReplayCommand,

--- a/cmd/trace-cli/trace/proxy_recorder.go
+++ b/cmd/trace-cli/trace/proxy_recorder.go
@@ -1,4 +1,4 @@
-package tracer
+package trace
 
 import (
 	"math/big"

--- a/cmd/trace-cli/trace/record.go
+++ b/cmd/trace-cli/trace/record.go
@@ -84,7 +84,7 @@ func traceRecordTask(block uint64, tx, chainID int, recording *substate.Substate
 
 	var statedb state.StateDB
 	statedb = state.MakeInMemoryStateDB(&inputAlloc)
-	statedb = tracer.NewProxyRecorder(statedb, dCtx, ch, utils.TraceDebug)
+	statedb = NewProxyRecorder(statedb, dCtx, ch, utils.TraceDebug)
 
 	// Apply Message
 	var (

--- a/scripts/run_operation_statistics_eval.rb
+++ b/scripts/run_operation_statistics_eval.rb
@@ -66,7 +66,7 @@ puts "OK"
 def runAida (startBlock) 
 
     puts "Running evaluation at block #{startBlock} .."
-    cmd = "./build/trace run-vm --substatedir #{SubstateDir} --updatedir #{UpdateDir} --deleted-account-dir #{DeletedAccountDir} --db-impl memory --vm-impl lfvm --skip-priming --max-transactions #{NumTransactionsPerEval} --profile #{ExtraFlags} #{startBlock} 100000000"
+    cmd = "./build/aida-runvm --substatedir #{SubstateDir} --updatedir #{UpdateDir} --deleted-account-dir #{DeletedAccountDir} --db-impl memory --vm-impl lfvm --skip-priming --max-transactions #{NumTransactionsPerEval} --profile #{ExtraFlags} #{startBlock} 100000000"
 
     puts "Running #{cmd}\n"
     

--- a/scripts/run_throughput_eval.rb
+++ b/scripts/run_throughput_eval.rb
@@ -97,7 +97,7 @@ puts "OK"
 def runAida (iteration, evm, db, variant) 
 
     puts "Running for #{evm} with #{db}/#{variant} .."
-    cmd = "timeout #{MaxDuration} ./build/trace run-vm --substatedir #{SubstateDir} --updatedir #{UpdateDir} --deleted-account-dir #{DeletedAccountDir} --db-impl #{db} --db-variant \"#{variant}\" --vm-impl #{evm} --cpuprofile=#{PROFILE_FILE_PREFIX}_profile_#{evm}_#{db}_#{variant}_#{StartBlock}_#{EndBlock}_#{iteration}.dat #{ExtraFlags} #{StartBlock} #{EndBlock}"
+    cmd = "timeout #{MaxDuration} ./build/aida-runvm --substatedir #{SubstateDir} --updatedir #{UpdateDir} --deleted-account-dir #{DeletedAccountDir} --db-impl #{db} --db-variant \"#{variant}\" --vm-impl #{evm} --cpuprofile=#{PROFILE_FILE_PREFIX}_profile_#{evm}_#{db}_#{variant}_#{StartBlock}_#{EndBlock}_#{iteration}.dat #{ExtraFlags} #{StartBlock} #{EndBlock}"
 
     puts "Running #{cmd}\n"
     


### PR DESCRIPTION
New command names:
 - `trace record` -> `aida-trace record`
 - `trace replay` -> `aida-trace replay`
 - `trace run-vm` -> `aida-runvm`