### PR TITLE
Limit operations per bulk load

### DIFF
--- a/cmd/trace-cli/trace/replay_substate.go
+++ b/cmd/trace-cli/trace/replay_substate.go
@@ -74,7 +74,7 @@ func traceReplaySubstateTask(cfg *utils.Config, log *logging.Logger) error {
 	defer os.RemoveAll(stateDbDir)
 
 	// create prime context
-	pc := utils.NewPrimeContext(cfg, log)
+	pc := utils.NewPrimeContext(cfg, db, log)
 
 	var (
 		start        time.Time

--- a/state/geth.go
+++ b/state/geth.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	triesInMemory    = 16
+	triesInMemory    = 1
 	memoryUpperLimit = 256 * 1024 * 1024
 	imgUpperLimit    = 4 * 1024 * 1024
 )

--- a/utils/prime_test.go
+++ b/utils/prime_test.go
@@ -36,7 +36,7 @@ func TestPrime_PrimeStateDB(t *testing.T) {
 			// Generating randomized world state
 			ws, _ := makeWorldState(t)
 
-			pc := NewPrimeContext(cfg, log)
+			pc := NewPrimeContext(cfg, sDB, log)
 			// Priming state DB
 			pc.PrimeStateDB(ws, sDB)
 

--- a/utils/statedb_test.go
+++ b/utils/statedb_test.go
@@ -265,7 +265,7 @@ func TestStatedb_DeleteDestroyedAccountsFromStateDB(t *testing.T) {
 			log := logger.NewLogger("INFO", "TestStateDb")
 
 			// Create new prime context
-			pc := NewPrimeContext(cfg, log)
+			pc := NewPrimeContext(cfg, sDB, log)
 			// Priming state DB with given world state
 			pc.PrimeStateDB(ws, sDB)
 
@@ -311,7 +311,7 @@ func TestStatedb_ValidateStateDB(t *testing.T) {
 			log := logger.NewLogger("INFO", "TestStateDb")
 
 			// Create new prime context
-			pc := NewPrimeContext(cfg, log)
+			pc := NewPrimeContext(cfg, sDB, log)
 			// Priming state DB with given world state
 			pc.PrimeStateDB(ws, sDB)
 
@@ -351,7 +351,7 @@ func TestStatedb_ValidateStateDBWithUpdate(t *testing.T) {
 			log := logger.NewLogger("INFO", "TestStateDb")
 
 			// Create new prime context
-			pc := NewPrimeContext(cfg, log)
+			pc := NewPrimeContext(cfg, sDB, log)
 			// Priming state DB with given world state
 			pc.PrimeStateDB(ws, sDB)
 


### PR DESCRIPTION
This PR limit bulk load size by number of operations rather than number of accounts. This ensures more stable memory consumption.