### PR TITLE
Remove gas limit capping

### DIFF
--- a/cmd/substate-cli/replay/replay.go
+++ b/cmd/substate-cli/replay/replay.go
@@ -3,7 +3,6 @@ package replay
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/big"
 	"os"
 	"runtime/pprof"
@@ -166,11 +165,6 @@ func replayTask(config ReplayConfig, block uint64, tx int, recording *substate.S
 	// If currentBaseFee is defined, add it to the vmContext.
 	if inputEnv.BaseFee != nil {
 		blockCtx.BaseFee = new(big.Int).Set(inputEnv.BaseFee)
-	}
-	// Limit the GasLimit to MaxInt64 since some VM implementations use
-	// int64 instead of uint64 to represent gas quantities.
-	if blockCtx.GasLimit > uint64(math.MaxInt64) {
-		blockCtx.GasLimit = uint64(math.MaxInt64)
 	}
 
 	msg := inputMessage.AsMessage()

--- a/utils/tx_processor.go
+++ b/utils/tx_processor.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"math"
 	"math/big"
 	"strings"
 
@@ -153,11 +152,6 @@ func prepareBlockCtx(inputEnv *substate.SubstateEnv) *vm.BlockContext {
 	// If currentBaseFee is defined, add it to the vmContext.
 	if inputEnv.BaseFee != nil {
 		blockCtx.BaseFee = new(big.Int).Set(inputEnv.BaseFee)
-	}
-	// Limit the GasLimit to MaxInt64 since some VM implementations use
-	// int64 instead of uint64 to represent gas quantities.
-	if blockCtx.GasLimit > uint64(math.MaxInt64) {
-		blockCtx.GasLimit = uint64(math.MaxInt64)
 	}
 	return blockCtx
 }


### PR DESCRIPTION
The change fixes the substate processing for `lfvm-no-sha-cache` and `geth`.

Before this fix, both failed at block 5340432.

The gas-price capping was introduced by #409, since some EVM implementations use signed gas limits. Such high gas limits have not been expected, and also have been considered irrelevant for processing. Turns out, they are not.