### PR TITLE
Fix stationary distribution computation

### DIFF
--- a/stochastic/estimation.go
+++ b/stochastic/estimation.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	approxEps       = 1e-9   // epsilon for terminating the bi-section for finding minimal LSE
+	estimationEps   = 1e-9   // epsilon for bi-section,  and stationary distribution
 	approxMaxSteps  = 10000  // maximum number of iterations for finding minimal LSE
 	approxInfLambda = 1.0    // lower bound for searching minimal LSE
 	approxSupLambda = 1000.0 // upper bound for searching minimal LSE
@@ -111,7 +111,7 @@ func ApproximateLambda(points [][2]float64) (float64, error) {
 		} else {
 			left = mid
 		}
-		if math.Abs(right-left) < approxEps {
+		if math.Abs(right-left) < estimationEps {
 			return mid, nil
 		}
 	}
@@ -130,9 +130,9 @@ func PiecewiseLinearCdf(lambda float64, n int) [][2]float64 {
 	return fn
 }
 
-// SteadyStateDistribution computes the steady-state for a stochastic matrix.
-func SteadyStateDistribution(M [][]float64) []float64 {
-	// compute eigen-value/vector of stochastic matrix
+// StationaryDistribution computes the stationary distribution for a stochastic matrix.
+func StationaryDistribution(M [][]float64) ([]float64, error) {
+	// flatten matrix for gonum package
 	n := len(M)
 	elements := []float64{}
 	for i := 0; i < n; i++ {
@@ -141,22 +141,44 @@ func SteadyStateDistribution(M [][]float64) []float64 {
 		}
 	}
 	a := mat.NewDense(n, n, elements)
+
+	// perform eigenvalue decomposition
 	var eig mat.Eigen
 	ok := eig.Factorize(a, mat.EigenLeft)
 	if !ok {
-		log.Fatal("eigen-decomposition failed")
+		return nil, fmt.Errorf("eigen-value decomposition failed")
 	}
+
+	// find index for eigenvalue of one
+	// (note that it is not necessarily the first index)
+	v := eig.Values(nil)
+	k := -1
+	for i, eigenValue := range v {
+		if math.Abs(real(eigenValue)-1.0) < estimationEps && math.Abs(imag(eigenValue)) < estimationEps {
+			k = i
+		}
+	}
+	if k == -1 {
+		return nil, fmt.Errorf("eigen-decomposition failed; no eigenvalue of one found")
+	}
+
+	// find left eigenvectors of decomposition
 	var ev mat.CDense
 	eig.LeftVectorsTo(&ev)
-	// compute total of the first left eigenvector
-	total := float64(0)
+
+	// compute total for eigenvector with eigenvalue of one.
+	total := complex128(0)
 	for i := 0; i < n; i++ {
-		total += math.Abs(real(ev.At(i, 0)))
+		total += ev.At(i, k)
 	}
-	// steady state is the normalized, first left eigenvector
-	steadyState := []float64{}
+	if imag(total) > estimationEps {
+		return nil, fmt.Errorf("eigen-decomposition failed; eigen-vector is a complex number")
+	}
+
+	// normalize eigenvector by total
+	stationary := []float64{}
 	for i := 0; i < n; i++ {
-		steadyState = append(steadyState, math.Abs(real(ev.At(i, 0)))/total)
+		stationary = append(stationary, math.Abs(real(ev.At(i, k))/real(total)))
 	}
-	return steadyState
+	return stationary, nil
 }

--- a/stochastic/estimation_test.go
+++ b/stochastic/estimation_test.go
@@ -1,0 +1,61 @@
+package stochastic
+
+import (
+	"math"
+	"testing"
+)
+
+// TestEstimation checks the correcntness of approximating
+// a lambda for a discrete CDF.
+func TestEstimation(t *testing.T) {
+	for l := 2; l < 900; l += 5 {
+		checkEstimation(t, float64(l))
+	}
+}
+
+// checkEstimation checks whether the approximate lambda can be
+// rediscovered from a discretized CDF.
+func checkEstimation(t *testing.T, expectedLambda float64) {
+	Cdf := PiecewiseLinearCdf(expectedLambda, 100)
+	computedLambda, err := ApproximateLambda(Cdf)
+	if err != nil {
+		t.Fatalf("Failed to approximate. Error: %v", err)
+	}
+	if math.Abs(expectedLambda-computedLambda) > estimationEps {
+		t.Fatalf("Failed to approximate. Expected Lambda:%v Computed Lambda: %v", expectedLambda, computedLambda)
+	}
+}
+
+// checkStationaryDistribution tests stationary distribution of a uniform Markovian process
+// whose transition probability is 1/n for n states.
+func checkStationaryDistribution(t *testing.T, n int) {
+	A := make([][]float64, n)
+	for i := 0; i < n; i++ {
+		A[i] = make([]float64, n)
+		for j := 0; j < n; j++ {
+			A[i][j] = 1.0 / float64(n)
+		}
+	}
+	eps := 1e-3
+	dist, err := StationaryDistribution(A)
+	if err != nil {
+		t.Fatalf("Failed to compute stationary distribution. Error: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		if dist[i] < 0.0 || dist[i] > 1.0 {
+			t.Fatalf("Not a probability in distribution.")
+		}
+		if math.Abs(dist[i]-1.0/float64(n)) > eps {
+			t.Fatalf("Failed to compute sufficiently precise stationary distribution.")
+		}
+	}
+}
+
+// TestStationaryDistribution of a Markov Chain
+// TestEstimation checks the correcntness of approximating
+// a lambda for a discrete CDF.
+func TestStationaryDistribution(t *testing.T) {
+	for n := 2; n < 10; n++ {
+		checkStationaryDistribution(t, n)
+	}
+}

--- a/stochastic/gen_data.go
+++ b/stochastic/gen_data.go
@@ -11,7 +11,7 @@ type EventData struct {
 	Keys      AccessData // storage-key view model
 	Values    AccessData // storage-value view model
 
-	SteadyState      []OpData    // steady-state model
+	Stationary       []OpData    // stationary distribution model
 	OperationLabel   []string    // operation labels for stochastic matrix
 	StochasticMatrix [][]float64 // stochastic Matrix
 }
@@ -50,20 +50,20 @@ func (e *EventData) PopulateEventData(d *EventRegistryJSON) {
 	// populate access stats for storage values
 	e.Values.PopulateAccessStats(&d.Values)
 
-	// Sort entries of the steady and populate
+	// Sort entries of the stationary distribution and populate
 	n := len(d.Operations)
-	steadyState := SteadyStateDistribution(d.StochasticMatrix)
+	stationary, _ := StationaryDistribution(d.StochasticMatrix)
 	data := []OpData{}
 	for i := 0; i < n; i++ {
 		data = append(data, OpData{
 			label: d.Operations[i],
-			p:     steadyState[i],
+			p:     stationary[i],
 		})
 	}
 	sort.Slice(data, func(i, j int) bool {
 		return data[i].p < data[j].p
 	})
-	e.SteadyState = data
+	e.Stationary = data
 
 	// Populate stochastic matrix
 	e.OperationLabel = make([]string, len(d.Operations))

--- a/stochastic/visualize_data.go
+++ b/stochastic/visualize_data.go
@@ -142,7 +142,7 @@ func renderQueuingStats(w http.ResponseWriter, r *http.Request) {
 	scatter.Render(w)
 }
 
-// convertOperationData produces the data series for the steady-state.
+// convertOperationData produces the data series for the sationary distribution.
 func convertOperationData(data []OpData) []opts.BarData {
 	items := []opts.BarData{}
 	for i := 0; i < len(data); i++ {
@@ -160,7 +160,7 @@ func convertOperationLabel(data []OpData) []string {
 	return items
 }
 
-// renderOperationStats renders the steady-state distribution.
+// renderOperationStats renders the stationary distribution.
 func renderOperationStats(w http.ResponseWriter, r *http.Request) {
 	events := GetEventsData()
 	bar := charts.NewBar()
@@ -185,7 +185,7 @@ func renderOperationStats(w http.ResponseWriter, r *http.Request) {
 		charts.WithTitleOpts(opts.Title{
 			Title: "StateDB Operations",
 		}))
-	bar.SetXAxis(convertOperationLabel(events.SteadyState)).AddSeries("Steady-State Distribution", convertOperationData(events.SteadyState))
+	bar.SetXAxis(convertOperationLabel(events.Stationary)).AddSeries("Stationary Distribution", convertOperationData(events.Stationary))
 	bar.XYReversal()
 	bar.Render(w)
 }


### PR DESCRIPTION
This PR fixes the stationary distribution (aka. steady-state). There was the underlying assumption that the eigenvalue of one is always the first index. This assumption was wrong, and the eigenvalue of one must be searched in the vector of eigenvalues. When found, the associated left-eigenvector needs to be normalized and returned as stationary distribution.

This PR also renames the distribution to the common name stationary distribution.

A test-case for approximating lambda was added as well that tests whether a discretized CDF reveals the same lambda again by approximating it.