### PR TITLE
Refactor Tx processing function

### DIFF
--- a/cmd/runarchive-cli/runarchive/runarchive.go
+++ b/cmd/runarchive-cli/runarchive/runarchive.go
@@ -8,7 +8,6 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/Fantom-foundation/Aida/cmd/runvm-cli/runvm"
 	"github.com/Fantom-foundation/Aida/state"
 	"github.com/Fantom-foundation/Aida/utils"
 	substate "github.com/Fantom-foundation/Substate"
@@ -28,6 +27,7 @@ func RunArchive(ctx *cli.Context) error {
 
 	// process general arguments
 	cfg, argErr := utils.NewConfig(ctx, utils.BlockRangeArgs)
+	cfg.StateValidationMode = utils.SubsetCheck
 	if argErr != nil {
 		return argErr
 	}
@@ -215,7 +215,7 @@ func runBlocks(
 		state.BeginBlock(block)
 		for _, tx := range transactions {
 			state.BeginTransaction(uint32(tx.Transaction))
-			if _, err = runvm.RunVMTask(state, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
+			if err = utils.ProcessTx(db, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
 				issues <- fmt.Errorf("processing of transaction %d/%d failed: %v", block, tx.Transaction, err)
 				break
 			}

--- a/cmd/runvm-cli/main.go
+++ b/cmd/runvm-cli/main.go
@@ -41,6 +41,7 @@ var RunVMApp = cli.App{
 		&utils.SkipPrimingFlag,
 		&utils.StateDbImplementationFlag,
 		&utils.StateDbVariantFlag,
+		&utils.StateDbSrcDirFlag,
 		&utils.StateDbTempDirFlag,
 		&utils.StateDbLoggingFlag,
 		&utils.ShadowDbImplementationFlag,

--- a/cmd/stochastic-cli/stochastic/record.go
+++ b/cmd/stochastic-cli/stochastic/record.go
@@ -5,24 +5,14 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"math/big"
 	"os"
 	"runtime/pprof"
 	"time"
 
-	"github.com/Fantom-foundation/Aida/cmd/substate-cli/replay"
 	"github.com/Fantom-foundation/Aida/state"
 	"github.com/Fantom-foundation/Aida/stochastic"
 	"github.com/Fantom-foundation/Aida/utils"
 	substate "github.com/Fantom-foundation/Substate"
-	"github.com/Fantom-foundation/go-opera/evmcore"
-	"github.com/Fantom-foundation/go-opera/opera"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/urfave/cli/v2"
 )
 
@@ -49,137 +39,17 @@ The stochastic record command requires two arguments:
 last block for recording events.`,
 }
 
-// stochasticRecordTask generates events for a transaction.
-func stochasticRecordTask(block uint64, tx, chainID int, recording *substate.Substate, eventRegistry *stochastic.EventRegistry) error {
-
-	inputAlloc := recording.InputAlloc
-	inputEnv := recording.Env
-	inputMessage := recording.Message
-
-	outputAlloc := recording.OutputAlloc
-	outputResult := recording.Result
-
-	var (
-		vmConfig    vm.Config
-		chainConfig *params.ChainConfig
-	)
-
-	vmConfig = opera.DefaultVMConfig
-	vmConfig.NoBaseFee = true
-	chainConfig = utils.GetChainConfig(chainID)
-
-	var hashError error
-	getHash := func(num uint64) common.Hash {
-		if inputEnv.BlockHashes == nil {
-			hashError = fmt.Errorf("getHash(%d) invoked, no blockhashes provided", num)
-			return common.Hash{}
-		}
-		h, ok := inputEnv.BlockHashes[num]
-		if !ok {
-			hashError = fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", num)
-		}
-		return h
-	}
-
-	var statedb state.StateDB
-	statedb = state.MakeGethInMemoryStateDB(&inputAlloc, inputEnv.Number)
-	statedb = stochastic.NewEventProxy(statedb, eventRegistry)
-
-	// Apply Message
-	var (
-		gaspool   = new(evmcore.GasPool)
-		blockHash = common.Hash{0x01}
-		txHash    = common.Hash{0x02}
-		txIndex   = tx
-	)
-
-	gaspool.AddGas(inputEnv.GasLimit)
-	blockCtx := vm.BlockContext{
-		CanTransfer: core.CanTransfer,
-		Transfer:    core.Transfer,
-		Coinbase:    inputEnv.Coinbase,
-		BlockNumber: new(big.Int).SetUint64(inputEnv.Number),
-		Time:        new(big.Int).SetUint64(inputEnv.Timestamp),
-		Difficulty:  inputEnv.Difficulty,
-		GasLimit:    inputEnv.GasLimit,
-		GetHash:     getHash,
-	}
-	// If currentBaseFee is defined, add it to the vmContext.
-	if inputEnv.BaseFee != nil {
-		blockCtx.BaseFee = new(big.Int).Set(inputEnv.BaseFee)
-	}
-
-	msg := inputMessage.AsMessage()
-
-	statedb.Prepare(txHash, txIndex)
-
-	txCtx := evmcore.NewEVMTxContext(msg)
-
-	evm := vm.NewEVM(blockCtx, txCtx, statedb, chainConfig, vmConfig)
-
-	snapshot := statedb.Snapshot()
-
-	msgResult, err := evmcore.ApplyMessage(evm, msg, gaspool)
-	if err != nil {
-		statedb.RevertToSnapshot(snapshot)
-		return err
-	}
-	if hashError != nil {
-		return hashError
-	}
-	if chainConfig.IsByzantium(blockCtx.BlockNumber) {
-		statedb.Finalise(true)
-	} else {
-		statedb.IntermediateRoot(chainConfig.IsEIP158(blockCtx.BlockNumber))
-	}
-
-	evmResult := &substate.SubstateResult{}
-	if msgResult.Failed() {
-		evmResult.Status = types.ReceiptStatusFailed
-	} else {
-		evmResult.Status = types.ReceiptStatusSuccessful
-	}
-	evmResult.Logs = statedb.GetLogs(txHash, blockHash)
-	evmResult.Bloom = types.BytesToBloom(types.LogsBloom(evmResult.Logs))
-	if to := msg.To(); to == nil {
-		evmResult.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, msg.Nonce())
-	}
-	evmResult.GasUsed = msgResult.UsedGas
-	evmAlloc := statedb.GetSubstatePostAlloc()
-
-	r := outputResult.Equal(evmResult)
-	a := outputAlloc.Equal(evmAlloc)
-	if !(r && a) {
-		fmt.Printf("Block: %v Transaction: %v\n", block, tx)
-		if !r {
-			fmt.Printf("inconsistent output: result\n")
-			replay.PrintResultDiffSummary(outputResult, evmResult)
-		}
-		if !a {
-			fmt.Printf("inconsistent output: alloc\n")
-			replay.PrintAllocationDiffSummary(&outputAlloc, &evmAlloc)
-		}
-		return fmt.Errorf("inconsistent output")
-	}
-
-	return nil
-}
-
 // stochasticRecordAction implements recording of events.
 func stochasticRecordAction(ctx *cli.Context) error {
 	substate.RecordReplay = true
 	var err error
 
-	if ctx.Args().Len() != 2 {
-		return fmt.Errorf("stochastic record command requires exactly 2 arguments")
+	cfg, err := utils.NewConfig(ctx, utils.BlockRangeArgs)
+	if err != nil {
+		return err
 	}
-
-	// Fetch length of epoch from command line.
-	epochLength := ctx.Uint64(utils.EpochLengthFlag.Name)
-	if epochLength <= 0 {
-		epochLength = 300
-	}
-	log.Printf("Using epoch length of %d blocks\n", epochLength)
+	// force enable tracsaction validation
+	cfg.ValidateTxState = true
 
 	// start CPU profiling if enabled.
 	if profileFileName := ctx.String(utils.CpuProfileFlag.Name); profileFileName != "" {
@@ -191,24 +61,15 @@ func stochasticRecordAction(ctx *cli.Context) error {
 		defer pprof.StopCPUProfile()
 	}
 
-	// get progress flag
-	enableProgress := !ctx.Bool(utils.DisableProgressFlag.Name)
-
-	// process arguments
-	chainID := ctx.Int(utils.ChainIDFlag.Name)
 	if ctx.Bool(utils.TraceDebugFlag.Name) {
 		utils.TraceDebug = true
-	}
-	first, last, argErr := utils.SetBlockRange(ctx.Args().Get(0), ctx.Args().Get(1))
-	if argErr != nil {
-		return argErr
 	}
 
 	// iterate through subsets in sequence
 	substate.SetSubstateFlags(ctx)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
-	iter := substate.NewSubstateIterator(first, ctx.Int(substate.WorkersFlag.Name))
+	iter := substate.NewSubstateIterator(cfg.First, ctx.Int(substate.WorkersFlag.Name))
 	defer iter.Release()
 	oldBlock := uint64(math.MaxUint64) // set to an infeasible block
 	var (
@@ -216,7 +77,7 @@ func stochasticRecordAction(ctx *cli.Context) error {
 		sec     float64
 		lastSec float64
 	)
-	if enableProgress {
+	if cfg.EnableProgress {
 		start = time.Now()
 		sec = time.Since(start).Seconds()
 		lastSec = time.Since(start).Seconds()
@@ -225,7 +86,7 @@ func stochasticRecordAction(ctx *cli.Context) error {
 	// create a new event registry
 	eventRegistry := stochastic.NewEventRegistry()
 
-	curEpoch := first / epochLength
+	curEpoch := cfg.First / cfg.EpochLength
 	eventRegistry.RegisterOp(stochastic.BeginEpochID)
 
 	// iterate over all substates in order
@@ -233,12 +94,12 @@ func stochasticRecordAction(ctx *cli.Context) error {
 		tx := iter.Value()
 		// close off old block with an end-block operation
 		if oldBlock != tx.Block {
-			if tx.Block > last {
+			if tx.Block > cfg.Last {
 				break
 			}
 			if oldBlock != math.MaxUint64 {
 				eventRegistry.RegisterOp(stochastic.EndBlockID)
-				newEpoch := tx.Block / epochLength
+				newEpoch := tx.Block / cfg.EpochLength
 				for curEpoch < newEpoch {
 					eventRegistry.RegisterOp(stochastic.EndEpochID)
 					curEpoch++
@@ -250,9 +111,16 @@ func stochasticRecordAction(ctx *cli.Context) error {
 			oldBlock = tx.Block
 		}
 		eventRegistry.RegisterOp(stochastic.BeginTransactionID)
-		stochasticRecordTask(tx.Block, tx.Transaction, chainID, tx.Substate, &eventRegistry)
+
+		var statedb state.StateDB
+		statedb = state.MakeGethInMemoryStateDB(&tx.Substate.InputAlloc, tx.Block)
+		statedb = stochastic.NewEventProxy(statedb, &eventRegistry)
+		if err := utils.ProcessTx(statedb, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
+			return err
+		}
+
 		eventRegistry.RegisterOp(stochastic.EndTransactionID)
-		if enableProgress {
+		if cfg.EnableProgress {
 			// report progress
 			sec = time.Since(start).Seconds()
 			if sec-lastSec >= 15 {
@@ -267,9 +135,9 @@ func stochasticRecordAction(ctx *cli.Context) error {
 	}
 	eventRegistry.RegisterOp(stochastic.EndEpochID)
 
-	if enableProgress {
+	if cfg.EnableProgress {
 		sec = time.Since(start).Seconds()
-		fmt.Printf("stochastic record: Total elapsed time: %.3f s, processed %v blocks\n", sec, last-first+1)
+		fmt.Printf("stochastic record: Total elapsed time: %.3f s, processed %v blocks\n", sec, cfg.Last-cfg.First+1)
 	}
 
 	// writing event registry

--- a/cmd/substate-cli/replay/gen_deleted_accounts.go
+++ b/cmd/substate-cli/replay/gen_deleted_accounts.go
@@ -203,11 +203,11 @@ func genDeletedAccountsTask(block uint64, tx int, recording *substate.Substate, 
 	if !(r && a) {
 		if !r {
 			fmt.Printf("inconsistent output: result\n")
-			PrintResultDiffSummary(outputResult, evmResult)
+			utils.PrintResultDiffSummary(outputResult, evmResult)
 		}
 		if !a {
 			fmt.Printf("inconsistent output: alloc\n")
-			PrintAllocationDiffSummary(&outputAlloc, &evmAlloc)
+			utils.PrintAllocationDiffSummary(&outputAlloc, &evmAlloc)
 		}
 		return fmt.Errorf("inconsistent output")
 	}

--- a/cmd/substate-cli/replay/replay.go
+++ b/cmd/substate-cli/replay/replay.go
@@ -1,7 +1,6 @@
 package replay
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math/big"
@@ -11,14 +10,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Fantom-foundation/Aida/state"
 	"github.com/Fantom-foundation/Aida/utils"
 	substate "github.com/Fantom-foundation/Substate"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-
-	"github.com/Fantom-foundation/Aida/state"
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/core/vm/lfvm"
@@ -215,123 +213,16 @@ func replayTask(config ReplayConfig, block uint64, tx int, recording *substate.S
 		fmt.Printf("block: %v Transaction: %v\n", block, tx)
 		if !r {
 			fmt.Printf("inconsistent output: result\n")
-			PrintResultDiffSummary(outputResult, evmResult)
+			utils.PrintResultDiffSummary(outputResult, evmResult)
 		}
 		if !a {
 			fmt.Printf("inconsistent output: alloc\n")
-			PrintAllocationDiffSummary(&outputAlloc, &evmAlloc)
+			utils.PrintAllocationDiffSummary(&outputAlloc, &evmAlloc)
 		}
 		return fmt.Errorf("inconsistent output")
 	}
 
 	return nil
-}
-
-func printIfDifferent[T comparable](label string, want, have T) bool {
-	if want != have {
-		fmt.Printf("  Different %s:\n", label)
-		fmt.Printf("    want: %v\n", want)
-		fmt.Printf("    have: %v\n", have)
-		return true
-	}
-	return false
-}
-
-func printIfDifferentBytes(label string, want, have []byte) bool {
-	if !bytes.Equal(want, have) {
-		fmt.Printf("  Different %s:\n", label)
-		fmt.Printf("    want: %v\n", want)
-		fmt.Printf("    have: %v\n", have)
-		return true
-	}
-	return false
-}
-
-func printIfDifferentBigInt(label string, want, have *big.Int) bool {
-	if want == nil && have == nil {
-		return false
-	}
-	if want == nil || have == nil || want.Cmp(have) != 0 {
-		fmt.Printf("  Different %s:\n", label)
-		fmt.Printf("    want: %v\n", want)
-		fmt.Printf("    have: %v\n", have)
-		return true
-	}
-	return false
-}
-
-func PrintResultDiffSummary(want, have *substate.SubstateResult) {
-	printIfDifferent("status", want.Status, have.Status)
-	printIfDifferent("contract address", want.ContractAddress, have.ContractAddress)
-	printIfDifferent("gas usage", want.GasUsed, have.GasUsed)
-	printIfDifferent("log bloom filter", want.Bloom, have.Bloom)
-	if !printIfDifferent("log size", len(want.Logs), len(have.Logs)) {
-		for i := range want.Logs {
-			printLogDiffSummary(fmt.Sprintf("log[%d]", i), want.Logs[i], have.Logs[i])
-		}
-	}
-}
-
-func printLogDiffSummary(label string, want, have *types.Log) {
-	printIfDifferent(fmt.Sprintf("%s.address", label), want.Address, have.Address)
-	if !printIfDifferent(fmt.Sprintf("%s.Topics size", label), len(want.Topics), len(have.Topics)) {
-		for i := range want.Topics {
-			printIfDifferent(fmt.Sprintf("%s.Topics[%d]", label, i), want.Topics[i], have.Topics[i])
-		}
-	}
-	printIfDifferentBytes(fmt.Sprintf("%s.data", label), want.Data, have.Data)
-}
-
-func PrintAllocationDiffSummary(want, have *substate.SubstateAlloc) {
-	printIfDifferent("substate alloc size", len(*want), len(*have))
-	for key := range *want {
-		_, present := (*have)[key]
-		if !present {
-			fmt.Printf("    missing key=%v\n", key)
-		}
-	}
-
-	for key := range *have {
-		_, present := (*want)[key]
-		if !present {
-			fmt.Printf("    extra key=%v\n", key)
-		}
-	}
-
-	for key, is := range *have {
-		should, present := (*want)[key]
-		if present {
-			printAccountDiffSummary(fmt.Sprintf("key=%v:", key), should, is)
-		}
-	}
-}
-
-func printAccountDiffSummary(label string, want, have *substate.SubstateAccount) {
-	printIfDifferent(fmt.Sprintf("%s.Nonce", label), want.Nonce, have.Nonce)
-	printIfDifferentBigInt(fmt.Sprintf("%s.Balance", label), want.Balance, have.Balance)
-	printIfDifferentBytes(fmt.Sprintf("%s.Code", label), want.Code, have.Code)
-
-	printIfDifferent(fmt.Sprintf("len(%s.Storage)", label), len(want.Storage), len(have.Storage))
-	for key := range want.Storage {
-		_, present := have.Storage[key]
-		if !present {
-			fmt.Printf("    %s.Storage misses key %v\n", label, key)
-		}
-	}
-
-	for key := range have.Storage {
-		_, present := want.Storage[key]
-		if !present {
-			fmt.Printf("    %s.Storage has extra key %v\n", label, key)
-		}
-	}
-
-	for key, is := range have.Storage {
-		should, present := want.Storage[key]
-		if present {
-			printIfDifferent(fmt.Sprintf("%s.Storage[%v]", label, key), should, is)
-		}
-	}
 }
 
 // create new execution context for a data collector

--- a/cmd/trace-cli/trace/record.go
+++ b/cmd/trace-cli/trace/record.go
@@ -5,26 +5,17 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"math/big"
 	"os"
 	"runtime/pprof"
 	"time"
 
-	"github.com/Fantom-foundation/Aida/cmd/substate-cli/replay"
 	"github.com/Fantom-foundation/Aida/state"
 	"github.com/Fantom-foundation/Aida/tracer"
 	"github.com/Fantom-foundation/Aida/tracer/dictionary"
 	"github.com/Fantom-foundation/Aida/tracer/operation"
 	"github.com/Fantom-foundation/Aida/utils"
 	substate "github.com/Fantom-foundation/Substate"
-	"github.com/Fantom-foundation/go-opera/evmcore"
-	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/dsnet/compress/bzip2"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli/v2"
 )
 
@@ -54,122 +45,6 @@ The trace record command requires two arguments:
 <blockNumFirst> <blockNumLast>
 <blockNumFirst> and <blockNumLast> are the first and
 last block of the inclusive range of blocks to trace transactions.`,
-}
-
-// traceRecordTask generates storage traces for a transaction.
-func traceRecordTask(block uint64, tx, chainID int, recording *substate.Substate, dCtx *dictionary.Context, ch chan operation.Operation) error {
-
-	inputAlloc := recording.InputAlloc
-	inputEnv := recording.Env
-	inputMessage := recording.Message
-
-	outputAlloc := recording.OutputAlloc
-	outputResult := recording.Result
-
-	var (
-		vmConfig vm.Config
-	)
-
-	vmConfig = opera.DefaultVMConfig
-	vmConfig.NoBaseFee = true
-	chainConfig := utils.GetChainConfig(chainID)
-
-	var hashError error
-	getHash := func(num uint64) common.Hash {
-		if inputEnv.BlockHashes == nil {
-			hashError = fmt.Errorf("getHash(%d) invoked, no blockhashes provided", num)
-			return common.Hash{}
-		}
-		h, ok := inputEnv.BlockHashes[num]
-		if !ok {
-			hashError = fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", num)
-		}
-		return h
-	}
-
-	var statedb state.StateDB
-	statedb = state.MakeGethInMemoryStateDB(&inputAlloc, inputEnv.Number)
-	statedb = NewProxyRecorder(statedb, dCtx, ch, utils.TraceDebug)
-
-	// Apply Message
-	var (
-		gaspool   = new(evmcore.GasPool)
-		blockHash = common.Hash{0x01}
-		txHash    = common.Hash{0x02}
-		txIndex   = tx
-	)
-
-	gaspool.AddGas(inputEnv.GasLimit)
-	blockCtx := vm.BlockContext{
-		CanTransfer: core.CanTransfer,
-		Transfer:    core.Transfer,
-		Coinbase:    inputEnv.Coinbase,
-		BlockNumber: new(big.Int).SetUint64(inputEnv.Number),
-		Time:        new(big.Int).SetUint64(inputEnv.Timestamp),
-		Difficulty:  inputEnv.Difficulty,
-		GasLimit:    inputEnv.GasLimit,
-		GetHash:     getHash,
-	}
-	// If currentBaseFee is defined, add it to the vmContext.
-	if inputEnv.BaseFee != nil {
-		blockCtx.BaseFee = new(big.Int).Set(inputEnv.BaseFee)
-	}
-
-	msg := inputMessage.AsMessage()
-
-	statedb.Prepare(txHash, txIndex)
-
-	txCtx := evmcore.NewEVMTxContext(msg)
-
-	evm := vm.NewEVM(blockCtx, txCtx, statedb, chainConfig, vmConfig)
-
-	snapshot := statedb.Snapshot()
-
-	msgResult, err := evmcore.ApplyMessage(evm, msg, gaspool)
-
-	if err != nil {
-		statedb.RevertToSnapshot(snapshot)
-		return err
-	}
-	if hashError != nil {
-		return hashError
-	}
-	if chainConfig.IsByzantium(blockCtx.BlockNumber) {
-		statedb.Finalise(true)
-	} else {
-		statedb.IntermediateRoot(chainConfig.IsEIP158(blockCtx.BlockNumber))
-	}
-
-	evmResult := &substate.SubstateResult{}
-	if msgResult.Failed() {
-		evmResult.Status = types.ReceiptStatusFailed
-	} else {
-		evmResult.Status = types.ReceiptStatusSuccessful
-	}
-	evmResult.Logs = statedb.GetLogs(txHash, blockHash)
-	evmResult.Bloom = types.BytesToBloom(types.LogsBloom(evmResult.Logs))
-	if to := msg.To(); to == nil {
-		evmResult.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, msg.Nonce())
-	}
-	evmResult.GasUsed = msgResult.UsedGas
-	evmAlloc := statedb.GetSubstatePostAlloc()
-
-	r := outputResult.Equal(evmResult)
-	a := outputAlloc.Equal(evmAlloc)
-	if !(r && a) {
-		fmt.Printf("Block: %v Transaction: %v\n", block, tx)
-		if !r {
-			fmt.Printf("inconsistent output: result\n")
-			replay.PrintResultDiffSummary(outputResult, evmResult)
-		}
-		if !a {
-			fmt.Printf("inconsistent output: alloc\n")
-			replay.PrintAllocationDiffSummary(&outputAlloc, &evmAlloc)
-		}
-		return fmt.Errorf("inconsistent output")
-	}
-
-	return nil
 }
 
 // OperationWriter reads operations from the operation channel and writes
@@ -217,18 +92,13 @@ func sendOperation(dCtx *dictionary.Context, ch chan operation.Operation, op ope
 // traceRecordAction implements trace command for recording.
 func traceRecordAction(ctx *cli.Context) error {
 	substate.RecordReplay = true
-	var err error
 
-	if ctx.Args().Len() != 2 {
-		return fmt.Errorf("trace record command requires exactly 2 arguments")
+	cfg, err := utils.NewConfig(ctx, utils.BlockRangeArgs)
+	if err != nil {
+		return err
 	}
-
-	// Fetch length of epoch from command line.
-	epochLength := ctx.Uint64(utils.EpochLengthFlag.Name)
-	if epochLength <= 0 {
-		epochLength = 300
-	}
-	log.Printf("Using epoch length of %d blocks\n", epochLength)
+	// force enable tracsaction validation
+	cfg.ValidateTxState = true
 
 	// start CPU profiling if enabled.
 	if profileFileName := ctx.String(utils.CpuProfileFlag.Name); profileFileName != "" {
@@ -240,9 +110,6 @@ func traceRecordAction(ctx *cli.Context) error {
 		defer pprof.StopCPUProfile()
 	}
 
-	// get progress flag
-	enableProgress := !ctx.Bool(utils.DisableProgressFlag.Name)
-
 	// create dictionary and index contexts
 	dCtx := dictionary.NewContext()
 
@@ -251,70 +118,68 @@ func traceRecordAction(ctx *cli.Context) error {
 	go OperationWriter(opChannel)
 
 	// process arguments
-	chainID := ctx.Int(utils.ChainIDFlag.Name)
 	tracer.TraceDir = ctx.String(utils.TraceDirectoryFlag.Name) + "/"
 	dictionary.ContextDir = ctx.String(utils.TraceDirectoryFlag.Name) + "/"
 	if ctx.Bool(utils.TraceDebugFlag.Name) {
 		utils.TraceDebug = true
-	}
-	first, last, argErr := utils.SetBlockRange(ctx.Args().Get(0), ctx.Args().Get(1))
-	if argErr != nil {
-		return argErr
 	}
 
 	// iterate through subsets in sequence
 	substate.SetSubstateFlags(ctx)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
-	iter := substate.NewSubstateIterator(first, ctx.Int(substate.WorkersFlag.Name))
+	iter := substate.NewSubstateIterator(cfg.First, cfg.Workers)
 	defer iter.Release()
-	oldBlock := uint64(math.MaxUint64) // set to an infeasible block
+	curBlock := uint64(math.MaxUint64) // set to an infeasible block
 	var (
 		start   time.Time
 		sec     float64
 		lastSec float64
 	)
-	if enableProgress {
+	if cfg.EnableProgress {
 		start = time.Now()
 		sec = time.Since(start).Seconds()
 		lastSec = time.Since(start).Seconds()
 	}
 
-	curEpoch := first / epochLength
+	curEpoch := cfg.First / cfg.EpochLength
 	sendOperation(dCtx, opChannel, operation.NewBeginEpoch(curEpoch))
 
 	for iter.Next() {
 		tx := iter.Value()
 		// close off old block with an end-block operation
-		if oldBlock != tx.Block {
-			if tx.Block > last {
+		if curBlock != tx.Block {
+			if tx.Block > cfg.Last {
 				break
 			}
-			if oldBlock != math.MaxUint64 {
+			if curBlock != math.MaxUint64 {
 				sendOperation(dCtx, opChannel, operation.NewEndBlock())
 				// Record epoch changes.
-				newEpoch := tx.Block / epochLength
+				newEpoch := tx.Block / cfg.EpochLength
 				for curEpoch < newEpoch {
 					sendOperation(dCtx, opChannel, operation.NewEndEpoch())
 					curEpoch++
 					sendOperation(dCtx, opChannel, operation.NewBeginEpoch(curEpoch))
 				}
 			}
-			oldBlock = tx.Block
+			curBlock = tx.Block
 			// open new block with a begin-block operation and clear index cache
 			sendOperation(dCtx, opChannel, operation.NewBeginBlock(tx.Block))
 		}
 		sendOperation(dCtx, opChannel, operation.NewBeginTransaction(uint32(tx.Transaction)))
-		err = traceRecordTask(tx.Block, tx.Transaction, chainID, tx.Substate, dCtx, opChannel)
-		if err != nil {
-			return err
+		var statedb state.StateDB
+		statedb = state.MakeGethInMemoryStateDB(&tx.Substate.InputAlloc, tx.Block)
+		statedb = NewProxyRecorder(statedb, dCtx, opChannel, utils.TraceDebug)
+
+		if err := utils.ProcessTx(statedb, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
+			return fmt.Errorf("Failed to process block %v tx %v. %v", tx.Block, tx.Transaction, err)
 		}
 		sendOperation(dCtx, opChannel, operation.NewEndTransaction())
-		if enableProgress {
+		if cfg.EnableProgress {
 			// report progress
 			sec = time.Since(start).Seconds()
 			if sec-lastSec >= 15 {
-				fmt.Printf("trace record: Elapsed time: %.0f s, at block %v\n", sec, oldBlock)
+				fmt.Printf("trace record: Elapsed time: %.0f s, at block %v\n", sec, curBlock)
 				lastSec = sec
 			}
 		}
@@ -322,14 +187,14 @@ func traceRecordAction(ctx *cli.Context) error {
 	}
 
 	// end last block
-	if oldBlock != math.MaxUint64 {
+	if curBlock != math.MaxUint64 {
 		sendOperation(dCtx, opChannel, operation.NewEndBlock())
 	}
 	sendOperation(dCtx, opChannel, operation.NewEndEpoch())
 
-	if enableProgress {
+	if cfg.EnableProgress {
 		sec = time.Since(start).Seconds()
-		fmt.Printf("trace record: Total elapsed time: %.3f s, processed %v blocks\n", sec, last-first+1)
+		fmt.Printf("trace record: Total elapsed time: %.3f s, processed %v blocks\n", sec, cfg.Last-cfg.First+1)
 	}
 
 	// close channel
@@ -338,5 +203,5 @@ func traceRecordAction(ctx *cli.Context) error {
 	// write dictionaries and indexes
 	dCtx.Write()
 
-	return err
+	return nil
 }

--- a/utils/tx_processor.go
+++ b/utils/tx_processor.go
@@ -1,0 +1,336 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"math/big"
+	"strings"
+
+	"github.com/Fantom-foundation/Aida/state"
+	substate "github.com/Fantom-foundation/Substate"
+	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Count total errors occured while processing transactions
+const (
+	MaxErrors       = 50   // maximum number of errors before terminating program
+	UpdateOnFailure = true // update when statedb validation detects discrepancy
+)
+
+var (
+	NumErrors int   // total number of errors across processed transactions
+	hashError error // error when retriving block hashes
+)
+
+// runVMTask executes VM on a chosen storage system.
+func ProcessTx(db state.StateDB, cfg *Config, block uint64, txIndex int, tx *substate.Substate) (txerr error) {
+
+	inputEnv := tx.Env
+
+	var (
+		gaspool   = new(evmcore.GasPool)
+		blockHash = common.Hash{0x01}
+		txHash    = common.Hash{0x02}
+		newErrors int
+		errMsg    strings.Builder
+	)
+	defer handleErrorOnExit(&txerr, &errMsg, &newErrors, cfg.ContinueOnFailure)
+
+	vmConfig := opera.DefaultVMConfig
+	vmConfig.NoBaseFee = true
+	vmConfig.InterpreterImpl = cfg.VmImpl
+	hashError = nil
+	errMsg.WriteString(fmt.Sprintf("Block: %v Transaction: %v\n", block, txIndex))
+	// get chain configuration
+	chainConfig := GetChainConfig(cfg.ChainID)
+
+	// validate whether the input alloc is contained in the db
+	if cfg.ValidateTxState {
+		if err := ValidateStateDB(tx.InputAlloc, db, UpdateOnFailure); err != nil {
+			newErrors++
+			errMsg.WriteString("Input alloc is not contained in the stateDB.\n")
+			errMsg.WriteString(err.Error())
+			if !cfg.ContinueOnFailure {
+				return
+			}
+		}
+	}
+
+	// prepare tx
+	gaspool.AddGas(inputEnv.GasLimit)
+	msg := tx.Message.AsMessage()
+	db.Prepare(txHash, txIndex)
+	blockCtx := prepareBlockCtx(inputEnv)
+	txCtx := evmcore.NewEVMTxContext(msg)
+	evm := vm.NewEVM(*blockCtx, txCtx, db, chainConfig, vmConfig)
+	snapshot := db.Snapshot()
+	// call ApplyMessage
+	msgResult, err := evmcore.ApplyMessage(evm, msg, gaspool)
+
+	// if transaction fails, revert to the first snapshot.
+	if err != nil {
+		db.RevertToSnapshot(snapshot)
+		newErrors++
+		errMsg.WriteString(err.Error())
+		if !cfg.ContinueOnFailure {
+			return
+		}
+	}
+	if hashError != nil {
+		newErrors++
+		errMsg.WriteString(hashError.Error())
+		if !cfg.ContinueOnFailure {
+			return
+		}
+	}
+	if chainConfig.IsByzantium(blockCtx.BlockNumber) {
+		db.Finalise(true)
+	} else {
+		db.IntermediateRoot(chainConfig.IsEIP158(blockCtx.BlockNumber))
+	}
+
+	// check whether the outputAlloc substate is contained in the world-state db.
+	if cfg.ValidateTxState {
+		// validate result
+		logs := db.GetLogs(txHash, blockHash)
+		var contract common.Address
+		//TODO: check logs in "runvm"
+		if cfg.AppName == "runvm" || cfg.AppName == "runarchive" {
+			logs = tx.Result.Logs
+		}
+		if to := msg.To(); to == nil {
+			contract = crypto.CreateAddress(evm.TxContext.Origin, msg.Nonce())
+		}
+		vmResult := compileVMResult(logs, msgResult, contract)
+		if err := validateVMResult(vmResult, tx.Result); err != nil {
+			newErrors++
+			errMsg.WriteString(err.Error())
+			if !cfg.ContinueOnFailure {
+				return
+			}
+		}
+
+		// validate state
+		if err := validateVMAlloc(db, tx.OutputAlloc, cfg.StateValidationMode); err != nil {
+			newErrors++
+			errMsg.WriteString("Output alloc is not contained in the stateDB.\n")
+			errMsg.WriteString(err.Error())
+			if !cfg.ContinueOnFailure {
+				return
+			}
+		}
+	}
+	return
+}
+
+// prepareBlockCtx creates a block context for evm call from an environment of a substate.
+func prepareBlockCtx(inputEnv *substate.SubstateEnv) *vm.BlockContext {
+	getHash := func(num uint64) common.Hash {
+		if inputEnv.BlockHashes == nil {
+			hashError = fmt.Errorf("getHash(%d) invoked, no blockhashes provided", num)
+			return common.Hash{}
+		}
+		h, ok := inputEnv.BlockHashes[num]
+		if !ok {
+			hashError = fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", num)
+		}
+		return h
+	}
+	blockCtx := &vm.BlockContext{
+		CanTransfer: core.CanTransfer,
+		Transfer:    core.Transfer,
+		Coinbase:    inputEnv.Coinbase,
+		BlockNumber: new(big.Int).SetUint64(inputEnv.Number),
+		Time:        new(big.Int).SetUint64(inputEnv.Timestamp),
+		Difficulty:  inputEnv.Difficulty,
+		GasLimit:    inputEnv.GasLimit,
+		GetHash:     getHash,
+	}
+	// If currentBaseFee is defined, add it to the vmContext.
+	if inputEnv.BaseFee != nil {
+		blockCtx.BaseFee = new(big.Int).Set(inputEnv.BaseFee)
+	}
+	return blockCtx
+}
+
+// compileVMResult creates a result of a transaction as SubstateResult struct.
+func compileVMResult(logs []*types.Log, reciept *evmcore.ExecutionResult, contract common.Address) *substate.SubstateResult {
+	vmResult := &substate.SubstateResult{
+		ContractAddress: contract,
+		GasUsed:         reciept.UsedGas,
+		Logs:            logs,
+		Bloom:           types.BytesToBloom(types.LogsBloom(logs)),
+	}
+	if reciept.Failed() {
+		vmResult.Status = types.ReceiptStatusFailed
+	} else {
+		vmResult.Status = types.ReceiptStatusSuccessful
+	}
+	return vmResult
+}
+
+// validateVMResult compares the result of a transaction to an expected value.
+func validateVMResult(vmResult, expectedResult *substate.SubstateResult) error {
+	r := expectedResult.Equal(vmResult)
+	if !r {
+		log.Printf("inconsistent output: result\n")
+		PrintResultDiffSummary(expectedResult, vmResult)
+		return fmt.Errorf("inconsistent output")
+	}
+	return nil
+}
+
+// validateVMAlloc compares states of accounts in stateDB to an expected set of states.
+// If fullState mode, check if expected stae is contained in stateDB.
+// If partialState mode, check for equality of sets.
+func validateVMAlloc(db state.StateDB, expectedAlloc substate.SubstateAlloc, mode ValidationMode) error {
+	var err error
+	switch mode {
+	case SubsetCheck:
+		err = ValidateStateDB(expectedAlloc, db, !UpdateOnFailure)
+	case EqualityCheck:
+		vmAlloc := db.GetSubstatePostAlloc()
+		isEqual := expectedAlloc.Equal(vmAlloc)
+		if !isEqual {
+			err = fmt.Errorf("inconsistent output: alloc\n")
+			PrintAllocationDiffSummary(&expectedAlloc, &vmAlloc)
+		}
+	}
+	return err
+}
+
+// handleErrorOnExit reports error appropiately based on continue-on-failure option.
+func handleErrorOnExit(err *error, errMsg *strings.Builder, newErrors *int, continueOnFailure bool) {
+	if *newErrors > 0 {
+		if continueOnFailure {
+			log.Println(errMsg.String())
+		} else {
+			*err = fmt.Errorf(errMsg.String())
+		}
+	}
+	NumErrors += *newErrors
+	if NumErrors > MaxErrors {
+		*err = fmt.Errorf("%w\nToo many errors...", *err)
+	}
+}
+
+// printIfDifferent compares two values of any types and reports differences if any.
+func printIfDifferent[T comparable](label string, want, have T) bool {
+	if want != have {
+		fmt.Printf("  Different %s:\n", label)
+		fmt.Printf("    want: %v\n", want)
+		fmt.Printf("    have: %v\n", have)
+		return true
+	}
+	return false
+}
+
+// printIfDifferentBytes compares two values of byte type and reports differences if any.
+func printIfDifferentBytes(label string, want, have []byte) bool {
+	if !bytes.Equal(want, have) {
+		fmt.Printf("  Different %s:\n", label)
+		fmt.Printf("    want: %v\n", want)
+		fmt.Printf("    have: %v\n", have)
+		return true
+	}
+	return false
+}
+
+// printIfDifferentBigInt compares two values of big int type and reports differences if any.
+func printIfDifferentBigInt(label string, want, have *big.Int) bool {
+	if want == nil && have == nil {
+		return false
+	}
+	if want == nil || have == nil || want.Cmp(have) != 0 {
+		fmt.Printf("  Different %s:\n", label)
+		fmt.Printf("    want: %v\n", want)
+		fmt.Printf("    have: %v\n", have)
+		return true
+	}
+	return false
+}
+
+// PrintResultDiffSummary compares two tx results and reports differences if any.
+func PrintResultDiffSummary(want, have *substate.SubstateResult) {
+	printIfDifferent("status", want.Status, have.Status)
+	printIfDifferent("contract address", want.ContractAddress, have.ContractAddress)
+	printIfDifferent("gas usage", want.GasUsed, have.GasUsed)
+	printIfDifferent("log bloom filter", want.Bloom, have.Bloom)
+	if !printIfDifferent("log size", len(want.Logs), len(have.Logs)) {
+		for i := range want.Logs {
+			printLogDiffSummary(fmt.Sprintf("log[%d]", i), want.Logs[i], have.Logs[i])
+		}
+	}
+}
+
+// printLogDiffSummary compares two tx logs and reports differences if any.
+func printLogDiffSummary(label string, want, have *types.Log) {
+	printIfDifferent(fmt.Sprintf("%s.address", label), want.Address, have.Address)
+	if !printIfDifferent(fmt.Sprintf("%s.Topics size", label), len(want.Topics), len(have.Topics)) {
+		for i := range want.Topics {
+			printIfDifferent(fmt.Sprintf("%s.Topics[%d]", label, i), want.Topics[i], have.Topics[i])
+		}
+	}
+	printIfDifferentBytes(fmt.Sprintf("%s.data", label), want.Data, have.Data)
+}
+
+// PrintAllocationDiffSummary compares atrributes and existence of accounts and reports differences if any.
+func PrintAllocationDiffSummary(want, have *substate.SubstateAlloc) {
+	printIfDifferent("substate alloc size", len(*want), len(*have))
+	for key := range *want {
+		_, present := (*have)[key]
+		if !present {
+			fmt.Printf("    missing key=%v\n", key)
+		}
+	}
+
+	for key := range *have {
+		_, present := (*want)[key]
+		if !present {
+			fmt.Printf("    extra key=%v\n", key)
+		}
+	}
+
+	for key, is := range *have {
+		should, present := (*want)[key]
+		if present {
+			printAccountDiffSummary(fmt.Sprintf("key=%v:", key), should, is)
+		}
+	}
+}
+
+// PrintAccountDiffSummary compares attributes of two accounts and reports differences if any.
+func printAccountDiffSummary(label string, want, have *substate.SubstateAccount) {
+	printIfDifferent(fmt.Sprintf("%s.Nonce", label), want.Nonce, have.Nonce)
+	printIfDifferentBigInt(fmt.Sprintf("%s.Balance", label), want.Balance, have.Balance)
+	printIfDifferentBytes(fmt.Sprintf("%s.Code", label), want.Code, have.Code)
+
+	printIfDifferent(fmt.Sprintf("len(%s.Storage)", label), len(want.Storage), len(have.Storage))
+	for key := range want.Storage {
+		_, present := have.Storage[key]
+		if !present {
+			fmt.Printf("    %s.Storage misses key %v\n", label, key)
+		}
+	}
+
+	for key := range have.Storage {
+		_, present := want.Storage[key]
+		if !present {
+			fmt.Printf("    %s.Storage has extra key %v\n", label, key)
+		}
+	}
+
+	for key, is := range have.Storage {
+		should, present := want.Storage[key]
+		if present {
+			printIfDifferent(fmt.Sprintf("%s.Storage[%v]", label, key), should, is)
+		}
+	}
+}

--- a/utils/tx_processor_test.go
+++ b/utils/tx_processor_test.go
@@ -1,0 +1,169 @@
+package utils
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/Fantom-foundation/Aida/state"
+	substate "github.com/Fantom-foundation/Substate"
+	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func newDummyResult(t *testing.T) *substate.SubstateResult {
+	return &substate.SubstateResult{
+		Logs:            []*types.Log{},
+		ContractAddress: common.HexToAddress("0x0000000000085a12481aEdb59eb3200332aCA541"),
+		GasUsed:         1000000,
+		Status:          types.ReceiptStatusSuccessful,
+	}
+}
+
+func newDummyAlloc(t *testing.T) substate.SubstateAlloc {
+	dummyAddress1 := common.HexToAddress("0x0000000000085a12481aEdb59eb3200332aCA541")
+	dummyAddress2 := common.HexToAddress("0x0000000000085a12481aEdb59eb3200332aCA542")
+	dummyAddress3 := common.HexToAddress("0x0000000000085a12481aEdb59eb3200332aCA543")
+
+	dummyKey1 := common.HexToHash("0x0fa0c3892eaaf05eeca5cf62d715e3a70780103ea10f080e42ebd1c7a2631e1b")
+	dummyKey2 := common.HexToHash("0xea79a15cb6361d6a78eee4020c57bb2f58099dcb63a8fb5c2d15b82de2afc2b5")
+
+	dummyValue1 := common.HexToHash("0x01")
+	dummyValue2 := common.HexToHash("0x02")
+
+	sa := make(substate.SubstateAlloc)
+	// prime substate alloc
+	sa[dummyAddress1] = substate.NewSubstateAccount(1, big.NewInt(1000000), []byte{})
+	sa[dummyAddress1].Storage[dummyKey1] = dummyValue1
+	sa[dummyAddress2] = substate.NewSubstateAccount(2, big.NewInt(2000000), []byte{})
+	sa[dummyAddress2].Storage[dummyKey2] = dummyValue2
+	sa[dummyAddress3] = substate.NewSubstateAccount(3, big.NewInt(3000000), []byte{})
+	return sa
+}
+
+// TestPrepareBlockCtx tests a creation of block context from substate environment.
+func TestPrepareBlockCtx(t *testing.T) {
+	gaslimit := uint64(10000000)
+	blocknum := uint64(4600000)
+	basefee := big.NewInt(12345)
+	env := &substate.SubstateEnv{
+		Difficulty: big.NewInt(1),
+		GasLimit:   gaslimit,
+		Number:     blocknum,
+		Timestamp:  1675961395,
+		BaseFee:    basefee,
+	}
+
+	// BlockHashes are nil, expect an error
+	blockCtx := prepareBlockCtx(env)
+
+	if blocknum != blockCtx.BlockNumber.Uint64() {
+		t.Fatalf("Wrong block number")
+	}
+	if gaslimit != blockCtx.GasLimit {
+		t.Fatalf("Wrong amount of gas limit")
+	}
+	if basefee.Cmp(blockCtx.BaseFee) != 0 {
+		t.Fatalf("Wrong base fee")
+	}
+}
+
+// TestCompileVMResult tests a construction of substate.Result from tx output
+func TestCompileVMResult(t *testing.T) {
+	var logs []*types.Log
+	reciept_fail := &evmcore.ExecutionResult{UsedGas: 100, Err: fmt.Errorf("Test Error")}
+	contract := common.HexToAddress("0x0000000000085a12481aEdb59eb3200332aCA541")
+
+	sr := compileVMResult(logs, reciept_fail, contract)
+
+	if sr.ContractAddress != contract {
+		t.Fatalf("Wrong contract address")
+	}
+	if sr.GasUsed != reciept_fail.UsedGas {
+		t.Fatalf("Wrong amount of gas used")
+	}
+	if sr.Status != types.ReceiptStatusFailed {
+		t.Fatalf("Wrong transaction status")
+	}
+
+	reciept_success := &evmcore.ExecutionResult{UsedGas: 100, Err: nil}
+	sr = compileVMResult(logs, reciept_success, contract)
+
+	if sr.Status != types.ReceiptStatusSuccessful {
+		t.Fatalf("Wrong transaction status")
+	}
+}
+
+// TestValidateVMResult tests validatation of tx result.
+func TestValidateVMResult(t *testing.T) {
+	expectedResult := newDummyResult(t)
+	vmResult := newDummyResult(t)
+
+	// test positive
+	err := validateVMResult(vmResult, expectedResult)
+	if err != nil {
+		t.Fatalf("Failed to validate VM output. %v", err)
+	}
+
+	// test negative
+	// mismatched contract
+	vmResult.ContractAddress = common.HexToAddress("0x0000000000085a12481aEdb59eb3200332aCA542")
+	err = validateVMResult(vmResult, expectedResult)
+	if err == nil {
+		t.Fatalf("Failed to validate VM output. Expect contract address mismatch error.")
+	}
+	// mismatched gas used
+	vmResult = newDummyResult(t)
+	vmResult.GasUsed = 0
+	err = validateVMResult(vmResult, expectedResult)
+	if err == nil {
+		t.Fatalf("Failed to validate VM output. Expect gas used mismatch error.")
+	}
+
+	// mismatched gas used
+	vmResult = newDummyResult(t)
+	vmResult.Status = types.ReceiptStatusFailed
+	err = validateVMResult(vmResult, expectedResult)
+	if err == nil {
+		t.Fatalf("Failed to validate VM output. Expect staatus mismatch error.")
+	}
+}
+
+// TestValidateVMResult tests validatation of statedb after tx processing.
+func TestValidateVMAlloc(t *testing.T) {
+	expectedResult := newDummyAlloc(t)
+	vmResult := newDummyAlloc(t)
+	db := state.MakeGethInMemoryStateDB(&vmResult, uint64(1234567))
+
+	// test positive
+	if err := validateVMAlloc(db, expectedResult, SubsetCheck); err != nil {
+		t.Fatalf("Failed to validate VM output. %v", err)
+	}
+	if err := validateVMAlloc(db, expectedResult, EqualityCheck); err != nil {
+		t.Fatalf("Failed to validate VM output. %v", err)
+	}
+
+	// DB has one more contract than expected result
+	newAddress := common.HexToAddress("0x0000000000085a12481aEdb59eb3200332aCA000")
+	vmResult[newAddress] = substate.NewSubstateAccount(1, big.NewInt(1000000), []byte{})
+	db = state.MakeGethInMemoryStateDB(&vmResult, uint64(1234567))
+
+	// check whether expectedResult is contained.
+	if err := validateVMAlloc(db, expectedResult, SubsetCheck); err != nil {
+		t.Fatalf("Failed to validate VM output. %v", err)
+	}
+	// check for equality. Since db has an extra contract, an error is expected.
+	if err := validateVMAlloc(db, expectedResult, EqualityCheck); err == nil {
+		t.Fatalf("Failed to detect an error.")
+	}
+
+	// test negative
+	vmResult = make(substate.SubstateAlloc)
+	if err := validateVMAlloc(db, expectedResult, SubsetCheck); err == nil {
+		t.Fatalf("Failed to detect an error.")
+	}
+	if err := validateVMAlloc(db, expectedResult, EqualityCheck); err == nil {
+		t.Fatalf("Failed to detect an error.")
+	}
+}


### PR DESCRIPTION
Refactoring of a common tx processing code as a utility function.

Items included in this PR:
- add a single Tx processing function used by  `record`, `aida-runvm` and `aida-runarchive`
- improve an error message handling, esp. in the case of continue on failure
- record commands adopt Config struct for handling cli options
- introduce unit tests of Tx processing function

To be added in a later patch:
- add more unit tests

Items Excluded from this PR
- Transaction processing in substate-cli