### PR TITLE
Fix Parallel Experiment Script

### DIFF
--- a/scripts/run_parallel_experiment.sh
+++ b/scripts/run_parallel_experiment.sh
@@ -64,7 +64,7 @@ Machine() {
 
 # run full parallel experiment
 log "run parallel experiment in the block range from $startblock to $endblock ..."
-#./build/aida-profile parallelisation --aida-db $aidadbpath --db-impl $dbimpl --db-variant $dbvariant --vm-impl=$vmimpl --db-tmp $tmpdir $startblock $endblock "$outputdir/profile.db"
+./build/aida-profile parallelisation --aida-db $aidadbpath --db-impl $dbimpl --db-variant $dbvariant --vm-impl=$vmimpl --db-tmp $tmpdir $startblock $endblock "$outputdir/profile.db"
 
 # reduce dataset in sqlite3 (NB: R consumes too much memory/is too slow for the reduction)
 log "reduce data set ..."


### PR DESCRIPTION
The aida-profile was disabled in the script. This PR enables the invocation again.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
