### PR TITLE
Remove deletion-db from GenerateUpdateSet argument

### DIFF
--- a/cmd/util-db/db/lachesis-update.go
+++ b/cmd/util-db/db/lachesis-update.go
@@ -107,7 +107,7 @@ func loadOperaWorldState(path string) (substate.SubstateAlloc, error) {
 // createLachesisWorldState creates update-set from block 0 to the last lachesis block
 func createLachesisWorldState(cfg *utils.Config) (substate.SubstateAlloc, error) {
 	lachesisLastBlock := utils.FirstOperaBlock - 1
-	lachesis, _, err := utils.GenerateUpdateSet(0, nil, lachesisLastBlock, cfg)
+	lachesis, _, err := utils.GenerateUpdateSet(0, lachesisLastBlock, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/prime.go
+++ b/utils/prime.go
@@ -250,6 +250,8 @@ func LoadWorldStateAndPrime(db state.StateDB, cfg *Config, target uint64) error 
 		log.Infof("\tMerge update set at block %v. New toal size %v MB (+%v MB)",
 			newSet.Block, totalSize/1_000_000,
 			incrementalSize/1_000_000)
+		// advance block after merge update set
+		block++
 	}
 	// if update set is not empty, prime the remaining
 	if len(update) > 0 {
@@ -261,10 +263,10 @@ func LoadWorldStateAndPrime(db state.StateDB, cfg *Config, target uint64) error 
 	}
 	updateIter.Release()
 
-	// advance from the latest precomputed state to the target block
-	if block < target || target == 0 {
-		log.Infof("\tPriming from substate from block %v", block)
-		update, deletedAccounts, err := GenerateUpdateSet(block, nil, target, cfg)
+	// advance from the latest precomputed updateset to the target block
+	if block < target {
+		log.Infof("\tPriming using substate from %v to %v", block, target)
+		update, deletedAccounts, err := GenerateUpdateSet(block, target, cfg)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

This PR removes ddb, an unused argument from GenerateUpdateSet function.

## Type of change

Please delete options that are not relevant.

- [x] Refactoring (changes that do NOT affect functionality)
