### PR TITLE
Record deleted accounts and resurrected accounts

### DIFF
--- a/cmd/substate-cli/main.go
+++ b/cmd/substate-cli/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	db2 "github.com/Fantom-foundation/Aida/cmd/substate-cli/db"
+	"github.com/Fantom-foundation/Aida/cmd/substate-cli/db"
 	"github.com/Fantom-foundation/Aida/cmd/substate-cli/replay"
 	substate "github.com/Fantom-foundation/Substate"
 	"github.com/ethereum/go-ethereum/params"
@@ -17,8 +17,8 @@ var (
 		Usage:       "A set of commands on substate DB",
 		Description: "",
 		Subcommands: []*cli.Command{
-			&db2.CloneCommand,
-			&db2.CompactCommand,
+			&db.CloneCommand,
+			&db.CompactCommand,
 		},
 	}
 )
@@ -37,6 +37,7 @@ func main() {
 		Flags:     []cli.Flag{},
 		Commands: []*cli.Command{
 			&replay.ReplayCommand,
+			&replay.GenDeletedAccountsCommand,
 			&replay.GetStorageUpdateSizeCommand,
 			&replay.GetCodeCommand,
 			&replay.GetCodeSizeCommand,

--- a/cmd/substate-cli/replay/gen_deleted_accounts.go
+++ b/cmd/substate-cli/replay/gen_deleted_accounts.go
@@ -1,0 +1,286 @@
+package replay
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/Fantom-foundation/Aida/state"
+	"github.com/Fantom-foundation/Aida/utils"
+	substate "github.com/Fantom-foundation/Substate"
+	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/urfave/cli/v2"
+)
+
+var GenDeletedAccountsCommand = cli.Command{
+	Action:    genDeletedAccountsAction,
+	Name:      "gen-deleted-accounts",
+	Usage:     "executes full state transitions and record suicided accounts",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	Flags: []cli.Flag{
+		&substate.WorkersFlag,
+		&substate.SubstateDirFlag,
+		&ChainIDFlag,
+		&utils.DeletedAccountDirFlag,
+	},
+	Description: `
+The substate-cli replay command requires two arguments:
+<blockNumFirst> <blockNumLast>
+<blockNumFirst> and <blockNumLast> are the first and
+last block of the inclusive range of blocks to replay transactions.`,
+}
+
+const channelSize = 1000 //size of deletion channel
+
+var DeleteHistory map[common.Address]bool //address recently and deleted
+
+// readAccounts reads contracts which were suicided or created and adds them to lists
+func readAccounts(ch chan ContractLiveness) ([]common.Address, []common.Address) {
+	des := make(map[common.Address]bool)
+	res := make(map[common.Address]bool)
+	for contract := range ch {
+		addr := contract.Addr
+		if contract.IsDeleted {
+			// if a contract was resurrected before suicided in the same tx,
+			// only keep the last action.
+			if _, found := res[addr]; found {
+				delete(res, addr)
+			}
+			DeleteHistory[addr] = true // meta list
+			des[addr] = true
+		} else {
+			// if a contract was suicided before resurrected in the same tx,
+			// only keep the last action.
+			if _, found := des[addr]; found {
+				delete(des, addr)
+			}
+			// an account is considered as resurrected if it was recently deleted.
+			if recentlyDeleted, found := DeleteHistory[addr]; found && recentlyDeleted {
+				DeleteHistory[addr] = false
+				res[addr] = true
+			} else if found && !recentlyDeleted {
+			}
+		}
+	}
+
+	var deletedAccounts []common.Address
+	var resurrectedAccounts []common.Address
+
+	for addr := range des {
+		deletedAccounts = append(deletedAccounts, addr)
+	}
+	for addr := range res {
+		resurrectedAccounts = append(resurrectedAccounts, addr)
+	}
+	return deletedAccounts, resurrectedAccounts
+}
+
+// genDeletedAccountsTask process a transaction substate then records self-destructed accounts
+// and resurrected accounts to a database.
+func genDeletedAccountsTask(block uint64, tx int, recording *substate.Substate, ddb *substate.DestroyedAccountDB) error {
+
+	inputAlloc := recording.InputAlloc
+	inputEnv := recording.Env
+	inputMessage := recording.Message
+
+	outputAlloc := recording.OutputAlloc
+	outputResult := recording.Result
+
+	var (
+		vmConfig    vm.Config
+		chainConfig *params.ChainConfig
+	)
+
+	vmConfig = opera.DefaultVMConfig
+	vmConfig.NoBaseFee = true
+
+	chainConfig = params.AllEthashProtocolChanges
+	chainConfig.ChainID = big.NewInt(int64(chainID))
+	switch chainID {
+	case 250:
+		chainConfig.LondonBlock = new(big.Int).SetUint64(37534833)
+		chainConfig.BerlinBlock = new(big.Int).SetUint64(37455223)
+	case 4002:
+		chainConfig.LondonBlock = new(big.Int).SetUint64(7513335)
+		chainConfig.BerlinBlock = new(big.Int).SetUint64(1559470)
+	}
+
+	var hashError error
+	getHash := func(num uint64) common.Hash {
+		if inputEnv.BlockHashes == nil {
+			hashError = fmt.Errorf("getHash(%d) invoked, no blockhashes provided", num)
+			return common.Hash{}
+		}
+		h, ok := inputEnv.BlockHashes[num]
+		if !ok {
+			hashError = fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", num)
+		}
+		return h
+	}
+
+	ch := make(chan ContractLiveness, channelSize)
+	var statedb state.StateDB
+	statedb = state.MakeGethInMemoryStateDB(&inputAlloc, block)
+	//wrapper
+	statedb = NewProxyDeletion(statedb, ch)
+
+	// Apply Message
+	var (
+		gaspool   = new(evmcore.GasPool)
+		blockHash = common.Hash{0x01}
+		txHash    = common.Hash{0x02}
+		txIndex   = tx
+	)
+
+	gaspool.AddGas(inputEnv.GasLimit)
+	blockCtx := vm.BlockContext{
+		CanTransfer: core.CanTransfer,
+		Transfer:    core.Transfer,
+		Coinbase:    inputEnv.Coinbase,
+		BlockNumber: new(big.Int).SetUint64(inputEnv.Number),
+		Time:        new(big.Int).SetUint64(inputEnv.Timestamp),
+		Difficulty:  inputEnv.Difficulty,
+		GasLimit:    inputEnv.GasLimit,
+		GetHash:     getHash,
+	}
+	// If currentBaseFee is defined, add it to the vmContext.
+	if inputEnv.BaseFee != nil {
+		blockCtx.BaseFee = new(big.Int).Set(inputEnv.BaseFee)
+	}
+
+	msg := inputMessage.AsMessage()
+
+	vmConfig.Tracer = nil
+	vmConfig.Debug = false
+	statedb.Prepare(txHash, txIndex)
+
+	txCtx := evmcore.NewEVMTxContext(msg)
+
+	evm := vm.NewEVM(blockCtx, txCtx, statedb, chainConfig, vmConfig)
+
+	snapshot := statedb.Snapshot()
+	msgResult, err := evmcore.ApplyMessage(evm, msg, gaspool)
+
+	if err != nil {
+		statedb.RevertToSnapshot(snapshot)
+		return err
+	}
+
+	if hashError != nil {
+		return hashError
+	}
+
+	if chainConfig.IsByzantium(blockCtx.BlockNumber) {
+		statedb.Finalise(true)
+	} else {
+		statedb.IntermediateRoot(chainConfig.IsEIP158(blockCtx.BlockNumber))
+	}
+
+	evmResult := &substate.SubstateResult{}
+	if msgResult.Failed() {
+		evmResult.Status = types.ReceiptStatusFailed
+	} else {
+		evmResult.Status = types.ReceiptStatusSuccessful
+	}
+	evmResult.Logs = statedb.GetLogs(txHash, blockHash)
+	evmResult.Bloom = types.BytesToBloom(types.LogsBloom(evmResult.Logs))
+	if to := msg.To(); to == nil {
+		evmResult.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, msg.Nonce())
+	}
+	evmResult.GasUsed = msgResult.UsedGas
+
+	evmAlloc := statedb.GetSubstatePostAlloc()
+
+	r := outputResult.Equal(evmResult)
+	a := outputAlloc.Equal(evmAlloc)
+	if !(r && a) {
+		if !r {
+			fmt.Printf("inconsistent output: result\n")
+			PrintResultDiffSummary(outputResult, evmResult)
+		}
+		if !a {
+			fmt.Printf("inconsistent output: alloc\n")
+			PrintAllocationDiffSummary(&outputAlloc, &evmAlloc)
+		}
+		return fmt.Errorf("inconsistent output")
+	}
+
+	close(ch)
+	des, res := readAccounts(ch)
+	if len(des)+len(res) > 0 {
+		// if transaction completed successfully, put destroyed accounts
+		// and resurrected accounts to a database
+		if !msgResult.Failed() {
+			ddb.SetDestroyedAccounts(block, tx, des, res)
+		}
+	}
+
+	return nil
+}
+
+// genDeletedAccountsAction replays transactions and record self-destructed accounts and resurrected accounts.
+func genDeletedAccountsAction(ctx *cli.Context) error {
+	var err error
+
+	if ctx.Args().Len() != 2 {
+		return fmt.Errorf("substate-cli gen-deleted-accounts command requires exactly 2 arguments")
+	}
+
+	chainID = ctx.Int(ChainIDFlag.Name)
+	fmt.Printf("chain-id: %v\n", chainID)
+	fmt.Printf("git-date: %v\n", gitDate)
+	fmt.Printf("git-commit: %v\n", gitCommit)
+
+	first, last, argErr := utils.SetBlockRange(ctx.Args().Get(0), ctx.Args().Get(1))
+	if argErr != nil {
+		return argErr
+	}
+
+	substate.SetSubstateFlags(ctx)
+	substate.OpenSubstateDBReadOnly()
+	defer substate.CloseSubstateDB()
+
+	ddb := substate.OpenDestroyedAccountDB(ctx.String(utils.DeletedAccountDirFlag.Name))
+	defer ddb.Close()
+
+	start := time.Now()
+	sec := time.Since(start).Seconds()
+	lastSec := time.Since(start).Seconds()
+	txCount := uint64(0)
+	lastTxCount := uint64(0)
+	DeleteHistory = make(map[common.Address]bool)
+
+	workers := ctx.Int(substate.WorkersFlag.Name)
+	iter := substate.NewSubstateIterator(first, workers)
+	defer iter.Release()
+
+	for iter.Next() {
+		tx := iter.Value()
+		if tx.Block > last {
+			break
+		}
+
+		err := genDeletedAccountsTask(tx.Block, tx.Transaction, tx.Substate, ddb)
+		if err != nil {
+			return err
+		}
+		txCount++
+		sec = time.Since(start).Seconds()
+		diff := sec - lastSec
+		if diff >= 30 {
+			numTx := txCount - lastTxCount
+			lastTxCount = txCount
+			fmt.Printf("substate-cli: Elapsed time: %.0f s, at block %v (~%.1f Tx/s)\n", sec, tx.Block, float64(numTx)/diff)
+			lastSec = sec
+		}
+	}
+
+	return err
+}

--- a/cmd/substate-cli/replay/proxy_deletion.go
+++ b/cmd/substate-cli/replay/proxy_deletion.go
@@ -1,0 +1,293 @@
+package replay
+
+import (
+	"math/big"
+
+	"github.com/Fantom-foundation/Aida/state"
+	substate "github.com/Fantom-foundation/Substate"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type ContractLiveness struct {
+	Addr      common.Address
+	IsDeleted bool //if false, the account was created
+}
+
+// ProxyDeletion data structure for capturing and recording
+// invoked StateDB operations.
+type ProxyDeletion struct {
+	db state.StateDB // state db
+	ch chan ContractLiveness
+}
+
+// NewProxyDeletion creates a new StateDB proxy.
+func NewProxyDeletion(db state.StateDB, ch chan ContractLiveness) *ProxyDeletion {
+	r := new(ProxyDeletion)
+	r.db = db
+	r.ch = ch
+	return r
+}
+
+// CreateAccounts creates a new account.
+func (r *ProxyDeletion) CreateAccount(addr common.Address) {
+	r.db.CreateAccount(addr)
+	r.ch <- ContractLiveness{Addr: addr, IsDeleted: false}
+}
+
+// SubtractBalance subtracts amount from a contract address.
+func (r *ProxyDeletion) SubBalance(addr common.Address, amount *big.Int) {
+	r.db.SubBalance(addr, amount)
+}
+
+// AddBalance adds amount to a contract address.
+func (r *ProxyDeletion) AddBalance(addr common.Address, amount *big.Int) {
+	r.db.AddBalance(addr, amount)
+}
+
+// GetBalance retrieves the amount of a contract address.
+func (r *ProxyDeletion) GetBalance(addr common.Address) *big.Int {
+	balance := r.db.GetBalance(addr)
+	return balance
+}
+
+// GetNonce retrieves the nonce of a contract address.
+func (r *ProxyDeletion) GetNonce(addr common.Address) uint64 {
+	nonce := r.db.GetNonce(addr)
+	return nonce
+}
+
+// SetNonce sets the nonce of a contract address.
+func (r *ProxyDeletion) SetNonce(addr common.Address, nonce uint64) {
+	r.db.SetNonce(addr, nonce)
+}
+
+// GetCodeHash returns the hash of the EVM bytecode.
+func (r *ProxyDeletion) GetCodeHash(addr common.Address) common.Hash {
+	hash := r.db.GetCodeHash(addr)
+	return hash
+}
+
+// GetCode returns the EVM bytecode of a contract.
+func (r *ProxyDeletion) GetCode(addr common.Address) []byte {
+	code := r.db.GetCode(addr)
+	return code
+}
+
+// Setcode sets the EVM bytecode of a contract.
+func (r *ProxyDeletion) SetCode(addr common.Address, code []byte) {
+	r.db.SetCode(addr, code)
+}
+
+// GetCodeSize returns the EVM bytecode's size.
+func (r *ProxyDeletion) GetCodeSize(addr common.Address) int {
+	size := r.db.GetCodeSize(addr)
+	return size
+}
+
+// AddRefund adds gas to the refund counter.
+func (r *ProxyDeletion) AddRefund(gas uint64) {
+	r.db.AddRefund(gas)
+}
+
+// SubRefund subtracts gas to the refund counter.
+func (r *ProxyDeletion) SubRefund(gas uint64) {
+	r.db.SubRefund(gas)
+}
+
+// GetRefund returns the current value of the refund counter.
+func (r *ProxyDeletion) GetRefund() uint64 {
+	gas := r.db.GetRefund()
+	return gas
+}
+
+// GetCommittedState retrieves a value that is already committed.
+func (r *ProxyDeletion) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
+	value := r.db.GetCommittedState(addr, key)
+	return value
+}
+
+// GetState retrieves a value from the StateDB.
+func (r *ProxyDeletion) GetState(addr common.Address, key common.Hash) common.Hash {
+	value := r.db.GetState(addr, key)
+	return value
+}
+
+// SetState sets a value in the StateDB.
+func (r *ProxyDeletion) SetState(addr common.Address, key common.Hash, value common.Hash) {
+	r.db.SetState(addr, key, value)
+}
+
+// Suicide marks the given account as suicided. This clears the account balance.
+// The account is still available until the state is committed;
+// return a non-nil account after Suicide.
+func (r *ProxyDeletion) Suicide(addr common.Address) bool {
+	ok := r.db.Suicide(addr)
+	if ok {
+		r.ch <- ContractLiveness{Addr: addr, IsDeleted: true}
+	}
+	return ok
+}
+
+// HasSuicided checks whether a contract has been suicided.
+func (r *ProxyDeletion) HasSuicided(addr common.Address) bool {
+	hasSuicided := r.db.HasSuicided(addr)
+	return hasSuicided
+}
+
+// Exist checks whether the contract exists in the StateDB.
+// Notably this also returns true for suicided accounts.
+func (r *ProxyDeletion) Exist(addr common.Address) bool {
+	return r.db.Exist(addr)
+}
+
+// Empty checks whether the contract is either non-existent
+// or empty according to the EIP161 specification (balance = nonce = code = 0).
+func (r *ProxyDeletion) Empty(addr common.Address) bool {
+	empty := r.db.Empty(addr)
+	return empty
+}
+
+// PrepareAccessList handles the preparatory steps for executing a state transition with
+// regards to both EIP-2929 and EIP-2930:
+//
+// - Add sender to access list (2929)
+// - Add destination to access list (2929)
+// - Add precompiles to access list (2929)
+// - Add the contents of the optional tx access list (2930)
+//
+// This method should only be called if Berlin/2929+2930 is applicable at the current number.
+func (r *ProxyDeletion) PrepareAccessList(render common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	r.db.PrepareAccessList(render, dest, precompiles, txAccesses)
+}
+
+// AddAddressToAccessList adds an address to the access list.
+func (r *ProxyDeletion) AddAddressToAccessList(addr common.Address) {
+	r.db.AddAddressToAccessList(addr)
+}
+
+// AddressInAccessList checks whether an address is in the access list.
+func (r *ProxyDeletion) AddressInAccessList(addr common.Address) bool {
+	ok := r.db.AddressInAccessList(addr)
+	return ok
+}
+
+// SlotInAccessList checks whether the (address, slot)-tuple is in the access list.
+func (r *ProxyDeletion) SlotInAccessList(addr common.Address, slot common.Hash) (bool, bool) {
+	addressOk, slotOk := r.db.SlotInAccessList(addr, slot)
+	return addressOk, slotOk
+}
+
+// AddSlotToAccessList adds the given (address, slot)-tuple to the access list
+func (r *ProxyDeletion) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	r.db.AddSlotToAccessList(addr, slot)
+}
+
+// RevertToSnapshot reverts all state changes from a given revision.
+func (r *ProxyDeletion) RevertToSnapshot(snapshot int) {
+	r.db.RevertToSnapshot(snapshot)
+}
+
+// Snapshot returns an identifier for the current revision of the state.
+func (r *ProxyDeletion) Snapshot() int {
+	snapshot := r.db.Snapshot()
+	return snapshot
+}
+
+// AddLog adds a log entry.
+func (r *ProxyDeletion) AddLog(log *types.Log) {
+	r.db.AddLog(log)
+}
+
+// GetLogs retrieves log entries.
+func (r *ProxyDeletion) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	return r.db.GetLogs(hash, blockHash)
+}
+
+// AddPreimage adds a SHA3 preimage.
+func (r *ProxyDeletion) AddPreimage(addr common.Hash, image []byte) {
+	r.db.AddPreimage(addr, image)
+}
+
+// ForEachStorage performs a function over all storage locations in a contract.
+func (r *ProxyDeletion) ForEachStorage(addr common.Address, fn func(common.Hash, common.Hash) bool) error {
+	err := r.db.ForEachStorage(addr, fn)
+	return err
+}
+
+// Prepare sets the current transaction hash and index.
+func (r *ProxyDeletion) Prepare(thash common.Hash, ti int) {
+	r.db.Prepare(thash, ti)
+}
+
+// Finalise the state in StateDB.
+func (r *ProxyDeletion) Finalise(deleteEmptyObjects bool) {
+	r.db.Finalise(deleteEmptyObjects)
+}
+
+// IntermediateRoot computes the current hash of the StateDB.
+// It is called in between transactions to get the root hash that
+// goes into transaction receipts.
+func (r *ProxyDeletion) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	return r.db.IntermediateRoot(deleteEmptyObjects)
+}
+
+func (r *ProxyDeletion) Commit(deleteEmptyObjects bool) (common.Hash, error) {
+	return r.db.Commit(deleteEmptyObjects)
+}
+
+// GetSubstatePostAlloc gets substate post allocation.
+func (r *ProxyDeletion) GetSubstatePostAlloc() substate.SubstateAlloc {
+	return r.db.GetSubstatePostAlloc()
+}
+
+func (r *ProxyDeletion) PrepareSubstate(substate *substate.SubstateAlloc, block uint64) {
+	r.db.PrepareSubstate(substate, block)
+}
+
+func (r *ProxyDeletion) BeginTransaction(number uint32) {
+	r.db.BeginTransaction(number)
+}
+
+func (r *ProxyDeletion) EndTransaction() {
+	r.db.EndTransaction()
+}
+
+func (r *ProxyDeletion) BeginBlock(number uint64) {
+	r.db.BeginBlock(number)
+}
+
+func (r *ProxyDeletion) EndBlock() {
+	r.db.EndBlock()
+}
+
+func (r *ProxyDeletion) BeginEpoch(number uint64) {
+	r.db.BeginEpoch(number)
+}
+
+func (r *ProxyDeletion) EndEpoch() {
+	r.db.EndEpoch()
+}
+
+func (r *ProxyDeletion) GetArchiveState(block uint64) (state.StateDB, error) {
+	return r.db.GetArchiveState(block)
+}
+
+// BeginBlockApply creates a new object copying state from
+// the old stateDB or clears execution state of stateDB
+func (r *ProxyDeletion) BeginBlockApply() error {
+	return r.db.BeginBlockApply()
+}
+
+func (r *ProxyDeletion) Close() error {
+	return r.db.Close()
+}
+
+func (r *ProxyDeletion) StartBulkLoad() state.BulkLoad {
+	panic("StartBulkLoad not supported by ProxyDeletion")
+	return nil
+}
+
+func (r *ProxyDeletion) GetMemoryUsage() *state.MemoryUsage {
+	return r.db.GetMemoryUsage()
+}


### PR DESCRIPTION
This PR is a part of a fix which clears storage of suicided contracts. Since substate only keeps touched addresses, it cannot distinguish between storage keys have been deleted or they are not accessed. For simplicity, a storage slot is marked as deleted by setting to common.Hash{}. This change is particularly important for accounts which later resurrected.

Recording of deleted addresses and resurrected addresses

Deleted address: an account which was successfully suicided in a transaction. Resurrected address: an account created in a transaction which was previously suicided. Only successful transactions are recorded.