### PR TITLE
Add random-seed for the replay tool

### DIFF
--- a/cmd/stochastic-cli/stochastic/replay.go
+++ b/cmd/stochastic-cli/stochastic/replay.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"strconv"
 	"time"
@@ -23,10 +24,8 @@ var StochasticReplayCommand = cli.Command{
 	Flags: []cli.Flag{
 		&utils.TraceDebugFlag,
 		&utils.DisableProgressFlag,
-		// TODO: this flag does not make sense for stochastic replay/remove, however
-		// cannot be removed without rewriting config.go
-		&utils.ChainIDFlag,
 		&utils.MemoryBreakdownFlag,
+		&utils.RandomSeedFlag,
 		&utils.StateDbImplementationFlag,
 		&utils.StateDbVariantFlag,
 		&utils.StateDbSrcDirFlag,
@@ -83,6 +82,11 @@ func stochasticReplayAction(ctx *cli.Context) error {
 	fmt.Printf("stochastic replay: run simulation ...\n")
 	traceDebug := ctx.Bool(utils.TraceDebugFlag.Name)
 	disableProgress := ctx.Bool(utils.DisableProgressFlag.Name)
+
+	// set random seed so that runs are deterministic
+	randomSeed := ctx.Int(utils.RandomSeedFlag.Name)
+	rand.Seed(int64(randomSeed))
+
 	stochastic.RunStochasticReplay(db, simulation, int(simLength), traceDebug, disableProgress)
 
 	// print memory usage after simulation

--- a/utils/config.go
+++ b/utils/config.go
@@ -110,6 +110,11 @@ var (
 		Usage: "set number of accounts written to stateDB before applying pending state updates",
 		Value: 0,
 	}
+	RandomSeedFlag = cli.IntFlag{
+		Name:  "random-seed",
+		Usage: "Set random seed",
+		Value: 42,
+	}
 	SkipPrimingFlag = cli.BoolFlag{
 		Name:  "skip-priming",
 		Usage: "if set, DB priming should be skipped; most useful with the 'memory' DB implementation",
@@ -351,6 +356,9 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 		VmImpl:              ctx.String(VmImplementation.Name),
 		Workers:             ctx.Int(substate.WorkersFlag.Name),
 		MemoryProfile:       ctx.String(MemProfileFlag.Name),
+	}
+	if cfg.ChainID == 0 {
+		cfg.ChainID = ChainIDFlag.Value
 	}
 	setFirstBlockFromChainID(cfg.ChainID)
 	if cfg.EpochLength <= 0 {


### PR DESCRIPTION
This PR adds a random-seed flag to the stochastic replay tool. This flag permits configuring the random number generator so that the generated operations are deterministic (assuming that the DB implementations don't use the random generator on their own/especially in concurrent threads).

I also removed the Chain-Id flag from the replay tool, which required setting the internal chain-id to the default setting (otherwise, it receives the zero value and the replay tool fails).