### PR TITLE
Add logging message for stochastic/generate & fix small frequency issue

### DIFF
--- a/cmd/stochastic-cli/stochastic/generate.go
+++ b/cmd/stochastic-cli/stochastic/generate.go
@@ -1,8 +1,7 @@
 package stochastic
 
 import (
-	"log"
-
+	"github.com/Fantom-foundation/Aida/logger"
 	"github.com/Fantom-foundation/Aida/stochastic"
 	"github.com/Fantom-foundation/Aida/utils"
 	"github.com/urfave/cli/v2"
@@ -15,6 +14,7 @@ var StochasticGenerateCommand = cli.Command{
 	Usage:     "generate uniform events file",
 	ArgsUsage: "",
 	Flags: []cli.Flag{
+		&logger.LogLevelFlag,
 		&utils.BlockLengthFlag,
 		&utils.SyncPeriodLengthFlag,
 		&utils.TransactionLengthFlag,
@@ -28,24 +28,28 @@ var StochasticGenerateCommand = cli.Command{
 
 // stochasticGenerateAction generates the uniform simulation data and writes the JSON file.
 func stochasticGenerateAction(ctx *cli.Context) error {
-	var err error
 
 	cfg, err := utils.NewConfig(ctx, utils.NoArgs)
 	if err != nil {
 		return err
 	}
 
-	log.Println("produce uniform stochastic event file")
+	log := logger.NewLogger(cfg.LogLevel, "StochasticGenerate")
+
+	log.Info("Produce uniform stochastic event file")
 
 	// create a new uniformly distributed event registry
-	eventRegistry := stochastic.GenerateUniformRegistry(cfg)
+	eventRegistry := stochastic.GenerateUniformRegistry(cfg, log)
 
 	// writing event registry
 	if cfg.Output == "" {
 		cfg.Output = "./events.json"
 	}
-	log.Printf("write event file to %v\n", cfg.Output)
-	WriteEvents(eventRegistry, cfg.Output)
+	log.Noticef("Write event file to %v", cfg.Output)
+	err = WriteEvents(eventRegistry, cfg.Output)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/stochastic-cli/stochastic/record.go
+++ b/cmd/stochastic-cli/stochastic/record.go
@@ -3,7 +3,6 @@ package stochastic
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"time"
@@ -135,26 +134,31 @@ func stochasticRecordAction(ctx *cli.Context) error {
 	if cfg.Output == "" {
 		cfg.Output = "./events.json"
 	}
-	WriteEvents(&eventRegistry, cfg.Output)
+	err = WriteEvents(&eventRegistry, cfg.Output)
+	if err != nil {
+		return err
+	}
 
-	return err
+	return nil
 }
 
 // WriteEvents writes event file in JSON format.
-func WriteEvents(r *stochastic.EventRegistry, filename string) {
+func WriteEvents(r *stochastic.EventRegistry, filename string) error {
 	f, fErr := os.Create(filename)
 	if fErr != nil {
-		log.Fatalf("cannot open JSON file. Error: %v", fErr)
+		return fmt.Errorf("cannot open JSON file; %v", fErr)
 	}
 	defer f.Close()
 
 	jOut, jErr := json.MarshalIndent(r.NewEventRegistryJSON(), "", "    ")
 	if jErr != nil {
-		log.Fatalf("failed to convert JSON file. Error: %v", jErr)
+		return fmt.Errorf("failed to convert JSON file; %v", jErr)
 	}
 
 	_, pErr := fmt.Fprintln(f, string(jOut))
 	if pErr != nil {
-		log.Fatalf("failed to convert JSON file. Error: %v", pErr)
+		return fmt.Errorf("failed to convert JSON file; %v", pErr)
 	}
+
+	return nil
 }

--- a/stochastic/fuzzing_test.go
+++ b/stochastic/fuzzing_test.go
@@ -87,7 +87,7 @@ func FuzzStochastic(f *testing.F) {
 		defer os.RemoveAll(cfg.StateDbSrc)
 
 		// generate uniform events
-		events := GenerateUniformRegistry(&cfg).NewEventRegistryJSON()
+		events := GenerateUniformRegistry(&cfg, logger.NewLogger(cfg.LogLevel, "FuzzingTest")).NewEventRegistryJSON()
 
 		// generate uniform matrix
 		e := NewEstimationModelJSON(&events)

--- a/stochastic/generate.go
+++ b/stochastic/generate.go
@@ -1,19 +1,18 @@
 package stochastic
 
 import (
-	"log"
-
 	"github.com/Fantom-foundation/Aida/stochastic/statistics"
 	"github.com/Fantom-foundation/Aida/utils"
+	"github.com/op/go-logging"
 )
 
 // GenerateUniformRegistry produces a uniformly distributed simulation file.
-func GenerateUniformRegistry(cfg *utils.Config) *EventRegistry {
+func GenerateUniformRegistry(cfg *utils.Config, log *logging.Logger) *EventRegistry {
 	r := NewEventRegistry()
 
 	// generate a uniform distribution for contracts, storage keys/values, and snapshots
 
-	log.Printf("number of contract addresses for priming: %v\n", cfg.ContractNumber)
+	log.Infof("Number of contract addresses for priming: %v", cfg.ContractNumber)
 	for i := int64(0); i < cfg.ContractNumber; i++ {
 		for j := i - statistics.QueueLen - 1; j <= i; j++ {
 			if j >= 0 {
@@ -22,7 +21,7 @@ func GenerateUniformRegistry(cfg *utils.Config) *EventRegistry {
 		}
 	}
 
-	log.Printf("number of storage keys for priming: %v\n", cfg.KeysNumber)
+	log.Infof("Number of storage keys for priming: %v", cfg.KeysNumber)
 	for i := int64(0); i < cfg.KeysNumber; i++ {
 		for j := i - statistics.QueueLen - 1; j <= i; j++ {
 			if j >= 0 {
@@ -31,7 +30,7 @@ func GenerateUniformRegistry(cfg *utils.Config) *EventRegistry {
 		}
 	}
 
-	log.Printf("number of storage values for priming: %v\n", cfg.ValuesNumber)
+	log.Infof("Number of storage values for priming: %v", cfg.ValuesNumber)
 	for i := int64(0); i < cfg.ValuesNumber; i++ {
 		for j := i - statistics.QueueLen - 1; j <= i; j++ {
 			if j >= 0 {
@@ -40,7 +39,7 @@ func GenerateUniformRegistry(cfg *utils.Config) *EventRegistry {
 		}
 	}
 
-	log.Printf("snapshot depth: %v\n", cfg.KeysNumber)
+	log.Infof("Snapshot depth: %v", cfg.KeysNumber)
 	for i := 0; i < cfg.SnapshotDepth; i++ {
 		r.snapshotFreq[i] = 1
 	}


### PR DESCRIPTION
This PR adds log messages to the `aida-stochastic generate` command. There was a minor impression related to the number of operations in a transaction.