### PR TITLE
Set default db-variant

### DIFF
--- a/state/carmen.go
+++ b/state/carmen.go
@@ -13,10 +13,6 @@ import (
 )
 
 func MakeCarmenStateDB(directory, variant, archive string, schema int) (StateDB, error) {
-	if variant == "" {
-		variant = "go-memory"
-	}
-
 	var archiveType carmen.ArchiveType
 	switch strings.ToLower(archive) {
 	case "none":
@@ -48,6 +44,8 @@ func MakeCarmenStateDB(directory, variant, archive string, schema int) (StateDB,
 		db, err = carmen.NewGoMemoryState(params)
 	case "go-file-nocache":
 		db, err = carmen.NewGoFileState(params)
+	case "":
+		fallthrough
 	case "go-file":
 		db, err = carmen.NewGoCachedFileState(params)
 	case "go-ldb-nocache":

--- a/state/erigon.go
+++ b/state/erigon.go
@@ -31,7 +31,7 @@ func MakeErigonStateDB(directory, variant string, rootHash common.Hash, batchLim
 	// erigon go-memory variant is not compatible with erigon batch mode
 	switch variant {
 	case "": // = default option
-		kv = launcher.InitChainKV(erigonDirectory)
+		fallthrough
 	case "go-mdbx":
 		kv = launcher.InitChainKV(erigonDirectory)
 	default:

--- a/utils/config.go
+++ b/utils/config.go
@@ -595,6 +595,16 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 	cfg.ProfileDB = profileDB
 	cfg.ChainID = chainId
 
+	// set default db variant if not provided.
+	if cfg.DbVariant == "" {
+		if cfg.DbImpl == "carmen" {
+			cfg.DbVariant = "go-file"
+		} else if cfg.DbImpl == "flat" {
+			cfg.DbVariant = "go-ldb"
+		} else if cfg.DbImpl == "erigon" {
+			cfg.DbVariant = "go-mdbx"
+		}
+	}
 	// --continue-on-failure implicitly enables transaction state validation
 	validateTxState := ctx.Bool(ValidateFlag.Name) ||
 		ctx.Bool(ValidateTxStateFlag.Name) ||


### PR DESCRIPTION
## Description

The default value of db variant  is  now set when constructing config. If db variant is not provided, the default value is set depending on db implementation
- carmen: go-file 
- flat: go-ldb
- erigon: go-mdbx

## Type of change

- [x] Refactoring (changes that do NOT affect functionality)
