### PR TITLE
Add logging of transactions causing panic-aborts

### DIFF
--- a/cmd/substate-cli/replay/replay.go
+++ b/cmd/substate-cli/replay/replay.go
@@ -105,8 +105,7 @@ func replayTask(config ReplayConfig, block uint64, tx int, recording *substate.S
 
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Printf("execution of block %d / tx %d paniced: %v\n", block, tx, r)
-			panic(r)
+			log.Fatalf("Execution of block %d / tx %d paniced: %v", block, tx, r)
 		}
 	}()
 


### PR DESCRIPTION
## Description

This PR adds a convenience feature of logging the transaction number in case its execution terminates with a panic.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
