### PR TITLE
Copy source statedb when using runvm

### DIFF
--- a/cmd/runvm-cli/runvm/runvm.go
+++ b/cmd/runvm-cli/runvm/runvm.go
@@ -46,11 +46,13 @@ func RunVM(ctx *cli.Context) error {
 
 	// process general arguments
 	cfg, argErr := utils.NewConfig(ctx, utils.BlockRangeArgs)
+	// if source db is supplied, make a copy and modify the copy
 	if argErr != nil {
 		return argErr
 	}
 
 	cfg.StateValidationMode = utils.SubsetCheck
+	cfg.CopySrcDb = true
 
 	log := logger.NewLogger(cfg.LogLevel, "Run-VM")
 
@@ -70,7 +72,7 @@ func RunVM(ctx *cli.Context) error {
 		return err
 	}
 	if !cfg.KeepDb {
-		log.Warningf("StateDB at %v will be removed at the end of this run.", stateDbDir)
+		log.Warningf("--keep-db is not used. Directory %v with DB will be removed at the end of this run.", stateDbDir)
 		defer os.RemoveAll(stateDbDir)
 	}
 

--- a/cmd/trace-cli/trace/replay.go
+++ b/cmd/trace-cli/trace/replay.go
@@ -93,7 +93,7 @@ func traceReplayTask(cfg *utils.Config, log *logging.Logger) error {
 		return err
 	}
 	if !cfg.KeepDb {
-		log.Warningf("Directory %v with DB will be removed at the end of this run.", cfg.StateDbSrc)
+		log.Warningf("--keep-db is not used. Directory %v with DB will be removed at the end of this run.", stateDbDir)
 		defer os.RemoveAll(stateDbDir)
 	}
 
@@ -236,6 +236,7 @@ func traceReplayAction(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg.CopySrcDb = true
 	if cfg.DbImpl == "memory" {
 		return fmt.Errorf("db-impl memory is not supported")
 	}

--- a/utils/config.go
+++ b/utils/config.go
@@ -384,6 +384,7 @@ type Config struct {
 	ContinueOnFailure   bool              // continue validation when an error detected
 	ContractNumber      int64             // number of contracts to create
 	CompactDb           bool              // compact database after merging
+	CopySrcDb           bool              // if true, make a copy the source statedb
 	CPUProfile          string            // pprof cpu profile output file name
 	Db                  string            // path to database
 	DbTmp               string            // path to temporary database
@@ -534,8 +535,10 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 		CarmenSchema:        ctx.Int(CarmenSchemaFlag.Name),
 		ChainID:             ctx.Int(ChainIDFlag.Name),
 		Cache:               ctx.Int(CacheFlag.Name),
+		CompactDb:           ctx.Bool(CompactDbFlag.Name),
 		ContractNumber:      ctx.Int64(ContractNumberFlag.Name),
 		ContinueOnFailure:   ctx.Bool(ContinueOnFailureFlag.Name),
+		CopySrcDb:           false,
 		CPUProfile:          ctx.String(CpuProfileFlag.Name),
 		Db:                  ctx.Path(DbFlag.Name),
 		DbTmp:               ctx.Path(DbTmpFlag.Name),
@@ -551,7 +554,6 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 		DbLogging:           ctx.Bool(StateDbLoggingFlag.Name),
 		DeletionDb:          ctx.Path(DeletionDbFlag.Name),
 		DeleteSourceDbs:     ctx.Bool(DeleteSourceDbsFlag.Name),
-		CompactDb:           ctx.Bool(CompactDbFlag.Name),
 		HasDeletedAccounts:  true,
 		KeepDb:              ctx.Bool(KeepDbFlag.Name),
 		KeysNumber:          ctx.Int64(KeysNumberFlag.Name),


### PR DESCRIPTION
## Description

When --db-src is used, depending on applications, loading statedb from source may behave differently.

- runvm, or trace replay command copy the source database. Only the copy is modified. The original is preserved.
- runarchive, api replay command read the source database directly. These commands perform read-only operaitons on statedb.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
