### PR TITLE
Register Scoping-Events

### DIFF
--- a/stochastic/event_proxy.go
+++ b/stochastic/event_proxy.go
@@ -25,7 +25,7 @@ func NewEventProxy(db state.StateDB, registry *EventRegistry) *EventProxy {
 // CreateAccount creates a new account.
 func (p *EventProxy) CreateAccount(address common.Address) {
 	// register event
-	p.registry.RegisterAddressOp(createAccountID, &address)
+	p.registry.RegisterAddressOp(CreateAccountID, &address)
 
 	// call real StateDB
 	p.db.CreateAccount(address)
@@ -34,7 +34,7 @@ func (p *EventProxy) CreateAccount(address common.Address) {
 // SubBalance subtracts amount from a contract address.
 func (p *EventProxy) SubBalance(address common.Address, amount *big.Int) {
 	// register event
-	p.registry.RegisterAddressOp(subBalanceID, &address)
+	p.registry.RegisterAddressOp(SubBalanceID, &address)
 
 	// call real StateDB
 	p.db.SubBalance(address, amount)
@@ -43,7 +43,7 @@ func (p *EventProxy) SubBalance(address common.Address, amount *big.Int) {
 // AddBalance adds amount to a contract address.
 func (p *EventProxy) AddBalance(address common.Address, amount *big.Int) {
 	// register event
-	p.registry.RegisterAddressOp(addBalanceID, &address)
+	p.registry.RegisterAddressOp(AddBalanceID, &address)
 
 	// call real StateDB
 	p.db.AddBalance(address, amount)
@@ -52,7 +52,7 @@ func (p *EventProxy) AddBalance(address common.Address, amount *big.Int) {
 // GetBalance retrieves the amount of a contract address.
 func (p *EventProxy) GetBalance(address common.Address) *big.Int {
 	// register event
-	p.registry.RegisterAddressOp(getBalanceID, &address)
+	p.registry.RegisterAddressOp(GetBalanceID, &address)
 
 	// call real StateDB
 	return p.db.GetBalance(address)
@@ -61,7 +61,7 @@ func (p *EventProxy) GetBalance(address common.Address) *big.Int {
 // GetNonce retrieves the nonce of a contract address.
 func (p *EventProxy) GetNonce(address common.Address) uint64 {
 	// register event
-	p.registry.RegisterAddressOp(getNonceID, &address)
+	p.registry.RegisterAddressOp(GetNonceID, &address)
 
 	// call real StateDB
 	return p.db.GetNonce(address)
@@ -70,7 +70,7 @@ func (p *EventProxy) GetNonce(address common.Address) uint64 {
 // SetNonce sets the nonce of a contract address.
 func (p *EventProxy) SetNonce(address common.Address, nonce uint64) {
 	// register event
-	p.registry.RegisterAddressOp(setNonceID, &address)
+	p.registry.RegisterAddressOp(SetNonceID, &address)
 
 	// call real StateDB
 	p.db.SetNonce(address, nonce)
@@ -79,7 +79,7 @@ func (p *EventProxy) SetNonce(address common.Address, nonce uint64) {
 // GetCodeHash returns the hash of the EVM bytecode.
 func (p *EventProxy) GetCodeHash(address common.Address) common.Hash {
 	// register event
-	p.registry.RegisterAddressOp(getCodeHashID, &address)
+	p.registry.RegisterAddressOp(GetCodeHashID, &address)
 
 	// call real StateDB
 	return p.db.GetCodeHash(address)
@@ -88,7 +88,7 @@ func (p *EventProxy) GetCodeHash(address common.Address) common.Hash {
 // GetCode returns the EVM bytecode of a contract.
 func (p *EventProxy) GetCode(address common.Address) []byte {
 	// register event
-	p.registry.RegisterAddressOp(getCodeID, &address)
+	p.registry.RegisterAddressOp(GetCodeID, &address)
 
 	// call real StateDB
 	return p.db.GetCode(address)
@@ -97,7 +97,7 @@ func (p *EventProxy) GetCode(address common.Address) []byte {
 // Setcode sets the EVM bytecode of a contract.
 func (p *EventProxy) SetCode(address common.Address, code []byte) {
 	// register event
-	p.registry.RegisterAddressOp(setCodeID, &address)
+	p.registry.RegisterAddressOp(SetCodeID, &address)
 
 	// call real StateDB
 	p.db.SetCode(address, code)
@@ -106,7 +106,7 @@ func (p *EventProxy) SetCode(address common.Address, code []byte) {
 // GetCodeSize returns the EVM bytecode's size.
 func (p *EventProxy) GetCodeSize(address common.Address) int {
 	// register event
-	p.registry.RegisterAddressOp(getCodeSizeID, &address)
+	p.registry.RegisterAddressOp(GetCodeSizeID, &address)
 
 	// call real StateDB
 	return p.db.GetCodeSize(address)
@@ -133,7 +133,7 @@ func (p *EventProxy) GetRefund() uint64 {
 // GetCommittedState retrieves a value that is already committed.
 func (p *EventProxy) GetCommittedState(address common.Address, key common.Hash) common.Hash {
 	// register event
-	p.registry.RegisterKeyOp(getCommittedStateID, &address, &key)
+	p.registry.RegisterKeyOp(GetCommittedStateID, &address, &key)
 
 	// call real StateDB
 	return p.db.GetCommittedState(address, key)
@@ -142,7 +142,7 @@ func (p *EventProxy) GetCommittedState(address common.Address, key common.Hash) 
 // GetState retrieves a value from the StateDB.
 func (p *EventProxy) GetState(address common.Address, key common.Hash) common.Hash {
 	// register event
-	p.registry.RegisterKeyOp(getStateID, &address, &key)
+	p.registry.RegisterKeyOp(GetStateID, &address, &key)
 
 	// call real StateDB
 	return p.db.GetState(address, key)
@@ -151,7 +151,7 @@ func (p *EventProxy) GetState(address common.Address, key common.Hash) common.Ha
 // SetState sets a value in the StateDB.
 func (p *EventProxy) SetState(address common.Address, key common.Hash, value common.Hash) {
 	// register event
-	p.registry.RegisterValueOp(setStateID, &address, &key, &value)
+	p.registry.RegisterValueOp(SetStateID, &address, &key, &value)
 
 	// call real StateDB
 	p.db.SetState(address, key, value)
@@ -160,7 +160,7 @@ func (p *EventProxy) SetState(address common.Address, key common.Hash, value com
 // Suicide an account.
 func (p *EventProxy) Suicide(address common.Address) bool {
 	// register event
-	p.registry.RegisterAddressOp(suicideID, &address)
+	p.registry.RegisterAddressOp(SuicideID, &address)
 
 	// call real StateDB
 	return p.db.Suicide(address)
@@ -169,7 +169,7 @@ func (p *EventProxy) Suicide(address common.Address) bool {
 // HasSuicided checks whether a contract has been suicided.
 func (p *EventProxy) HasSuicided(address common.Address) bool {
 	// register event
-	p.registry.RegisterAddressOp(hasSuicidedID, &address)
+	p.registry.RegisterAddressOp(HasSuicidedID, &address)
 
 	// call real StateDB
 	return p.db.HasSuicided(address)
@@ -178,7 +178,7 @@ func (p *EventProxy) HasSuicided(address common.Address) bool {
 // Exist checks whether the contract exists in the StateDB.
 func (p *EventProxy) Exist(address common.Address) bool {
 	// register event
-	p.registry.RegisterAddressOp(existID, &address)
+	p.registry.RegisterAddressOp(ExistID, &address)
 
 	// call real StateDB
 	return p.db.Exist(address)
@@ -188,7 +188,7 @@ func (p *EventProxy) Exist(address common.Address) bool {
 // or empty according to the EIP161 specification (balance = nonce = code = 0).
 func (p *EventProxy) Empty(address common.Address) bool {
 	// register event
-	p.registry.RegisterAddressOp(emptyID, &address)
+	p.registry.RegisterAddressOp(EmptyID, &address)
 
 	// call real StateDB
 	return p.db.Empty(address)
@@ -227,7 +227,7 @@ func (p *EventProxy) AddSlotToAccessList(address common.Address, slot common.Has
 // RevertToSnapshot reverts all state changes from a given revision.
 func (p *EventProxy) RevertToSnapshot(snapshot int) {
 	// register event
-	p.registry.RegisterOp(revertToSnapshotID)
+	p.registry.RegisterOp(RevertToSnapshotID)
 
 	// call real StateDB
 	p.db.RevertToSnapshot(snapshot)
@@ -236,7 +236,7 @@ func (p *EventProxy) RevertToSnapshot(snapshot int) {
 // Snapshot returns an identifier for the current revision of the state.
 func (p *EventProxy) Snapshot() int {
 	// register event
-	p.registry.RegisterOp(snapshotID)
+	p.registry.RegisterOp(SnapshotID)
 
 	// call real StateDB
 	return p.db.Snapshot()
@@ -275,7 +275,7 @@ func (p *EventProxy) Prepare(thash common.Hash, ti int) {
 // Finalise the state in StateDB.
 func (p *EventProxy) Finalise(deleteEmptyObjects bool) {
 	// register event
-	p.registry.RegisterOp(finaliseID)
+	p.registry.RegisterOp(FinaliseID)
 
 	// call real StateDB
 	p.db.Finalise(deleteEmptyObjects)

--- a/stochastic/event_registry_test.go
+++ b/stochastic/event_registry_test.go
@@ -24,7 +24,7 @@ func TestEventRegistryUpdateFreq(t *testing.T) {
 	}
 
 	// inject first operation
-	op := createAccountID
+	op := CreateAccountID
 	addr := randomValueID
 	key := noArgID
 	value := noArgID
@@ -47,7 +47,7 @@ func TestEventRegistryUpdateFreq(t *testing.T) {
 	}
 
 	// inject second operation
-	op = setStateID
+	op = SetStateID
 	addr = randomValueID
 	key = previousValueID
 	value = zeroValueID
@@ -106,8 +106,8 @@ func TestEventRegistryOperation(t *testing.T) {
 
 	// inject first operation and check frequencies.
 	addr := common.HexToAddress("0x000000010")
-	r.RegisterAddressOp(createAccountID, &addr)
-	argop1 := EncodeArgOp(createAccountID, newValueID, noArgID, noArgID)
+	r.RegisterAddressOp(CreateAccountID, &addr)
+	argop1 := EncodeArgOp(CreateAccountID, newValueID, noArgID, noArgID)
 	opFreq[argop1]++
 	if !checkFrequencies(&r, opFreq, transitFreq) {
 		t.Fatalf("operation/transit frequency diverges")
@@ -115,8 +115,8 @@ func TestEventRegistryOperation(t *testing.T) {
 
 	// inject second operation and check frequencies.
 	key := common.HexToHash("0x000000200")
-	r.RegisterKeyOp(getStateID, &addr, &key)
-	argop2 := EncodeArgOp(getStateID, previousValueID, newValueID, noArgID)
+	r.RegisterKeyOp(GetStateID, &addr, &key)
+	argop2 := EncodeArgOp(GetStateID, previousValueID, newValueID, noArgID)
 	opFreq[argop2]++
 	transitFreq[argop1][argop2]++
 	if !checkFrequencies(&r, opFreq, transitFreq) {
@@ -125,8 +125,8 @@ func TestEventRegistryOperation(t *testing.T) {
 
 	// inject third operation and check frequencies.
 	value := common.Hash{}
-	r.RegisterValueOp(setStateID, &addr, &key, &value)
-	argop3 := EncodeArgOp(setStateID, previousValueID, previousValueID, zeroValueID)
+	r.RegisterValueOp(SetStateID, &addr, &key, &value)
+	argop3 := EncodeArgOp(SetStateID, previousValueID, previousValueID, zeroValueID)
 	opFreq[argop3]++
 	transitFreq[argop2][argop3]++
 	if !checkFrequencies(&r, opFreq, transitFreq) {
@@ -134,8 +134,8 @@ func TestEventRegistryOperation(t *testing.T) {
 	}
 
 	// inject forth operation and check frequencies.
-	r.RegisterOp(snapshotID)
-	argop4 := EncodeArgOp(snapshotID, noArgID, noArgID, noArgID)
+	r.RegisterOp(SnapshotID)
+	argop4 := EncodeArgOp(SnapshotID, noArgID, noArgID, noArgID)
 	opFreq[argop4]++
 	transitFreq[argop3][argop4]++
 	if !checkFrequencies(&r, opFreq, transitFreq) {
@@ -163,8 +163,8 @@ func TestEventRegistryZeroOperation(t *testing.T) {
 	addr := common.Address{}
 	key := common.Hash{}
 	value := common.Hash{}
-	r.RegisterValueOp(setStateID, &addr, &key, &value)
-	argop1 := EncodeArgOp(setStateID, zeroValueID, zeroValueID, zeroValueID)
+	r.RegisterValueOp(SetStateID, &addr, &key, &value)
+	argop1 := EncodeArgOp(SetStateID, zeroValueID, zeroValueID, zeroValueID)
 	opFreq[argop1]++
 	if !checkFrequencies(&r, opFreq, transitFreq) {
 		t.Fatalf("operation/transit frequency diverges")
@@ -174,8 +174,8 @@ func TestEventRegistryZeroOperation(t *testing.T) {
 	addr = common.HexToAddress("0x12312121212")
 	key = common.HexToHash("0x232313123123213")
 	value = common.HexToHash("0x2301238021830912830")
-	r.RegisterValueOp(setStateID, &addr, &key, &value)
-	argop2 := EncodeArgOp(setStateID, newValueID, newValueID, newValueID)
+	r.RegisterValueOp(SetStateID, &addr, &key, &value)
+	argop2 := EncodeArgOp(SetStateID, newValueID, newValueID, newValueID)
 	opFreq[argop2]++
 	transitFreq[argop1][argop2]++
 	if !checkFrequencies(&r, opFreq, transitFreq) {
@@ -183,8 +183,8 @@ func TestEventRegistryZeroOperation(t *testing.T) {
 	}
 
 	// inject third operation and check frequencies.
-	r.RegisterValueOp(setStateID, &addr, &key, &value)
-	argop3 := EncodeArgOp(setStateID, previousValueID, previousValueID, previousValueID)
+	r.RegisterValueOp(SetStateID, &addr, &key, &value)
+	argop3 := EncodeArgOp(SetStateID, previousValueID, previousValueID, previousValueID)
 	opFreq[argop3]++
 	transitFreq[argop2][argop3]++
 	if !checkFrequencies(&r, opFreq, transitFreq) {

--- a/stochastic/operation.go
+++ b/stochastic/operation.go
@@ -7,26 +7,32 @@ import (
 
 // IDs of StateDB Operations
 const (
-	addBalanceID = iota
-	createAccountID
-	emptyID
-	existID
-	finaliseID
-	getBalanceID
-	getCodeHashID
-	getCodeID
-	getCodeSizeID
-	getCommittedStateID
-	getNonceID
-	getStateID
-	hasSuicidedID
-	revertToSnapshotID
-	setCodeID
-	setNonceID
-	setStateID
-	snapshotID
-	subBalanceID
-	suicideID
+	AddBalanceID = iota
+	BeginBlockID
+	BeginEpochID
+	BeginTransactionID
+	CreateAccountID
+	EmptyID
+	EndBlockID
+	EndEpochID
+	EndTransactionID
+	ExistID
+	FinaliseID
+	GetBalanceID
+	GetCodeHashID
+	GetCodeID
+	GetCodeSizeID
+	GetCommittedStateID
+	GetNonceID
+	GetStateID
+	HasSuicidedID
+	RevertToSnapshotID
+	SetCodeID
+	SetNonceID
+	SetStateID
+	SnapshotID
+	SubBalanceID
+	SuicideID
 
 	numOps
 )
@@ -45,74 +51,92 @@ const (
 
 // opMnemo is a mnemonics table for operations.
 var opMnemo = map[int]string{
-	addBalanceID:        "AB",
-	createAccountID:     "CA",
-	emptyID:             "EM",
-	existID:             "EX",
-	finaliseID:          "FI",
-	getBalanceID:        "GB",
-	getCodeHashID:       "GH",
-	getCodeID:           "GC",
-	getCodeSizeID:       "GZ",
-	getCommittedStateID: "GM",
-	getNonceID:          "GN",
-	getStateID:          "GS",
-	hasSuicidedID:       "HS",
-	revertToSnapshotID:  "RS",
-	setCodeID:           "SC",
-	setNonceID:          "SO",
-	snapshotID:          "SN",
-	subBalanceID:        "SB",
-	setStateID:          "SS",
-	suicideID:           "SU",
+	AddBalanceID:        "AB",
+	BeginBlockID:        "BB",
+	BeginEpochID:        "BE",
+	BeginTransactionID:  "BT",
+	CreateAccountID:     "CA",
+	EmptyID:             "EM",
+	EndBlockID:          "EB",
+	EndEpochID:          "EE",
+	EndTransactionID:    "ET",
+	ExistID:             "EX",
+	FinaliseID:          "FI",
+	GetBalanceID:        "GB",
+	GetCodeHashID:       "GH",
+	GetCodeID:           "GC",
+	GetCodeSizeID:       "GZ",
+	GetCommittedStateID: "GM",
+	GetNonceID:          "GN",
+	GetStateID:          "GS",
+	HasSuicidedID:       "HS",
+	RevertToSnapshotID:  "RS",
+	SetCodeID:           "SC",
+	SetNonceID:          "SO",
+	SetStateID:          "SS",
+	SnapshotID:          "SN",
+	SubBalanceID:        "SB",
+	SuicideID:           "SU",
 }
 
 // opNumArgs is an argument number table for operations.
 var opNumArgs = map[int]int{
-	addBalanceID:        1,
-	createAccountID:     1,
-	emptyID:             1,
-	existID:             1,
-	finaliseID:          0,
-	getBalanceID:        1,
-	getCodeHashID:       1,
-	getCodeID:           1,
-	getCodeSizeID:       1,
-	getCommittedStateID: 2,
-	getNonceID:          1,
-	getStateID:          2,
-	hasSuicidedID:       1,
-	revertToSnapshotID:  0,
-	setCodeID:           1,
-	setNonceID:          1,
-	snapshotID:          0,
-	subBalanceID:        1,
-	setStateID:          3,
-	suicideID:           1,
+	AddBalanceID:        1,
+	BeginBlockID:        0,
+	BeginEpochID:        0,
+	BeginTransactionID:  0,
+	CreateAccountID:     1,
+	EmptyID:             1,
+	EndBlockID:          0,
+	EndEpochID:          0,
+	EndTransactionID:    0,
+	ExistID:             1,
+	FinaliseID:          0,
+	GetBalanceID:        1,
+	GetCodeHashID:       1,
+	GetCodeID:           1,
+	GetCodeSizeID:       1,
+	GetCommittedStateID: 2,
+	GetNonceID:          1,
+	GetStateID:          2,
+	HasSuicidedID:       1,
+	RevertToSnapshotID:  0,
+	SetCodeID:           1,
+	SetNonceID:          1,
+	SetStateID:          3,
+	SnapshotID:          0,
+	SubBalanceID:        1,
+	SuicideID:           1,
 }
 
 // opId is an operation ID table.
 var opId = map[string]int{
-	"AB": addBalanceID,
-	"CA": createAccountID,
-	"EM": emptyID,
-	"EX": existID,
-	"FI": finaliseID,
-	"GB": getBalanceID,
-	"GH": getCodeHashID,
-	"GC": getCodeID,
-	"GZ": getCodeSizeID,
-	"GM": getCommittedStateID,
-	"GN": getNonceID,
-	"GS": getStateID,
-	"HS": hasSuicidedID,
-	"RS": revertToSnapshotID,
-	"SC": setCodeID,
-	"SO": setNonceID,
-	"SN": snapshotID,
-	"SB": subBalanceID,
-	"SS": setStateID,
-	"SU": suicideID,
+	"AB": AddBalanceID,
+	"BB": BeginBlockID,
+	"BE": BeginEpochID,
+	"BT": BeginTransactionID,
+	"CA": CreateAccountID,
+	"EM": EmptyID,
+	"EB": EndBlockID,
+	"EE": EndEpochID,
+	"ET": EndTransactionID,
+	"EX": ExistID,
+	"FI": FinaliseID,
+	"GB": GetBalanceID,
+	"GH": GetCodeHashID,
+	"GC": GetCodeID,
+	"GZ": GetCodeSizeID,
+	"GM": GetCommittedStateID,
+	"GN": GetNonceID,
+	"GS": GetStateID,
+	"HS": HasSuicidedID,
+	"RS": RevertToSnapshotID,
+	"SC": SetCodeID,
+	"SO": SetNonceID,
+	"SN": SnapshotID,
+	"SB": SubBalanceID,
+	"SS": SetStateID,
+	"SU": SuicideID,
 }
 
 // argMnemo is the argument-class mnemonics table.


### PR DESCRIPTION
This PR adds code so that scoping events such as Begin/End Epoch, Begin/End Block, and Begin/End Transaction are recorded.

These events are necessary for issuing the proper StateDB operations for the simulator. 

For the blocks from 5000000 to 5000100, the scoping events are shown in the following fragment:
![MarkovChain](https://user-images.githubusercontent.com/14209113/218469594-4b0c86b1-5b8e-42b2-8a4d-ad1ac6ba898c.png)
