### PR TITLE
Fix performance bug: deleteAccounts()

### DIFF
--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -162,6 +162,7 @@ func NewStochasticState(db state.StateDB, contracts *generator.IndirectAccess, k
 		snapshotLambda: snapshotLambda,
 		traceDebug:     traceDebug,
 		balanceLog:     make(map[int64][]int64),
+		suicided:       []int64{},
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bottleneck in searching for suicided accounts. Instead of a direct search, we keep a list of suicided accounts in the state.