### PR TITLE
Remove support for substatedb, updatedb and deletiondb in cmd/aida-*

### DIFF
--- a/cmd/aida-profile/profile/address_stats.go
+++ b/cmd/aida-profile/profile/address_stats.go
@@ -15,7 +15,7 @@ var GetAddressStatsCommand = cli.Command{
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		&substate.WorkersFlag,
-		&substate.SubstateDbFlag,
+		&utils.AidaDbFlag,
 		&utils.ChainIDFlag,
 	},
 	Description: `

--- a/cmd/aida-profile/profile/codesize.go
+++ b/cmd/aida-profile/profile/codesize.go
@@ -17,7 +17,7 @@ var GetCodeSizeCommand = cli.Command{
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		&substate.WorkersFlag,
-		&substate.SubstateDbFlag,
+		&utils.AidaDbFlag,
 		&utils.ChainIDFlag,
 	},
 	Description: `
@@ -85,7 +85,7 @@ func getCodeSizeAction(ctx *cli.Context) error {
 
 	fmt.Printf("chain-id: %v\n", cfg.ChainID)
 
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 

--- a/cmd/aida-profile/profile/key_stats.go
+++ b/cmd/aida-profile/profile/key_stats.go
@@ -18,7 +18,7 @@ var GetKeyStatsCommand = cli.Command{
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		&substate.WorkersFlag,
-		&substate.SubstateDbFlag,
+		&utils.AidaDbFlag,
 		&utils.ChainIDFlag,
 		&logger.LogLevelFlag,
 	},

--- a/cmd/aida-profile/profile/location_stats.go
+++ b/cmd/aida-profile/profile/location_stats.go
@@ -18,7 +18,7 @@ var GetLocationStatsCommand = cli.Command{
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		&substate.WorkersFlag,
-		&substate.SubstateDbFlag,
+		&utils.AidaDbFlag,
 		&utils.ChainIDFlag,
 		&logger.LogLevelFlag,
 	},

--- a/cmd/aida-profile/profile/statistic.go
+++ b/cmd/aida-profile/profile/statistic.go
@@ -115,7 +115,7 @@ func getReferenceStatsActionWithConsumer[T comparable](ctx *cli.Context, cli_com
 	log.Infof("chain-id: %v\n", cfg.ChainID)
 	log.Infof("contract-db: %v\n", cfg.Db)
 
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 

--- a/cmd/aida-profile/profile/storage.go
+++ b/cmd/aida-profile/profile/storage.go
@@ -18,7 +18,7 @@ var GetStorageUpdateSizeCommand = cli.Command{
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		&substate.WorkersFlag,
-		&substate.SubstateDbFlag,
+		&utils.AidaDbFlag,
 		&utils.ChainIDFlag,
 		&logger.LogLevelFlag,
 	},
@@ -118,7 +118,7 @@ func getStorageUpdateSizeAction(ctx *cli.Context) error {
 
 	log.Infof("chain-id: %v\n", cfg.ChainID)
 
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 

--- a/cmd/aida-sdb/main_util_test.go
+++ b/cmd/aida-sdb/main_util_test.go
@@ -24,7 +24,8 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// setup prepares substateDB and creates trace directory
+// setup prepares
+// substateDB and creates trace directory
 func setup() {
 	// download and extract substate.test
 	err := setupTestSubstateDB()

--- a/cmd/aida-sdb/trace/record.go
+++ b/cmd/aida-sdb/trace/record.go
@@ -27,7 +27,6 @@ var TraceRecordCommand = cli.Command{
 		&utils.SyncPeriodLengthFlag,
 		&utils.QuietFlag,
 		&substate.WorkersFlag,
-		&substate.SubstateDbFlag,
 		&utils.ChainIDFlag,
 		&utils.TraceFileFlag,
 		&utils.TraceDebugFlag,
@@ -69,7 +68,7 @@ func traceRecordAction(ctx *cli.Context) error {
 	defer rCtx.Close()
 
 	// open SubstateDB and create an substate iterator
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 	iter := substate.NewSubstateIterator(cfg.First, cfg.Workers)

--- a/cmd/aida-sdb/trace/replay.go
+++ b/cmd/aida-sdb/trace/replay.go
@@ -27,7 +27,6 @@ var TraceReplayCommand = cli.Command{
 		&utils.CarmenSchemaFlag,
 		&utils.ChainIDFlag,
 		&utils.CpuProfileFlag,
-		&utils.DeletionDbFlag,
 		&utils.QuietFlag,
 		&utils.SyncPeriodLengthFlag,
 		&utils.KeepDbFlag,
@@ -50,13 +49,11 @@ var TraceReplayCommand = cli.Command{
 		&utils.ShadowDb,
 		&utils.ShadowDbImplementationFlag,
 		&utils.ShadowDbVariantFlag,
-		&substate.SubstateDbFlag,
 		&substate.WorkersFlag,
 		&utils.TraceFileFlag,
 		&utils.TraceDirectoryFlag,
 		&utils.TraceDebugFlag,
 		&utils.DebugFromFlag,
-		&utils.UpdateDbFlag,
 		&utils.ValidateFlag,
 		&utils.ValidateWorldStateFlag,
 		&utils.AidaDbFlag,
@@ -258,7 +255,7 @@ func traceReplayAction(ctx *cli.Context) error {
 	defer utils.StopCPUProfile(cfg)
 
 	// run storage driver
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 

--- a/cmd/aida-sdb/trace/replay_substate.go
+++ b/cmd/aida-sdb/trace/replay_substate.go
@@ -34,7 +34,6 @@ var TraceReplaySubstateCommand = cli.Command{
 		&utils.StateDbLoggingFlag,
 		&utils.ShadowDbImplementationFlag,
 		&utils.ShadowDbVariantFlag,
-		&substate.SubstateDbFlag,
 		&utils.SyncPeriodLengthFlag,
 		&substate.WorkersFlag,
 		&utils.TraceFileFlag,
@@ -198,7 +197,7 @@ func traceReplaySubstateAction(ctx *cli.Context) error {
 		return err
 	}
 	// run storage driver
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 

--- a/cmd/aida-stochastic-sdb/stochastic/record.go
+++ b/cmd/aida-stochastic-sdb/stochastic/record.go
@@ -26,7 +26,6 @@ var StochasticRecordCommand = cli.Command{
 		&utils.SyncPeriodLengthFlag,
 		&utils.OutputFlag,
 		&substate.WorkersFlag,
-		&substate.SubstateDbFlag,
 		&utils.ChainIDFlag,
 		&utils.AidaDbFlag,
 	},
@@ -57,7 +56,7 @@ func stochasticRecordAction(ctx *cli.Context) error {
 	defer utils.StopCPUProfile(cfg)
 
 	// iterate through subsets in sequence
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 	iter := substate.NewSubstateIterator(cfg.First, ctx.Int(substate.WorkersFlag.Name))

--- a/cmd/aida-vm-adb/main.go
+++ b/cmd/aida-vm-adb/main.go
@@ -22,13 +22,13 @@ var RunArchiveApp = cli.App{
 	Flags: []cli.Flag{
 		// substate
 		&substate.WorkersFlag,
-		&substate.SubstateDbFlag,
 
 		// utils
 		&utils.CpuProfileFlag,
 		&utils.ChainIDFlag,
 		&logger.LogLevelFlag,
 		&utils.StateDbLoggingFlag,
+		&utils.AidaDbFlag,
 
 		// StateDb
 		&utils.AidaDbFlag,

--- a/cmd/aida-vm-adb/vm-adb/runarchive.go
+++ b/cmd/aida-vm-adb/vm-adb/runarchive.go
@@ -50,7 +50,7 @@ func RunArchive(ctx *cli.Context) error {
 	defer db.Close()
 
 	// open substate DB
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 

--- a/cmd/aida-vm-sdb/main.go
+++ b/cmd/aida-vm-sdb/main.go
@@ -22,9 +22,6 @@ var RunVMApp = cli.App{
 	Flags: []cli.Flag{
 		// AidaDb
 		&utils.AidaDbFlag,
-		&substate.SubstateDbFlag,
-		&utils.DeletionDbFlag,
-		&utils.UpdateDbFlag,
 
 		// StateDb
 		&utils.CarmenSchemaFlag,

--- a/cmd/aida-vm-sdb/vm-sdb/runvm.go
+++ b/cmd/aida-vm-sdb/vm-sdb/runvm.go
@@ -63,7 +63,7 @@ func RunVM(ctx *cli.Context) error {
 	defer utils.StopCPUProfile(cfg)
 
 	// iterate through subsets in sequence
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 

--- a/cmd/aida-vm/vm/replay.go
+++ b/cmd/aida-vm/vm/replay.go
@@ -38,7 +38,6 @@ var ReplayCommand = cli.Command{
 		&substate.SkipTransferTxsFlag,
 		&substate.SkipCallTxsFlag,
 		&substate.SkipCreateTxsFlag,
-		&substate.SubstateDbFlag,
 		&utils.ChainIDFlag,
 		&utils.ProfileEVMCallFlag,
 		&utils.MicroProfilingFlag,
@@ -49,6 +48,7 @@ var ReplayCommand = cli.Command{
 		&utils.OnlySuccessfulFlag,
 		&utils.CpuProfileFlag,
 		&utils.StateDbImplementationFlag,
+		&utils.AidaDbFlag,
 		&logger.LogLevelFlag,
 	},
 	Description: `
@@ -342,7 +342,7 @@ func replayAction(ctx *cli.Context) error {
 		vm.BasicBlockProfilingDB = cfg.ProfilingDbName
 	}
 
-	substate.SetSubstateDb(cfg.SubstateDb)
+	substate.SetSubstateDb(cfg.AidaDb)
 	substate.OpenSubstateDBReadOnly()
 	defer substate.CloseSubstateDB()
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -405,7 +405,7 @@ type Config struct {
 	BlockLength         uint64         // length of a block in number of transactions
 	BalanceRange        int64          // balance range for stochastic simulation/replay
 	CarmenSchema        int            // the current DB schema ID to use in Carmen
-	ChainID             ChainID            // Blockchain ID (mainnet: 250/testnet: 4002)
+	ChainID             ChainID        // Blockchain ID (mainnet: 250/testnet: 4002)
 	Cache               int            // Cache for StateDb or Priming
 	ContinueOnFailure   bool           // continue validation when an error detected
 	ContractNumber      int64          // number of contracts to create

--- a/utils/worldstate_update.go
+++ b/utils/worldstate_update.go
@@ -67,7 +67,7 @@ func GenerateWorldStateFromUpdateDB(cfg *Config, target uint64) (substate.Substa
 	ws := make(substate.SubstateAlloc)
 	blockPos := uint64(0)
 	// load pre-computed update-set from update-set db
-	db, err := substate.OpenUpdateDBReadOnly(cfg.UpdateDb)
+	db, err := substate.OpenUpdateDBReadOnly(cfg.AidaDb)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This PR removes usage of flags `--substatedb`, `--updatedb` and `--deletiondb` from `cmd/aida-*` directories

## Type of change

- [ ] Refactoring (changes that do NOT affect functionality)
