### PR TITLE
Fix handling of random seed to actually use a random seed by default

### DIFF
--- a/cmd/stochastic-cli/stochastic/replay.go
+++ b/cmd/stochastic-cli/stochastic/replay.go
@@ -93,7 +93,11 @@ func stochasticReplayAction(ctx *cli.Context) error {
 
 	// set random seed so that runs are deterministic
 	randomSeed := ctx.Int(utils.RandomSeedFlag.Name)
+	if randomSeed < 0 {
+		randomSeed = int(rand.Uint32())
+	}
 	rand.Seed(int64(randomSeed))
+	fmt.Printf("stochastic replay: using random seed %d\n", randomSeed)
 
 	stochastic.RunStochasticReplay(db, simulation, int(simLength), traceDebug, disableProgress)
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -115,7 +115,7 @@ var (
 	RandomSeedFlag = cli.IntFlag{
 		Name:  "random-seed",
 		Usage: "Set random seed",
-		Value: 42,
+		Value: -1,
 	}
 	SkipPrimingFlag = cli.BoolFlag{
 		Name:  "skip-priming",


### PR DESCRIPTION
Before this change, the random seed was not actually random when not specified. I believe, however, this was the original intention.

Also: prints the used random seed for completeness