### PR TITLE
Refactor stochastic cli

### DIFF
--- a/cmd/stochastic-cli/main.go
+++ b/cmd/stochastic-cli/main.go
@@ -19,6 +19,7 @@ func initStochasticApp() *cli.App {
 			&stochastic.StochasticEstimatorCommand,
 			&stochastic.StochasticRecordCommand,
 			&stochastic.StochasticReplayCommand,
+			&stochastic.StochasticVisualizerCommand,
 		},
 	}
 }

--- a/cmd/stochastic-cli/stochastic/estimator.go
+++ b/cmd/stochastic-cli/stochastic/estimator.go
@@ -15,12 +15,9 @@ import (
 // StochasticEstimatorCommand data structure for the estimator app
 var StochasticEstimatorCommand = cli.Command{
 	Action:    stochasticEstimatorAction,
-	Name:      "estimator",
+	Name:      "estimate",
 	Usage:     "estimates parameters of access distributions and produces a simulation file",
 	ArgsUsage: "<event-file>",
-	Flags: []cli.Flag{
-		&utils.VisualizeFlag,
-	},
 	Description: `
 The stochastic estimator command requires one argument:
 <events.json>
@@ -58,18 +55,6 @@ func stochasticEstimatorAction(ctx *cli.Context) error {
 		outputFileName = "./simulation.json"
 	}
 	WriteSimulation(&estimationModel, outputFileName)
-
-	// visualize estimator results
-	if addr := ctx.String(utils.VisualizeFlag.Name); addr != "" {
-		// populate viewing model
-		eventModel := stochastic.GetEventsData()
-		eventModel.PopulateEventData(&eventRegistry)
-
-		// fire-up web-server
-		fmt.Println("Open web browser with http://localhost:" + addr)
-		fmt.Println("Cancel estimator with ^C")
-		stochastic.FireUpWeb(addr)
-	}
 
 	return nil
 }

--- a/cmd/stochastic-cli/stochastic/visualizer.go
+++ b/cmd/stochastic-cli/stochastic/visualizer.go
@@ -1,0 +1,64 @@
+package stochastic
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/Fantom-foundation/Aida/stochastic"
+	"github.com/Fantom-foundation/Aida/utils"
+	"github.com/urfave/cli/v2"
+)
+
+// StochasticVisualizerCommand data structure for the visualizer app
+var StochasticVisualizerCommand = cli.Command{
+	Action:    stochasticVisualizerAction,
+	Name:      "visualize",
+	Usage:     "produces a graphical view of the estimated parameters for various distributions",
+	ArgsUsage: "<event-file>",
+	Flags: []cli.Flag{
+		&utils.PortFlag,
+	},
+	Description: `
+The stochastic visualizer command requires one argument:
+<events.json>
+
+<events.json> is the event file produced by the stochastic recorder.`,
+}
+
+// stochasticVisualizerAction implements visualizer command for computing statistical parameters.
+func stochasticVisualizerAction(ctx *cli.Context) error {
+	if ctx.Args().Len() != 1 {
+		return fmt.Errorf("missing event file")
+	}
+
+	// open file
+	file, err := os.Open(ctx.Args().Get(0))
+	if err != nil {
+		return fmt.Errorf("failed opening event file")
+	}
+	defer file.Close()
+
+	// read file
+	contents, err := ioutil.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("failed reading event file")
+	}
+
+	var eventRegistry stochastic.EventRegistryJSON
+	json.Unmarshal(contents, &eventRegistry)
+
+	// visualize visualizer results
+	addr := ctx.String(utils.PortFlag.Name)
+	if addr == "" {
+		addr = "8080"
+	}
+
+	// fire-up web-server
+	fmt.Println("Open web browser with http://localhost:" + addr)
+	fmt.Println("Cancel visualizer with ^C")
+	stochastic.FireUpWeb(&eventRegistry, addr)
+
+	return nil
+}

--- a/stochastic/visualize_data.go
+++ b/stochastic/visualize_data.go
@@ -336,8 +336,15 @@ func renderMarkovChain(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, txt)
 }
 
-// FireUpWeb fires up a new web-server for data visualisation.
-func FireUpWeb(addr string) {
+// FireUpWeb produces a data model for the recorded events and
+// visualizes with a local web-server.
+func FireUpWeb(eventRegistry *EventRegistryJSON, addr string) {
+
+	// create data model (as a singleton) for visualization
+	eventModel := GetEventsData()
+	eventModel.PopulateEventData(eventRegistry)
+
+	// create web server
 	http.HandleFunc("/", renderMain)
 	http.HandleFunc("/"+countingRef, renderCounting)
 	http.HandleFunc("/"+queuingRef, renderQueuing)

--- a/utils/config.go
+++ b/utils/config.go
@@ -197,8 +197,8 @@ var (
 		Name:  "output",
 		Usage: "output filename",
 	}
-	VisualizeFlag = cli.StringFlag{
-		Name:        "visualize",
+	PortFlag = cli.StringFlag{
+		Name:        "port",
 		Aliases:     []string{"v"},
 		Usage:       "enable visualization on `PORT`",
 		DefaultText: "8080",


### PR DESCRIPTION
This PR separates the estimation from the visualization. The benefit of the separation is that the after the estimation, we can be sure that the simulation file is written, and we don't need to wait to terminate the web server for visualization (in case the visualize flag was set).

With this PR, we have two new commands:
```
 aida-stochastic estimate <event-file>
 aida-stochastic visualize <event-file>
```
Both commands use the event file produced by the record command as an argument.