### PR TITLE
Makefile optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test:
 
 clean:
 	cd carmen/go ; \
-	rm -f lib/libstate.so ; \
+	rm -f lib/libcarmen.so ; \
 	cd ../cpp ; \
 	bazel clean ; \
 	cd ../.. ; \


### PR DESCRIPTION
`make all` command builds `carmen/go/lib/libcarmen.so` only once. This reduces the build time, especially when using dockerized bazel.