### PR TITLE
Update Tosca version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Fantom-foundation/Carmen/go v0.0.0-00010101000000-000000000000
 	github.com/Fantom-foundation/Substate v0.0.0-20230512151613-f039b23bf3f7
-	github.com/Fantom-foundation/Tosca v0.0.0-20230406154859-8e2180f5f5c9
+	github.com/Fantom-foundation/Tosca v0.0.0-20230527064715-aa1fc97baebe
 	github.com/Fantom-foundation/go-opera v1.1.1-rc.2
 	github.com/Fantom-foundation/go-opera-erigon v0.0.0-00010101000000-000000000000
 	github.com/Fantom-foundation/go-opera-flat v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
This PR updates Tosca version. Reason for update is change of Tosca converted code cache to be able to process all mainnet blocks till 60M