### PR TITLE
Update go-ethereum-substate version to include Geth state fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230301033351-d20d976d1f4c
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230331085425-52296093a646
 
 replace github.com/Fantom-foundation/go-opera => github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20230301090555-fe74c5a947fa
 

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/Fantom-foundation/Substate v0.0.0-20230313095132-69cdb7b639cd h1:4DYv
 github.com/Fantom-foundation/Substate v0.0.0-20230313095132-69cdb7b639cd/go.mod h1:KoObQO1Wmf3ACjxcXDREHf+mtDF4MAXfHwtxMIdyhx8=
 github.com/Fantom-foundation/Tosca v0.0.0-20230328180157-898d0ae722cb h1:S0KsunUvcmh1wPa/KGAkddy53iqXTH+PP/8t3Gmv5vE=
 github.com/Fantom-foundation/Tosca v0.0.0-20230328180157-898d0ae722cb/go.mod h1:NpXaJ+jksyraNZf9iHVPRDPGVr2j5jU0Tv7/weZpUr4=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230301033351-d20d976d1f4c h1:vA5wxnBTXJBuNtlvLe//aNIBEAHrgOKuB3BuA5bx+qE=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230301033351-d20d976d1f4c/go.mod h1:Hu8U9SrXP6ABqtSNfJHw8lRGnr6tyma9PNZvwTweDjQ=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230331085425-52296093a646 h1:wlo+TbNH2ZekB7uFMR69Z13ie6LvVdIIERXXojEc0ws=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230331085425-52296093a646/go.mod h1:Hu8U9SrXP6ABqtSNfJHw8lRGnr6tyma9PNZvwTweDjQ=
 github.com/Fantom-foundation/go-opera-fvm v0.0.0-20230112084156-680f281ea1cb h1:4GajUnaY0S4KUe9KO0L4S8wq8R7CtGJna/s6IobED70=
 github.com/Fantom-foundation/go-opera-fvm v0.0.0-20230112084156-680f281ea1cb/go.mod h1:WET74tpRJLCU44+/gINDchjqmM7kSSbIJgckUDl1a8s=
 github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20230301090555-fe74c5a947fa h1:xi4eLM2mqb5b1ZHTBHnu7eGXHkqI4+yXN9xsb2xC87w=


### PR DESCRIPTION
This update introduces a fix in go-ethereum-substate for an issue detected during testing with Aida's stochastic tool.