### PR TITLE
Delete accounts after EndBlock

### DIFF
--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -344,6 +344,7 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 	case EndBlockID:
 		db.EndBlock()
 		ss.blockNum++
+		ss.deleteAccounts()
 
 	case EndSyncPeriodID:
 		db.EndSyncPeriod()
@@ -353,7 +354,6 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 		db.EndTransaction()
 		ss.txNum++
 		ss.totalTx++
-		ss.deleteAccounts()
 
 	case ExistID:
 		db.Exist(addr)


### PR DESCRIPTION
This PR deletes the accounts in the EndBlock operation so that after a suicide operation, an account can still be used until the end of block operation (coincides with the StateDB semantics).