### PR TITLE
Fix deleted accounts

### DIFF
--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -276,13 +276,13 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 		db.EndTransaction()
 		ss.txNum++
 		ss.commitBalanceLog()
+		ss.deleteAccounts()
 
 	case ExistID:
 		db.Exist(addr)
 
 	case FinaliseID:
 		db.Finalise(FinaliseFlag)
-		ss.deleteAccounts()
 
 	case GetBalanceID:
 		db.GetBalance(addr)


### PR DESCRIPTION
This PR fixes the issues that accounts were deleted in `Finalise()` before `EndTransaction()`. As a consequence, there were balance entries in the log of the suicided account that triggered panic.

This solves issue #292.
