### PR TITLE
Consolidate BeginBlock and BeginBlockApply

### DIFF
--- a/cmd/runvm-cli/runvm/proxy_profiler.go
+++ b/cmd/runvm-cli/runvm/proxy_profiler.go
@@ -27,13 +27,6 @@ func NewProxyProfiler(db state.StateDB) (*ProxyProfiler, *operation.ProfileStats
 	return p, p.ps
 }
 
-// BeginBlockApply creates a new object copying state from
-// the old stateDB or clears execution state of stateDB
-func (p *ProxyProfiler) BeginBlockApply() error {
-	err := p.db.BeginBlockApply()
-	return err
-}
-
 // CreateAccounts creates a new account.
 func (p *ProxyProfiler) CreateAccount(addr common.Address) {
 	start := time.Now()

--- a/cmd/runvm-cli/runvm/runvm.go
+++ b/cmd/runvm-cli/runvm/runvm.go
@@ -170,7 +170,6 @@ func RunVM(ctx *cli.Context) error {
 			// Mark the beginning of a new block
 			curBlock = tx.Block
 			db.BeginBlock(curBlock)
-			db.BeginBlockApply()
 		}
 		if cfg.MaxNumTransactions >= 0 && txCount >= cfg.MaxNumTransactions {
 			break

--- a/cmd/substate-cli/replay/proxy_deletion.go
+++ b/cmd/substate-cli/replay/proxy_deletion.go
@@ -277,12 +277,6 @@ func (r *ProxyDeletion) GetArchiveState(block uint64) (state.StateDB, error) {
 	return r.db.GetArchiveState(block)
 }
 
-// BeginBlockApply creates a new object copying state from
-// the old stateDB or clears execution state of stateDB
-func (r *ProxyDeletion) BeginBlockApply() error {
-	return r.db.BeginBlockApply()
-}
-
 func (r *ProxyDeletion) Close() error {
 	return r.db.Close()
 }

--- a/cmd/trace-cli/trace/proxy_recorder.go
+++ b/cmd/trace-cli/trace/proxy_recorder.go
@@ -344,12 +344,6 @@ func (r *ProxyRecorder) GetArchiveState(block uint64) (state.StateDB, error) {
 	return r.db.GetArchiveState(block)
 }
 
-// BeginBlockApply creates a new object copying state from
-// the old stateDB or clears execution state of stateDB
-func (r *ProxyRecorder) BeginBlockApply() error {
-	return r.db.BeginBlockApply()
-}
-
 func (r *ProxyRecorder) Close() error {
 	return r.db.Close()
 }

--- a/state/carmen.go
+++ b/state/carmen.go
@@ -75,10 +75,6 @@ type carmenStateDB struct {
 	blockNumber uint64
 }
 
-func (s *carmenStateDB) BeginBlockApply() error {
-	return nil
-}
-
 func (s *carmenStateDB) CreateAccount(addr common.Address) {
 	s.db.CreateAccount(cc.Address(addr))
 }

--- a/state/carmen_test.go
+++ b/state/carmen_test.go
@@ -76,32 +76,6 @@ func TestCarmenState_InitCloseCarmenDB(t *testing.T) {
 	}
 }
 
-// TestCarmenState_BeginBlockApply tests block apply start
-func TestCarmenState_BeginBlockApply(t *testing.T) {
-	for _, tc := range getCarmenStateTestCases() {
-		t.Run(fmt.Sprintf("DB variant: %s, archive type: %v", tc.variant, tc.archive), func(t *testing.T) {
-			csDB, err := MakeCarmenStateDB(t.TempDir(), tc.variant, tc.archive, 1)
-
-			if err != nil {
-				t.Fatalf("failed to create carmen state DB: %v", err)
-			}
-
-			// Close DB after test ends
-			defer func(csDB StateDB) {
-				err = csDB.Close()
-				if err != nil {
-					t.Fatalf("failed to close carmen state DB: %v", err)
-				}
-			}(csDB)
-
-			err = csDB.BeginBlockApply()
-			if err != nil {
-				t.Fatalf("failed to begin block apply: %v", err)
-			}
-		})
-	}
-}
-
 // TestCarmenState_AccountLifecycle tests account operations - create, check if it exists, if it's empty, suicide and suicide confirmation
 func TestCarmenState_AccountLifecycle(t *testing.T) {
 	for _, tc := range getCarmenStateTestCases() {

--- a/state/flat.go
+++ b/state/flat.go
@@ -37,7 +37,7 @@ func MakeFlatStateDB(directory, variant string, rootHash common.Hash) (s StateDB
 	}
 
 	// initialize stateDB
-	fs.BeginBlockApply()
+	fs.openStateDB()
 	s = fs
 	return
 }
@@ -48,8 +48,8 @@ type flatStateDB struct {
 	*state.StateDB
 }
 
-// BeginBlockApply creates a new statedb from an existing geth database
-func (s *flatStateDB) BeginBlockApply() error {
+// openStateDB creates a new statedb from an existing geth database
+func (s *flatStateDB) openStateDB() error {
 	var err error
 	s.StateDB, err = state.New(s.stateRoot, s.db)
 	return err
@@ -64,7 +64,7 @@ func (s *flatStateDB) EndTransaction() {
 }
 
 func (s *flatStateDB) BeginBlock(number uint64) {
-	// ignored
+	s.openStateDB()
 }
 
 func (s *flatStateDB) EndBlock() {

--- a/state/flat_test.go
+++ b/state/flat_test.go
@@ -47,23 +47,6 @@ func TestFlatState_MakeFlatStateDBInvalid(t *testing.T) {
 	}
 }
 
-// TestFlatState_BeginBlockApply tests if starting block apply will run successfully
-func TestFlatState_BeginBlockApply(t *testing.T) {
-	for _, tc := range getFlatStateTestCases() {
-		t.Run(fmt.Sprintf("DB variant: %s", tc.variant), func(t *testing.T) {
-			fsDB, err := MakeFlatStateDB(t.TempDir(), tc.variant, common.Hash{})
-			if err != nil {
-				t.Fatalf("failed to create flat state DB: %v", err)
-			}
-
-			err = fsDB.BeginBlockApply()
-			if err != nil {
-				t.Fatalf("failed to begin block apply: %v", err)
-			}
-		})
-	}
-}
-
 // TestFlatState_StartBulkLoadAndClose tests starting and immediately closing bulk load without any operations
 func TestFlatState_StartBulkLoadAndClose(t *testing.T) {
 	for _, tc := range getFlatStateTestCases() {

--- a/state/geth.go
+++ b/state/geth.go
@@ -44,8 +44,8 @@ func MakeGethStateDB(directory, variant string, rootHash common.Hash, isArchiveM
 	}, nil
 }
 
-// BeginBlockApply creates a new statedb from an existing geth database
-func (s *gethStateDB) BeginBlockApply() error {
+// openStateDB creates a new statedb from an existing geth database
+func (s *gethStateDB) openStateDB() error {
 	var err error
 	s.db, err = geth.NewWithSnapLayers(s.stateRoot, s.evmState, nil, 0)
 	return err
@@ -150,6 +150,7 @@ func (s *gethStateDB) EndTransaction() {
 }
 
 func (s *gethStateDB) BeginBlock(number uint64) {
+	s.openStateDB()
 	s.block = number
 }
 

--- a/state/logger.go
+++ b/state/logger.go
@@ -19,11 +19,6 @@ type loggingStateDB struct {
 	db StateDB
 }
 
-func (s *loggingStateDB) BeginBlockApply() error {
-	log.Printf("BeginBlockApply\n")
-	return s.db.BeginBlockApply()
-}
-
 func (s *loggingStateDB) CreateAccount(addr common.Address) {
 	log.Printf("CreateAccount, %v\n", addr)
 	s.db.CreateAccount(addr)

--- a/state/memory.go
+++ b/state/memory.go
@@ -79,11 +79,6 @@ func makeSnapshot(parent *snapshot, id int) *snapshot {
 	}
 }
 
-func (db *inMemoryStateDB) BeginBlockApply() error {
-	// ignored
-	return nil
-}
-
 func (db *inMemoryStateDB) CreateAccount(addr common.Address) {
 	// TODO not a nice solution, but as inMemoryStateDB
 	// doesn't include journal as statedb has, this works to replay
@@ -444,7 +439,6 @@ func (db *inMemoryStateDB) EndTransaction() {
 }
 
 func (db *inMemoryStateDB) BeginBlock(number uint64) {
-	// ignored
 	db.blockNum = number
 }
 

--- a/state/shadow.go
+++ b/state/shadow.go
@@ -35,10 +35,6 @@ type snapshotPair struct {
 	prime, shadow int
 }
 
-func (s *shadowStateDB) BeginBlockApply() error {
-	return s.getError("BeginBlockApply", func(s StateDB) error { return s.BeginBlockApply() })
-}
-
 func (s *shadowStateDB) CreateAccount(addr common.Address) {
 	s.run("CreateAccount", func(s StateDB) { s.CreateAccount(addr) })
 }

--- a/state/shadow_test.go
+++ b/state/shadow_test.go
@@ -44,30 +44,6 @@ func TestShadowState_InitCloseShadowDB(t *testing.T) {
 	}
 }
 
-// TestShadowState_BeginBlockApply tests block apply start
-func TestShadowState_BeginBlockApply(t *testing.T) {
-	for _, ctc := range getCarmenStateTestCases() {
-		testCaseTitle := fmt.Sprintf("carmenDB variant: %s, archive type: %s", ctc.variant, ctc.archive)
-
-		t.Run(testCaseTitle, func(t *testing.T) {
-			shadowDB := makeTestShadowDB(t, ctc)
-
-			// Close DB after test ends
-			defer func(shadowDB StateDB) {
-				err := shadowDB.Close()
-				if err != nil {
-					t.Fatalf("failed to close shadow state DB: %v", err)
-				}
-			}(shadowDB)
-
-			err := shadowDB.BeginBlockApply()
-			if err != nil {
-				t.Fatalf("failed to begin block apply: %v", err)
-			}
-		})
-	}
-}
-
 // TestShadowState_AccountLifecycle tests account operations - create, check if it exists, if it's empty, suicide and suicide confirmation
 func TestShadowState_AccountLifecycle(t *testing.T) {
 	for _, ctc := range getCarmenStateTestCases() {

--- a/state/state.go
+++ b/state/state.go
@@ -83,9 +83,6 @@ type StateDB interface {
 	// After this call no more operations will be allowed on the state.
 	Close() error
 
-	// stateDB handler
-	BeginBlockApply() error
-
 	// StartBulkLoad creates a interface supporting the efficient loading of large amount
 	// of data as it is, for instance, needed during priming. Only one bulk load operation
 	// may be active at any time and no other concurrent operations on the StateDB are

--- a/stochastic/event_proxy.go
+++ b/stochastic/event_proxy.go
@@ -359,12 +359,6 @@ func (p *EventProxy) EndEpoch() {
 	p.db.EndEpoch()
 }
 
-// BeginBlockApply creates a new object copying state from
-// the old stateDB or clears execution state of stateDB
-func (p *EventProxy) BeginBlockApply() error {
-	return p.db.BeginBlockApply()
-}
-
 func (p *EventProxy) Close() error {
 	return p.db.Close()
 }


### PR DESCRIPTION
BeginBlockApply reopens stateDB object. Since this should be done at the beginning of block processing, this PR moves the functionality of BeginBlockApply to BeginBlock.