### PR TITLE
Finish lachesis updater

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -30,9 +30,8 @@ const (
 )
 
 const (
-	// todo remove after testing is finished
-	aidaDbRepositoryMainnetUrl = "http://xapi241.fantom.network"
-	aidaDbRepositoryTestnetUrl = "http://xapi241.fantom.network"
+	aidaDbRepositoryMainnetUrl = "https://aida.repository.fantom.network"
+	aidaDbRepositoryTestnetUrl = "https://aida.testnet.repository.fantom.network"
 )
 
 var (


### PR DESCRIPTION
## Description

This PR finishes previous PR with lachesis update.
If lachesis patch is being downloaded, it forces to download even second patch and deletes old update-set key on block `4_564_026`.
This is done due to incorrect data inside old AidaDb where Lachesis was not added yet.

## Type of change


- [x] New feature (non-breaking change which adds functionality)


## Before merging this PR this needs to be done:
- [x] New patches are open to download.
- [x] Patches.json are in correct form.