### PR TITLE
Add a suppression feature for debug output

### DIFF
--- a/cmd/stochastic-cli/stochastic/replay.go
+++ b/cmd/stochastic-cli/stochastic/replay.go
@@ -25,6 +25,7 @@ var StochasticReplayCommand = cli.Command{
 		&utils.ContinueOnFailureFlag,
 		&utils.CpuProfileFlag,
 		&utils.TraceDebugFlag,
+		&utils.TraceDebugSuppressFlag,
 		&utils.DisableProgressFlag,
 		&utils.MemoryBreakdownFlag,
 		&utils.RandomSeedFlag,

--- a/utils/config.go
+++ b/utils/config.go
@@ -158,6 +158,11 @@ var (
 		Name:  "trace-debug",
 		Usage: "enable debug output for tracing",
 	}
+	TraceDebugSuppressFlag = cli.IntFlag{
+		Name:  "trace-debug-suppress",
+		Usage: "suppress trace debug output for the first blocks",
+		Value: 0,
+	}
 	TraceDirectoryFlag = cli.StringFlag{
 		Name:  "tracedir",
 		Usage: "set storage trace's output directory",
@@ -241,6 +246,7 @@ type Config struct {
 	DbVariant           string         // database variant
 	DbLogging           bool           // set to true if all DB operations should be logged
 	Debug               bool           // enable trace debug flag
+	DebugSuppress       uint64         // enable trace debug flag
 	DeletedAccountDir   string         // directory of deleted account database
 	EnableProgress      bool           // enable progress report flag
 	EpochLength         uint64         // length of an epoch in number of blocks
@@ -346,6 +352,7 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 		ContinueOnFailure:   ctx.Bool(ContinueOnFailureFlag.Name),
 		CPUProfile:          ctx.String(CpuProfileFlag.Name),
 		Debug:               ctx.Bool(TraceDebugFlag.Name),
+		DebugSuppress:       ctx.Uint64(TraceDebugSuppressFlag.Name),
 		EnableProgress:      !ctx.Bool(DisableProgressFlag.Name),
 		EpochLength:         ctx.Uint64(EpochLengthFlag.Name),
 		First:               first,


### PR DESCRIPTION
This PR adds a suppression feature for debug output so that the first blocks of the stochastic replay tool are not printed.

This feature works only when flag --trace-debug is enabled.