### PR TITLE
call method block fix

### DIFF
--- a/cmd/api-replay-cli/apireplay/execute.go
+++ b/cmd/api-replay-cli/apireplay/execute.go
@@ -8,8 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// todo pending + 1 block
-
 // executeGetBalance request into given archive and send result to comparator
 func executeGetBalance(param interface{}, archive state.StateDB) (out *StateDBData) {
 	var (

--- a/cmd/api-replay-cli/apireplay/executor.go
+++ b/cmd/api-replay-cli/apireplay/executor.go
@@ -339,7 +339,8 @@ func decodeBlockNumber(params []interface{}, recordedBlockNumber uint64, returne
 		*returnedBlockID = uint64(rpc.EarliestBlockNumber)
 		break
 	case "pending":
-		*returnedBlockID = recordedBlockNumber
+		// pending blocks seems not to be working rn, skip them for now
+		return false
 	default:
 		// request requires specific currentBlockID
 		var (


### PR DESCRIPTION
## Description

By merging this PR we allow request that does not match its response with data in Carmen to be re-executed.
This is needed because recording blockId could be +1 so the blockId is not captured at the moment of execution of the request. Its captured some moments after that, so that causes the delay.

Fixes #470 #472 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)