### PR TITLE
Add missing vm imports

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	substate "github.com/Fantom-foundation/Substate"
+	_ "github.com/ethereum/go-ethereum/core/vm"
+	_ "github.com/ethereum/go-ethereum/core/vm/lfvm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/urfave/cli/v2"
 )

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Aida/state"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// TestVmImplsAreRegistered checks if interpreters are correctly registered
+func TestVmImplsAreRegistered(t *testing.T) {
+	checkedImpls := []string{"lfvm", "lfvm-si", "geth"}
+
+	statedb := state.MakeGethInMemoryStateDB(nil, 0)
+	defer statedb.Close()
+	chainConfig := GetChainConfig(0xFA)
+
+	for _, interpreterImpl := range checkedImpls {
+		evm := vm.NewEVM(vm.BlockContext{}, vm.TxContext{}, statedb, chainConfig, vm.Config{
+			InterpreterImpl: interpreterImpl,
+		})
+		if evm == nil {
+			t.Errorf("Unable to create EVM with InterpreterImpl %s", interpreterImpl)
+		}
+	}
+}


### PR DESCRIPTION
This fixes registering vm impls by adding explicit import.
This fixes an issue where aida-runvm reports:
```
13:18:05  2023/03/06 13:18:05 Run VM
13:18:05  2023/03/06 13:18:05 no factory for interpreter lfvm registered
```