### PR TITLE
Support debug from a specific block

### DIFF
--- a/cmd/stochastic-cli/stochastic/record.go
+++ b/cmd/stochastic-cli/stochastic/record.go
@@ -57,10 +57,6 @@ func stochasticRecordAction(ctx *cli.Context) error {
 	}
 	defer utils.StopCPUProfile(cfg)
 
-	if ctx.Bool(utils.TraceDebugFlag.Name) {
-		utils.TraceDebug = true
-	}
-
 	// iterate through subsets in sequence
 	substate.SetSubstateDirectory(cfg.SubstateDBDir)
 	substate.OpenSubstateDBReadOnly()

--- a/cmd/stochastic-cli/stochastic/replay.go
+++ b/cmd/stochastic-cli/stochastic/replay.go
@@ -25,6 +25,7 @@ var StochasticReplayCommand = cli.Command{
 		&utils.ContinueOnFailureFlag,
 		&utils.CpuProfileFlag,
 		&utils.TraceDebugFlag,
+		&utils.DebugFromFlag,
 		&utils.DisableProgressFlag,
 		&utils.MemoryBreakdownFlag,
 		&utils.RandomSeedFlag,

--- a/cmd/trace-cli/trace/proxy_recorder.go
+++ b/cmd/trace-cli/trace/proxy_recorder.go
@@ -18,16 +18,14 @@ type ProxyRecorder struct {
 	db     state.StateDB       // state db
 	dctx   *dictionary.Context // dictionary context for decoding information
 	output io.Writer           // write output
-	debug  bool
 }
 
 // NewProxyRecorder creates a new StateDB proxy.
-func NewProxyRecorder(db state.StateDB, dctx *dictionary.Context, output io.Writer, debug bool) *ProxyRecorder {
+func NewProxyRecorder(db state.StateDB, dctx *dictionary.Context, output io.Writer) *ProxyRecorder {
 	r := new(ProxyRecorder)
 	r.db = db
 	r.dctx = dctx
 	r.output = output
-	r.debug = debug
 	return r
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -70,6 +70,11 @@ var (
 		Name:  "cpuprofile",
 		Usage: "enables CPU profiling",
 	}
+	DebugFromFlag = cli.Uint64Flag{
+		Name:  "debug-from",
+		Usage: "sets the first block to print trace debug",
+		Value: 0,
+	}
 	DeletedAccountDirFlag = cli.StringFlag{
 		Name:  "deleted-account-dir",
 		Usage: "sets the directory containing deleted accounts database",
@@ -241,6 +246,7 @@ type Config struct {
 	DbVariant           string         // database variant
 	DbLogging           bool           // set to true if all DB operations should be logged
 	Debug               bool           // enable trace debug flag
+	DebugFrom           uint64         // the first block to print trace debug
 	DeletedAccountDir   string         // directory of deleted account database
 	EnableProgress      bool           // enable progress report flag
 	EpochLength         uint64         // length of an epoch in number of blocks
@@ -346,6 +352,7 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 		ContinueOnFailure:   ctx.Bool(ContinueOnFailureFlag.Name),
 		CPUProfile:          ctx.String(CpuProfileFlag.Name),
 		Debug:               ctx.Bool(TraceDebugFlag.Name),
+		DebugFrom:           ctx.Uint64(DebugFromFlag.Name),
 		EnableProgress:      !ctx.Bool(DisableProgressFlag.Name),
 		EpochLength:         ctx.Uint64(EpochLengthFlag.Name),
 		First:               first,


### PR DESCRIPTION
This PR introduces a new flag `--debug-from <block no.>` which allows users to limit debug information form the specified block. The flag must be used with `--trace-debug`.