### PR TITLE
Handle priming StateDB errors

### DIFF
--- a/utils/statedb.go
+++ b/utils/statedb.go
@@ -118,7 +118,9 @@ func PrimeStateDB(ws substate.SubstateAlloc, db state.StateDB, cfg *Config) {
 
 	}
 	log.Printf("\t\tHashing and flushing ...\n")
-	load.Close()
+	if err := load.Close(); err != nil {
+		panic(fmt.Errorf("failed to prime StateDB: %v", err))
+	}
 }
 
 // primeOneAccount initializes an account on stateDB with substate


### PR DESCRIPTION
This fixes silently ignored error in StateDB priming:
```
2023/03/01 08:47:55 		Loading state ... 239915.7 slots/s,  90.8%, time: 0:04, ETA: 0:00
2023/03/01 08:47:56 		Loading state ... 323626.1 slots/s,  97.8%, time: 0:04, ETA: 0:00
2023/03/01 08:47:56 		Hashing and flushing ...
record-replay: CloseSubstateDB
panic: failed to prime StateDB: unable to add block 0, is higher or equal to already present block 0

goroutine 1 [running]:
github.com/Fantom-foundation/Aida/utils.PrimeStateDB(0xc008ac62d0, {0xda3788?, 0xc008ae80e0?}, 0xc0001e4580)
	/home/jkalina/Aida/utils/statedb.go:122 +0x353
github.com/Fantom-foundation/Aida/cmd/runvm-cli/runvm.RunVM(0xb732e0?)
	/home/jkalina/Aida/cmd/runvm-cli/runvm/runvm.go:244 +0x5f1
github.com/urfave/cli/v2.(*Command).Run(0xc0001e4420, 0xc0002a4ec0, {0xc0001a6000, 0x10, 0x10})
	/home/jkalina/go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/command.go:273 +0xa42
github.com/urfave/cli/v2.(*App).RunContext(0x11e96a0, {0xd96ae8?, 0xc0001b8008}, {0xc0001a6000, 0x10, 0x10})
	/home/jkalina/go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/app.go:332 +0x616
github.com/urfave/cli/v2.(*App).Run(...)
	/home/jkalina/go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/app.go:309
main.main()
	/home/jkalina/Aida/cmd/runvm-cli/main.go:63 +0x47
```