### PR TITLE
Look for block range in Substate when calling Metadata info cmd

### DIFF
--- a/cmd/db-cli/db/info.go
+++ b/cmd/db-cli/db/info.go
@@ -111,19 +111,21 @@ func printMetadata(pathToDb string) error {
 
 	md.log.Notice("AIDA-DB INFO:")
 
-	printDbType(md)
-
-	// CHAIN-ID
-	chainID, err := md.getChainID()
-	if err != nil {
+	if err = printDbType(md); err != nil {
 		md.log.Warning("Metadata are not yet in this DB; Looking for block range in substate...")
+
 		fb, lb, err := findBlockRangeInSubstate(pathToDb)
 		if err != nil {
 			return fmt.Errorf("cannot find block range in substate; %v", err)
 		}
 		md.log.Noticef("First Block: %v Last Block: %v", fb, lb)
 		return nil
+	}
 
+	// CHAIN-ID
+	chainID, err := md.getChainID()
+	if err != nil {
+		md.log.Warning("Value for ChainID does not exist in given Dbs metadata")
 	} else {
 		md.log.Infof("Chain-ID: %v", chainID)
 	}
@@ -195,11 +197,10 @@ func printUpdateSetInfo(m *aidaMetadata) {
 }
 
 // printDbType from given AidaDb
-func printDbType(m *aidaMetadata) {
+func printDbType(m *aidaMetadata) error {
 	t, err := m.getDbType()
 	if err != nil {
-		m.log.Warning("Value for db type does not exist in given Dbs metadata")
-		return
+		return err
 	}
 
 	var typePrint string
@@ -215,6 +216,7 @@ func printDbType(m *aidaMetadata) {
 	}
 
 	m.log.Noticef("DB-Type: %v", typePrint)
+	return nil
 }
 
 // printAllCount counts all prefixes prints number of occurrences.


### PR DESCRIPTION
This PR adds finding block range in substate if we try to call Metadata info onto AidaDb without metadata