### PR TITLE
Fix invalid memory access from db.GetMemoryUsage

### DIFF
--- a/cmd/runvm-cli/runvm/runvm.go
+++ b/cmd/runvm-cli/runvm/runvm.go
@@ -92,13 +92,7 @@ func RunVM(ctx *cli.Context) error {
 	}
 
 	// print memory usage after priming
-	if cfg.MemoryBreakdown {
-		if usage := db.GetMemoryUsage(); usage != nil {
-			log.Noticef("State DB memory usage: %d byte\n%s", usage.UsedBytes, usage.Breakdown)
-		} else {
-			log.Info("Utilized storage solution does not support memory breakdowns.")
-		}
-	}
+	utils.MemoryBreakdown(db, cfg, log)
 
 	// wrap stateDB for profiling
 	var stats *profile.Stats
@@ -273,13 +267,7 @@ func RunVM(ctx *cli.Context) error {
 		}
 	}
 
-	if cfg.MemoryBreakdown {
-		if usage := db.GetMemoryUsage(); usage != nil {
-			log.Notice("State DB memory usage: %d byte\n%s", usage.UsedBytes, usage.Breakdown)
-		} else {
-			log.Info("Utilized storage solution does not support memory breakdowns.")
-		}
-	}
+	utils.MemoryBreakdown(db, cfg, log)
 
 	// write memory profile if requested
 	if err := utils.StartMemoryProfile(cfg); err != nil {

--- a/cmd/stochastic-cli/stochastic/replay.go
+++ b/cmd/stochastic-cli/stochastic/replay.go
@@ -108,13 +108,7 @@ func stochasticReplayAction(ctx *cli.Context) error {
 	runErr := stochastic.RunStochasticReplay(db, simulation, int(simLength), cfg, logger.NewLogger(ctx.String(logger.LogLevelFlag.Name), "Stochastic"))
 
 	// print memory usage after simulation
-	if cfg.MemoryBreakdown {
-		if usage := db.GetMemoryUsage(); usage != nil {
-			log.Noticef("State DB memory usage: %d byte\n%s", usage.UsedBytes, usage.Breakdown)
-		} else {
-			log.Info("Utilized storage solution does not support memory breakdowns")
-		}
-	}
+	utils.MemoryBreakdown(db, cfg, log)
 
 	// close the DB and print disk usage
 	start := time.Now()

--- a/cmd/trace-cli/trace/replay.go
+++ b/cmd/trace-cli/trace/replay.go
@@ -196,13 +196,7 @@ func traceReplayTask(cfg *utils.Config, log *logging.Logger) error {
 		}
 	}
 
-	if cfg.MemoryBreakdown {
-		if usage := db.GetMemoryUsage(); usage != nil {
-			log.Notice("State DB memory usage: %d byte\n%s", usage.UsedBytes, usage.Breakdown)
-		} else {
-			log.Notice("Utilized storage solution does not support memory breakdowns.")
-		}
-	}
+	utils.MemoryBreakdown(db, cfg, log)
 
 	// write memory profile if requested
 	if err := utils.StartMemoryProfile(cfg); err != nil {

--- a/state/erigon.go
+++ b/state/erigon.go
@@ -216,7 +216,7 @@ func (s *erigonStateDB) Close() error {
 
 func (s *erigonStateDB) GetMemoryUsage() *MemoryUsage {
 	// not supported yet
-	return nil
+	return &MemoryUsage{uint64(0), nil}
 }
 
 // BeginRwTxBatch begins erigon read/write transaction and batch

--- a/state/flat.go
+++ b/state/flat.go
@@ -121,7 +121,7 @@ func (s *flatStateDB) Close() error {
 
 func (s *flatStateDB) GetMemoryUsage() *MemoryUsage {
 	// not supported yet
-	return nil
+	return &MemoryUsage{uint64(0), nil}
 }
 
 func (s *flatStateDB) StartBulkLoad(block uint64) BulkLoad {

--- a/state/geth.go
+++ b/state/geth.go
@@ -295,7 +295,7 @@ func (s *gethStateDB) GetArchiveState(block uint64) (StateDB, error) {
 
 func (s *gethStateDB) GetMemoryUsage() *MemoryUsage {
 	// not supported yet
-	return nil
+	return &MemoryUsage{uint64(0), nil}
 }
 
 type gethBulkLoad struct {

--- a/state/memory.go
+++ b/state/memory.go
@@ -461,7 +461,7 @@ func (db *inMemoryStateDB) Close() error {
 
 func (db *inMemoryStateDB) GetMemoryUsage() *MemoryUsage {
 	// not supported yet
-	return nil
+	return &MemoryUsage{uint64(0), nil}
 }
 
 func (db *inMemoryStateDB) GetArchiveState(block uint64) (StateDB, error) {

--- a/utils/profile.go
+++ b/utils/profile.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"runtime"
 	"runtime/pprof"
+
+	"github.com/Fantom-foundation/Aida/state"
+	"github.com/op/go-logging"
 )
 
 func StartCPUProfile(cfg *Config) error {
@@ -39,4 +42,15 @@ func StartMemoryProfile(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+// MemoryBreakdown prints memory usage details of statedb if applicable
+func MemoryBreakdown(db state.StateDB, cfg *Config, log *logging.Logger) {
+	if cfg.MemoryBreakdown {
+		if usage := db.GetMemoryUsage(); usage.Breakdown != nil {
+			log.Noticef("State DB memory usage: %d byte\n%s", usage.UsedBytes, usage.Breakdown)
+		} else {
+			log.Notice("Utilized storage solution does not support memory breakdowns.")
+		}
+	}
 }


### PR DESCRIPTION
GetMemoryUsage returns an empty memory usage instead of `nil` 

Fix #478