### PR TITLE
Use carmen-schema 3 as default

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -105,7 +105,7 @@ var (
 	CarmenSchemaFlag = cli.IntFlag{
 		Name:  "carmen-schema",
 		Usage: "select the DB schema used by Carmen's current state DB",
-		Value: 0,
+		Value: 3,
 	}
 	ChainIDFlag = cli.IntFlag{
 		Name:  "chainid",


### PR DESCRIPTION
## Description

Change the default carmen schema to schema 3. This is to avoid using legacy schema in an experiment.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
