### PR TITLE
Fix search for BeginSyncPeriod in stochastic replay

### DIFF
--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -100,7 +100,7 @@ func RunStochasticReplay(db state.StateDB, e *EstimationModelJSON, nBlocks int, 
 	ss.prime()
 
 	// set initial state to BeginSyncPeriod
-	state := find(operations, "BE")
+	state := find(operations, OpMnemo(BeginSyncPeriodID))
 	if state == -1 {
 		return fmt.Errorf("BeginSyncPeriod cannot be observed in stochastic matrix/recording failed.")
 	}


### PR DESCRIPTION
This PR fixes the search for BeginSyncPeriod. The search used the old mnemo for BeginEpoch.