### PR TITLE
Refactor: use ProcessTx in aida-vm

### DIFF
--- a/block_processor/block_processor.go
+++ b/block_processor/block_processor.go
@@ -75,7 +75,7 @@ func (bp *BlockProcessor) ProcessFirstBlock(iter substate.SubstateIterator) erro
 	bp.db.BeginBlock(bp.block)
 
 	// process transaction
-	if err := utils.ProcessTx(bp.db, bp.cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
+	if _, err := utils.ProcessTx(bp.db, bp.cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
 		bp.log.Criticalf("\tFailed processing transaction: %v", err)
 		return err
 	}
@@ -181,7 +181,7 @@ func (bp *BlockProcessor) iterate(iter substate.SubstateIterator, actions Extens
 		}
 
 		// process transaction
-		if err = utils.ProcessTx(bp.db, bp.cfg, bp.tx.Block, bp.tx.Transaction, bp.tx.Substate); err != nil {
+		if _, err = utils.ProcessTx(bp.db, bp.cfg, bp.tx.Block, bp.tx.Transaction, bp.tx.Substate); err != nil {
 			bp.log.Criticalf("\tFailed processing transaction: %v", err)
 			return err
 		}

--- a/cmd/aida-profile/blockprofile/blockprofile.go
+++ b/cmd/aida-profile/blockprofile/blockprofile.go
@@ -154,7 +154,7 @@ func blockProfileAction(ctx *cli.Context) error {
 
 		// process current transaction
 		txTimer := time.Now()
-		if err = utils.ProcessTx(db, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
+		if _, err = utils.ProcessTx(db, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
 			log.Critical("\tFAILED executing transaction.")
 			return fmt.Errorf("execution failed; %v", err)
 		}

--- a/cmd/aida-sdb/trace/record.go
+++ b/cmd/aida-sdb/trace/record.go
@@ -116,7 +116,7 @@ func traceRecordAction(ctx *cli.Context) error {
 		statedb = state.MakeInMemoryStateDB(&tx.Substate.InputAlloc, tx.Block)
 		statedb = proxy.NewRecorderProxy(statedb, rCtx)
 
-		if err := utils.ProcessTx(statedb, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
+		if _, err := utils.ProcessTx(statedb, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
 			return fmt.Errorf("Failed to process block %v tx %v. %v", tx.Block, tx.Transaction, err)
 		}
 		if !cfg.Quiet {

--- a/cmd/aida-stochastic-sdb/stochastic/record.go
+++ b/cmd/aida-stochastic-sdb/stochastic/record.go
@@ -104,7 +104,7 @@ func stochasticRecordAction(ctx *cli.Context) error {
 		var statedb state.StateDB
 		statedb = state.MakeInMemoryStateDB(&tx.Substate.InputAlloc, tx.Block)
 		statedb = stochastic.NewEventProxy(statedb, &eventRegistry)
-		if err := utils.ProcessTx(statedb, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
+		if _, err := utils.ProcessTx(statedb, cfg, tx.Block, tx.Transaction, tx.Substate); err != nil {
 			return err
 		}
 

--- a/cmd/util-db/db/gen_deleted_accounts.go
+++ b/cmd/util-db/db/gen_deleted_accounts.go
@@ -88,7 +88,7 @@ func genDeletedAccountsTask(block uint64, tx int, recording *substate.Substate, 
 	//wrapper
 	statedb = proxy.NewDeletionProxy(statedb, ch, cfg.LogLevel)
 
-	err := utils.ProcessTx(statedb, cfg, block, tx, recording)
+	_, err := utils.ProcessTx(statedb, cfg, block, tx, recording)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
## Description

Refactor aida-vm by removing duplicated code. Reusing ProcessTx function in util to process transactions. 

## Type of change

Please delete options that are not relevant.

- [x] Refactoring (changes that do NOT affect functionality)
