### PR TITLE
Fix and refactor reports

### DIFF
--- a/reports/block_processing.rmd
+++ b/reports/block_processing.rmd
@@ -16,11 +16,31 @@ params:
 library(ggplot2)
 library(dplyr)
 library(RSQLite)
+
+# open database
 con <- dbConnect(SQLite(), params$db)
+
+# load block and transaction tables into data frames
 blockData <- dbReadTable(con, 'blockProfile')
-reducedBlockData <- dbReadTable(con, 'aggregatedBlockProfile')
 txData <- dbReadTable(con, 'TxProfile')
-reducedTxData <- dbReadTable(con, 'aggregatedTxProfile')
+
+# compress block dataframe for each 100K blocks
+block_group_size <- 100000
+blockData$block_group <- blockData$block %/% block_group_size
+reducedBlockData <- blockData %>% group_by(block_group) %>% summarise(tBlock=mean(tBlock)/1e6,             # block time in ms
+                                                                      tCommit=mean(tCommit)/1e3,           # commit time in us
+                                                                      numTx=mean(numTx),                   # average number of transactions
+                                                                      gasBlock=mean(gasBlock)/1e6,         # in MGas
+                                                                      gps=sum(gasBlock)/(sum(tBlock)/1e3), # gas rate in MGas/s
+                                                                      tps=sum(numTx)/(sum(tBlock)/1e9))    # transactions per second
+reducedBlockData$block <- reducedBlockData$block_group * block_group_size
+
+# compress transactional data for each 1M transactions
+tx_group_size <- 1000000
+txData$tx_group <- 1:nrow(txData) %/% tx_group_size
+reducedTxData <- txData %>% group_by(tx_group) %>% summarise(duration=mean(duration)/1e3,  # duration in us
+                                                             gas=mean(gas)/1e3)            # gas in KGas
+reducedTxData$tx <- reducedTxData$tx_group * tx_group_size
 dbDisconnect(con)
 ```
 
@@ -35,8 +55,10 @@ The data set for this experiment is stored in the database `r params$db`.
 ## 2. Block Processing Time
 
 The experiment was conducted for the block range from **`r format(min(blockData$block),big.mark=",")`**  to **`r format(max(blockData$block),big.mark=",")`**.
-The block range contains **`r format(sum(blockData$numTx), big.mark=",")`** transactions. We have `r format((max(blockData$block)-min(blockData$block)+1)-nrow(blockData), big.mark=",")` empty blocks.
-The accumulated block processing time is **`r format(sum(blockData$tBlock)/(1e9*3600), digits=3, nsmall=2)`** hours. The block rate is `r format(1e9*(max(blockData$block)-min(blockData$block)+1)/sum(blockData$tBlock), digits=3, nsmall=2)` blocks per second.
+The block range contains **`r format(sum(blockData$numTx), big.mark=",")`** transactions.
+We have **`r format((max(blockData$block)-min(blockData$block)+1)-nrow(blockData), big.mark=",")`** empty blocks.
+The accumulated block processing time is **`r format(sum(blockData$tBlock)/(1e9*3600), digits=3, nsmall=2)`** hours.
+The block rate is `r format(1e9*(max(blockData$block)-min(blockData$block)+1)/sum(blockData$tBlock), digits=3, nsmall=2)` blocks per second.
 The average block execution time is `r format(mean(blockData$tBlock)/1e6, digits=3, nsmall=3)` milliseconds, with a minimum of `r format(min(blockData$tBlock)/1e3, digits=3, nsmall=3)` microseconds and a maximum of `r format(max(blockData$tBlock)/1e9, digits=3, nsmall=3)` seconds.
 The smoothened trend line for the block time (in milliseconds) is shown below. In the figure, we aggregated the block time for all 100K blocks shown as points.
 
@@ -62,20 +84,7 @@ reducedBlockData %>%
   labs(x="Block Height", y="Transactions Per Second", title="Transactions per Second")
 ```
 
-## 4. Gas Consumption of Blocks
-
-The average gas consumption of a block is `r format(mean(blockData$gasBlock)/1e6, digits=3, nsmall=3)` MGas, with a minimum of `r format(min(blockData$gasBlock)/1e3, digits=3, nsmall=3)` KGas and a maximum of `r format(max(blockData$gasBlock)/1e6, digits=3, nsmall=3)` MGas.
-The smoothened trend line of gas consumption is shown in the figure below. In the figure, we aggregate the gas consumption for all 100K blocks as points.
-
-```{r, echo = FALSE, message=FALSE}
-reducedBlockData %>%
-  ggplot(aes(x = block, y = gasBlock)) +
-  geom_smooth(color = "tomato") +
-  geom_point(alpha=0.3) +
-  labs(x="Block Height", y="MGas", title="Gas Consumption of Blocks")
-```
-
-## 5. Block Gas Rate
+## 4. Block Gas Rate
 
 We achieve a gas rate of `r format(1e3*sum(blockData$gas)/sum(blockData$tBlock), digits=3, nsmall=3)` MGas per second.
 The smoothened trend line of the gas rate for each 100K blocks is shown in the figure below as points.
@@ -88,7 +97,7 @@ reducedBlockData %>%
   labs(x="Block Height", y="MGas Per Second", title="Throughput in MGas per Second")
 ```
 
-## 6. Commit Time
+## 5. Commit Time
 
 The average commit time of a block is `r format(mean(blockData$tCommit)/1e3, digits=3, nsmall=3)` microseconds, with a minimum of `r format(min(blockData$tCommit), digits=3, nsmall=3)` nanoseconds and a maximum of `r format(max(blockData$tCommit)/1e9, digits=3, nsmall=3)` seconds.
 The smoothened trend line of the commit time of a block is shown below. In the figure, we aggregated the commit time in microseconds for all 100K blocks shown as points.
@@ -101,38 +110,7 @@ reducedBlockData %>%
   labs(x="Block Height", y="Commit Time (us)", title="Commit Time")
 ```
 
-## 7. Number of Transactions per Block
-
-We have an average  of `r format(mean(blockData$numTx), digits=3, nsmall=3)` transactions per block.
-The smallest number of transactions in a block is `r min(blockData$numTx)`, and the largest number of transactions in a block is `r max(blockData$numTx)`.
-The histogram of the number of transactions in a block is shown below:
-
-```{r, echo = FALSE, message=FALSE}
-hist(blockData$numTx, freq=FALSE, main="Number of Transaction Distribution", xlab="Number of Transactions", col="lightblue1"); rug(blockData$numTx)
-abline(v=mean(blockData$numTx), col="dodgerblue3", lty=2, lwd=2)
-```
-
-The smoothened trend line for the number of transactions in a block is shown below. In this figure, we aggregated the number of transactions in a block for 100K blocks shown as points.
-
-```{r, echo=FALSE, message=FALSE}
-reducedBlockData %>%
-  ggplot(aes(x = block, y = numTx)) +
-  geom_smooth(color = "tomato") +
-  geom_point(alpha=0.3) +
-  labs(x="Block Height", y="Number of Transactions", title="Number of Transactions per Block")
-```
-
-The numbers and the figure above include maintenance transactions as well (SFC, etc.).
-
-Transactions are either wallet transfers, smart contract executions, smart contract creations, and maintenance contracts.
-```{r, echo=FALSE, message=FALSE}
-txTypeDf <- txData %>% count(txType)
-txTypeDf$label <- c("Wallet Transfer", "Contract Creation", "Contract Execution", "Maintenance Contract")
-txTypeDf$percent <- round(100 * txTypeDf$n / sum(txTypeDf$n), 1)
-pie(txTypeDf$n, labels = paste0(txTypeDf$label, " (", txTypeDf$percent, "%)"), main ="Transaction Types")
-```
-
-## 8. Transaction Processing Time
+## 6. Transaction Processing Time
 
 The average transaction processing time is `r format(mean(txData$duration)/1e3, digits=3, nsmall=3)` microseconds, with a minimum of `r format(min(txData$duration)/1e3, digits=3, nsmall=3)` microseconds and a maximum of `r format(max(txData$duration)/1e9, digits=3, nsmall=3)` seconds.
 The smoothened trend line of the transaction processing time is shown in the figure below. In the figure, we aggregated the transaction processing time for one million transactions shown as points.
@@ -144,20 +122,5 @@ reducedTxData %>%
   geom_smooth(color = "tomato") +
   geom_point(alpha=0.3) +
   labs(x="Transactions", y="Processing Time (us)", title="Transaction Processing Time")
-```
-
-
-## 9. Gas Consumption of Transactions
-
-The average gas consumption of a transaction is `r format(mean(txData$gas)/1e3, digits=3, nsmall=3)` KGas, with a minimum gas consumption of `r format(min(txData$gas)/1e3, digits=3, nsmall=3)` KGas and a maximum gas consumption of `r format(max(txData$gas)/1e6, digits=3, nsmall=3)` MGas.
-The smoothened trend line of gas consumption is shown below. In the figure, we aggregated the gas consumption for one million transactions shown as points.
-The numbers and the figure below include maintenance transactions as well (SFC, etc.).
-
-```{r, echo=FALSE, message=FALSE}
-reducedTxData %>%
-  ggplot(aes(x = tx, y = gas)) +
-  geom_smooth(color = "tomato") +
-  geom_point(alpha=0.3) +
-  labs(x="Transactions", y="KGas", title="Gas Consumption of Transactions")
 ```
 

--- a/reports/mainnet_report.rmd
+++ b/reports/mainnet_report.rmd
@@ -1,0 +1,142 @@
+---
+title: "Mainnet Report"
+date: "`r Sys.Date()`"
+params:
+  HwInfo: (Hardware Info)
+  OsInfo: (OS Info)
+  Machine: (Machine Info)
+  GoInfo: (GO Info)
+  GitHash: (GithubKey)
+  StateDB: (StateDB)
+  VM: (VM)
+  db: ./test.db
+---
+
+```{r, include = FALSE}
+library(ggplot2)
+library(dplyr)
+library(RSQLite)
+
+# open database
+con <- dbConnect(SQLite(), params$db)
+
+# load block and transaction tables into data frames
+blockData <- dbReadTable(con, 'blockProfile')
+txData <- dbReadTable(con, 'TxProfile')
+
+# compress block dataframe for each 100K blocks
+block_group_size <- 100000
+blockData$block_group <- blockData$block %/% block_group_size
+reducedBlockData <- blockData %>% group_by(block_group) %>% summarise(numTx=mean(numTx),           # average number of transactions
+                                                                      gasBlock=mean(gasBlock)/1e6) # in MGas
+reducedBlockData$block <- reducedBlockData$block_group * block_group_size
+
+# compress transactional data for each 1M transactions
+tx_group_size <- 1000000
+txData$tx_group <- 1:nrow(txData) %/% tx_group_size
+reducedTxData <- txData %>% group_by(tx_group) %>% summarise(duration=mean(duration)/1e3,  # duration in us
+                                                             gas=mean(gas)/1e3)            # gas in KGas
+reducedTxData$tx <- reducedTxData$tx_group * tx_group_size
+dbDisconnect(con)
+```
+
+The following report characterises the mainnet including charts related to block and transaction complexity.
+The report covers the block range from **`r format(min(blockData$block),big.mark=",")`**  to **`r format(max(blockData$block),big.mark=",")`**.
+The block range contains **`r format(sum(blockData$numTx), big.mark=",")`** transactions.
+We have **`r format((max(blockData$block)-min(blockData$block)+1)-nrow(blockData), big.mark=",")`** empty blocks.
+
+## 1. Number of Transactions per Block
+
+We have an average  of `r format(mean(blockData$numTx), digits=3, nsmall=3)` transactions per block.
+The smallest number of transactions in a block is `r min(blockData$numTx)`, and the largest number of transactions in a block is `r max(blockData$numTx)`.
+The histogram of the number of transactions in a block is shown below:
+
+```{r, echo = FALSE, message=FALSE}
+hist(blockData$numTx, freq=FALSE, main="Number of Transaction Distribution", xlab="Number of Transactions", col="lightblue1"); rug(blockData$numTx)
+abline(v=mean(blockData$numTx), col="dodgerblue3", lty=2, lwd=2)
+```
+
+The smoothened trend line for the number of transactions in a block is shown below. In this figure, we aggregated the number of transactions in a block for 100K blocks shown as points.
+
+```{r, echo=FALSE, message=FALSE}
+reducedBlockData %>%
+  ggplot(aes(x = block, y = numTx)) +
+  geom_smooth(color = "tomato") +
+  geom_point(alpha=0.3) +
+  labs(x="Block Height", y="Number of Transactions", title="Number of Transactions per Block")
+```
+
+The numbers and the figure above include maintenance transactions as well (SFC, etc.).
+
+Transactions are either wallet transfers, smart contract executions, smart contract creations, and maintenance contracts.
+```{r, echo=FALSE, message=FALSE}
+txTypeDf <- txData %>% count(txType)
+txTypeDf$label <- c("Wallet Transfer", "Contract Creation", "Contract Execution", "Maintenance Contract")
+txTypeDf$percent <- round(100 * txTypeDf$n / sum(txTypeDf$n), 1)
+pie(txTypeDf$n, labels = paste0(txTypeDf$label, " (", txTypeDf$percent, "%)"), main ="Transaction Types")
+```
+
+## 2. Gas Consumption of Blocks
+
+The average gas consumption of a block is `r format(mean(blockData$gasBlock)/1e6, digits=3, nsmall=3)` MGas, with a minimum of `r format(min(blockData$gasBlock)/1e3, digits=3, nsmall=3)` KGas and a maximum of `r format(max(blockData$gasBlock)/1e6, digits=3, nsmall=3)` MGas.
+The smoothened trend line of gas consumption is shown in the figure below. In the figure, we aggregate the gas consumption for all 100K blocks as points.
+
+```{r, echo = FALSE, message=FALSE}
+reducedBlockData %>%
+  ggplot(aes(x = block, y = gasBlock)) +
+  geom_smooth(color = "tomato") +
+  geom_point(alpha=0.3) +
+  labs(x="Block Height", y="MGas", title="Gas Consumption of Blocks")
+```
+
+## 3. Gas Consumption of Transactions
+
+The average gas consumption of a transaction is `r format(mean(txData$gas)/1e3, digits=3, nsmall=3)` KGas, with a minimum gas consumption of `r format(min(txData$gas)/1e3, digits=3, nsmall=3)` KGas and a maximum gas consumption of `r format(max(txData$gas)/1e6, digits=3, nsmall=3)` MGas.
+
+The gas consumption based on the transaction type is shown below:
+
+```{r, echo=FALSE, message=FALSE}
+txGasTypeDf <- txData %>% group_by(txType) %>% summarize(gas=sum(gas))
+txGasTypeDf$label <- c("Wallet Transfer", "Contract Creation", "Contract Execution", "Maintenance Contract")
+txGasTypeDf$percent <- round(100 * txGasTypeDf$gas / sum(txGasTypeDf$gas), 1)
+pie(txGasTypeDf$gas, labels = paste0(txGasTypeDf$label, " (", txGasTypeDf$percent, "%)"), main ="Gas Consumption of Transaction Types")
+```
+
+The smoothened trend line of gas consumption over all transaction is shown below. In the figure, we aggregate the gas consumption for one million transactions shown as points. The numbers and the figure below include maintenance transactions as well (SFC, etc.).
+
+```{r, echo=FALSE, message=FALSE}
+reducedTxData %>%
+  ggplot(aes(x = tx, y = gas)) +
+  geom_smooth(color = "tomato") +
+  geom_point(alpha=0.3) +
+  labs(x="Transactions", y="KGas", title="Gas Consumption of Transactions")
+```
+
+## 4. Gas Consumption for Transaction Types
+### Wallet Transfers
+
+```{r, echo=FALSE, message=FALSE}
+WalletTransferDf <- txData %>% filter(txType == 0)
+hist(WalletTransferDf$gas, main="Histogram for Wallet Transfers", freq=FALSE, xlab="Gas Consumption", col="lightblue1")
+```
+
+### Contract Creation 
+
+```{r, echo=FALSE, message=FALSE}
+ContractCreationDf <- txData %>% filter(txType == 1)
+hist(ContractCreationDf$gas, main="Histogram for Contract Creations", freq=FALSE, xlab="Gas Consumption", col="lightblue1")
+```
+
+### Contract Execution
+
+```{r, echo=FALSE, message=FALSE}
+ContractExecutionDf <- txData %>% filter(txType == 2)
+hist(ContractExecutionDf$gas, main="Histogram for Contract Executions", freq=FALSE, xlab="Gas Consumption", col="lightblue1")
+```
+
+### Maintenance Contract
+
+```{r, echo=FALSE, message=FALSE}
+MaintenanceContractDf <- txData %>% filter(txType == 3)
+hist(MaintenanceContractDf$gas, main="Histogram for Maintenance Contract (SFC, etc.)", freq=FALSE, xlab="Gas Consumption", col="lightblue1")
+```

--- a/reports/parallel_experiment.rmd
+++ b/reports/parallel_experiment.rmd
@@ -18,8 +18,17 @@ library(dplyr)
 library(RSQLite)
 con <- dbConnect(SQLite(), params$db)
 data <- dbReadTable(con, 'blockProfile')
-reducedData <- dbReadTable(con, 'aggregatedBlockProfile')
+
+# Find parallelisable blocks whose speedup is greater than 1.0
 parallelisable <- data %>% filter(speedup > 1.0)
+
+# Compress data to 100K blocks for visualisation
+group_size <- 100000
+data$block_group <- data$block %/% group_size
+reducedData <- data %>% group_by(block_group)  %>% summarise(speedup=exp(mean(log(speedup))))
+reducedData$block <- reducedData$block_group * group_size
+
+# close DB
 dbDisconnect(con)
 ```
 
@@ -58,8 +67,8 @@ hist(parallelisable$speedup, main="Speedup Distribution without Sequential Block
 lines(density(parallelisable$speedup), col="dodgerblue3", lwd=2)
 ```
 
-The following figure shows the speedup over block height.
-For this distribution, we did not filter the sequential blocks, i.e., all blocks are included for the following timeline:
+The following figure shows the speedup over block height. Points are the geometric mean of 100K aggregated blocks,
+for which we did not filter the sequential blocks.
 
 ```{r, echo = FALSE, message=FALSE}
 reducedData %>%
@@ -87,15 +96,17 @@ lines(density(parallelisable$utilisation), col="dodgerblue3", lwd=2)
 
 ## 4. Linear Prediction Model
 
-```{r, include = FALSE}
-lmSequentialTx <- lm(tSequential~numTx, data=data)
-lmCriticalTx <- lm(tCritical~numTx, data=data)
+```{r, message=FALSE, echo=FALSE}
+data$tSequentialUSec <- data$tSequential / 1e3
+data$tCriticalUSec <- data$tCritical / 1e3
+lmSequentialTx <- lm(tSequentialUSec~numTx, data=data)
+lmCriticalTx <- lm(tCriticalUSec~numTx, data=data)
 coeffCriticalTx <- lmCriticalTx$coefficients
 coeffSequentialTx <- lmSequentialTx$coefficients
-a1 <- coeffSequentialTx["numTx"]
-b1 <- coeffCriticalTx["numTx"]
-a0 <- coeffSequentialTx["(Intercept)"]
-b0 <- coeffCriticalTx["(Intercept)"]
+a1 <- unname(coeffSequentialTx["numTx"])
+b1 <- unname(coeffCriticalTx["numTx"])
+a0 <- unname(coeffSequentialTx["(Intercept)"])
+b0 <- unname(coeffCriticalTx["(Intercept)"])
 tCommit <- mean(data$tCommit)
 speedup <-  exp(mean(log(data$speedup)))
 tn <- function (s) {
@@ -103,12 +114,13 @@ tn <- function (s) {
 }
 ```
 
-The linear speedup prediction model estimates a maximum speedup of `r format(a1/b1, digits=4)` assuming an infinite number
+The linear speedup prediction model estimates a maximum theoretical speedup of `r format(a1/b1, digits=4)` assuming an infinite number
 of processors. The underlying assumption of the prediction model is that the degree of parallisation (ratio of sequential
-transaction execution time and critical path) does not change with an increasing number of transactions. We have following
-functions for $t_{\textit{sequential}}(n)=$ `r a1/1e9` $n +$ `r a0/1e9` and $t_{\textit{criticial}}(n)=$ `r b1/1e9` $n +$ `r b0/1e9`.
+transaction execution time and critical path) does not change with an increasing number of transactions in a block. We have
+functions for $t_{\textit{sequential}}(n)=$ `r a1` $n +$ `r a0` and $t_{\textit{criticial}}(n)=$ `r b1` $n +$ `r b0`
+where $n$ is the number of transactions. The units of the functions are in microseconds.
 
-The number of transactions required for a given speedup is shown in the figure below,
+The figure below shows the number of transactions required for achieving a given speedup between the speedup from the clairvoyance experiment and the five percent from the maximum theoretical speedup. 
 
 ```{r, echo=FALSE, message=TRUE}
 # check that fitting parameters are positive for plotting
@@ -127,4 +139,3 @@ if (a1 >= 0 && a0 >= 0 && b1 >= 0 && b0 >= 0) {
 ```
 
 Note that the number of transactions grows infinitely reaching the maximum speedup of `r format(a1/b1, digits=4)`.
-


### PR DESCRIPTION
## Description
This PR fixes a number overflow issue in the parallel report (the linear regression was in nanoseconds and caused an overflow), splits the block processing report into a block processing report and a mainnet report, and removes the SQLITE  pre-processing step (the aggregation is performed in the R scripts).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
