### PR TITLE
Remove DB implementation flags from substate replay

### DIFF
--- a/cmd/substate-cli/replay/replay.go
+++ b/cmd/substate-cli/replay/replay.go
@@ -48,7 +48,6 @@ var ReplayCommand = cli.Command{
 		&utils.VmImplementation,
 		&utils.OnlySuccessfulFlag,
 		&utils.CpuProfileFlag,
-		&utils.StateDbImplementationFlag,
 		&logger.LogLevelFlag,
 	},
 	Description: `
@@ -64,7 +63,6 @@ var vm_duration time.Duration
 type ReplayConfig struct {
 	vm_impl         string
 	only_successful bool
-	state_db_impl   string
 }
 
 // data collection execution context
@@ -142,15 +140,7 @@ func replayTask(config ReplayConfig, block uint64, tx int, recording *substate.S
 	}
 
 	// TODO: implement other state db types
-	var statedb state.StateDB
-	switch strings.ToLower(config.state_db_impl) {
-	case "geth":
-		statedb = state.MakeOffTheChainStateDB(inputAlloc)
-	case "geth-memory", "memory":
-		statedb = state.MakeInMemoryStateDB(&inputAlloc, block)
-	default:
-		return fmt.Errorf("unsupported db type: %s", config.state_db_impl)
-	}
+	statedb := state.MakeInMemoryStateDB(&inputAlloc, block)
 
 	// Apply Message
 	var (
@@ -361,7 +351,6 @@ func replayAction(ctx *cli.Context) error {
 	var config = ReplayConfig{
 		vm_impl:         cfg.VmImpl,
 		only_successful: cfg.OnlySuccessful,
-		state_db_impl:   cfg.DbImpl,
 	}
 
 	task := func(block uint64, tx int, recording *substate.Substate, taskPool *substate.SubstateTaskPool) error {


### PR DESCRIPTION
## Description

Remove the use of geth-db in substate replay tool. 
This is a manual revert of PR #505.

Fixes #503 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)