### PR TITLE
Fix closing stateDB before GetMemoryFootprint call

### DIFF
--- a/cmd/stochastic-cli/stochastic/replay.go
+++ b/cmd/stochastic-cli/stochastic/replay.go
@@ -96,15 +96,15 @@ func stochasticReplayAction(ctx *cli.Context) error {
 	}
 
 	// close the DB and print disk usage
+	if usage := db.GetMemoryUsage(); usage != nil {
+		log.Printf("stochastic replay: state DB memory usage: %d byte\n%s\n", usage.UsedBytes, usage.Breakdown)
+	}
 	start := time.Now()
 	if err := db.Close(); err != nil {
 		log.Printf("Failed to close database: %v", err)
 	}
 	log.Printf("stochastic replay: Closing DB took %v\n", time.Since(start))
 	log.Printf("stochastic replay: Final disk usage: %v MiB\n", float32(utils.GetDirectorySize(stateDirectory))/float32(1024*1024))
-	if usage := db.GetMemoryUsage(); usage != nil {
-		log.Printf("stochastic replay: state DB memory usage: %d byte\n%s\n", usage.UsedBytes, usage.Breakdown)
-	}
 
 	return nil
 }


### PR DESCRIPTION
Stochastic replay closes the StateDB before it reads the memory usage - because of this the memory usage obtaining fails:
```
00:15:45.532  2023/03/08 13:58:02 stochastic replay: Closing DB took 4.703104506s
00:15:45.532  2023/03/08 13:58:02 stochastic replay: Final disk usage: 1651.9001 MiB
00:15:45.532  panic: runtime error: invalid memory address or nil pointer dereference
00:15:45.532  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5cfe70]
00:15:45.532  
00:15:45.532  goroutine 1 [running]:
00:15:45.532  github.com/Fantom-foundation/Carmen/go/common.includeObjectIntoTotal(0x0, 0xc00d9896f0?)
00:15:45.532  	/var/lib/jenkins/workspace/Aida/Stochastic/carmen/go/common/mem_footprint.go:56 +0x70
00:15:45.532  github.com/Fantom-foundation/Carmen/go/common.includeObjectIntoTotal(0xc02bdd0b20, 0x0?)
00:15:45.532  	/var/lib/jenkins/workspace/Aida/Stochastic/carmen/go/common/mem_footprint.go:58 +0xd9
00:15:45.532  github.com/Fantom-foundation/Carmen/go/common.(*MemoryFootprint).Total(...)
00:15:45.532  	/var/lib/jenkins/workspace/Aida/Stochastic/carmen/go/common/mem_footprint.go:48
00:15:45.532  github.com/Fantom-foundation/Aida/state.(*carmenStateDB).GetMemoryUsage(0x5047ea?)
00:15:45.532  	/var/lib/jenkins/workspace/Aida/Stochastic/state/carmen.go:293 +0x98
00:15:45.532  github.com/Fantom-foundation/Aida/state.(*shadowStateDB).GetMemoryUsage(0xc000207640)
00:15:45.532  	/var/lib/jenkins/workspace/Aida/Stochastic/state/shadow.go:269 +0x110
00:15:45.532  github.com/Fantom-foundation/Aida/cmd/stochastic-cli/stochastic.stochasticReplayAction(0xc000206fc0)
00:15:45.532  	/var/lib/jenkins/workspace/Aida/Stochastic/cmd/stochastic-cli/stochastic/replay.go:104 +0x5a2
00:15:45.532  github.com/urfave/cli/v2.(*Command).Run(0x16cdcb20, 0xc000206fc0, {0xc0000e2600, 0xc, 0xc})
00:15:45.532  	/var/lib/jenkins/go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/command.go:273 +0xa42
00:15:45.532  github.com/urfave/cli/v2.(*Command).Run(0xc0000de9a0, 0xc000206f00, {0xc000036340, 0xd, 0xd})
00:15:45.532  	/var/lib/jenkins/go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/command.go:266 +0xc97
00:15:45.532  github.com/urfave/cli/v2.(*App).RunContext(0xc000256000, {0x76a7770?, 0xc00003e0d0}, {0xc000036340, 0xd, 0xd})
00:15:45.532  	/var/lib/jenkins/go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/app.go:332 +0x616
00:15:45.532  github.com/urfave/cli/v2.(*App).Run(...)
00:15:45.532  	/var/lib/jenkins/go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/app.go:309
00:15:45.532  main.main()
00:15:45.532  	/var/lib/jenkins/workspace/Aida/Stochastic/cmd/stochastic-cli/main.go:30 +0x125
```