### PR TITLE
Support profile extension in tx processor

### DIFF
--- a/cmd/aida-vm/vm/replay.go
+++ b/cmd/aida-vm/vm/replay.go
@@ -44,6 +44,7 @@ last block of the inclusive range of blocks to replay transactions.`,
 
 func Replay(ctx *cli.Context) error {
 	actions := tx_processor.NewExtensionList([]tx_processor.ProcessorExtensions{
+		tx_processor.NewProfileExtension(),
 		tx_processor.NewMicroProfileExtension(),
 		tx_processor.NewBasicProfileExtension(),
 	})

--- a/tx_processor/profile_extension.go
+++ b/tx_processor/profile_extension.go
@@ -1,0 +1,53 @@
+package tx_processor
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Aida/utils"
+)
+
+// ProfileExtension provide the logging action for tx processing
+type ProfileExtension struct {
+	ProcessorExtensions
+}
+
+// NewProfileExtension creates a new logging action for tx processing.
+func NewProfileExtension() *ProfileExtension {
+	return &ProfileExtension{}
+}
+
+// Init opens the CPU profiler if specied in the cli.
+func (ext *ProfileExtension) Init(bp *TxProcessor) error {
+	// CPU profiling (if enabled)
+	if err := utils.StartCPUProfile(bp.cfg); err != nil {
+		return fmt.Errorf("failed to open CPU profiler; %v", err)
+	}
+	return nil
+}
+
+func (ext *ProfileExtension) PostPrepare(bp *TxProcessor) error {
+	return nil
+}
+
+func (ext *ProfileExtension) PostBlock(bp *TxProcessor) error {
+	return nil
+}
+
+func (ext *ProfileExtension) PostTransaction(bp *TxProcessor) error {
+	return nil
+}
+
+// PostProcessing issues a memory profile report.
+func (ext *ProfileExtension) PostProcessing(bp *TxProcessor) error {
+	// write memory profile
+	if err := utils.StartMemoryProfile(bp.cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Exit stops CPU profiling.
+func (ext *ProfileExtension) Exit(bp *TxProcessor) error {
+	utils.StopCPUProfile(bp.cfg)
+	return nil
+}


### PR DESCRIPTION
## Description

Add support of cpuprofile and memory profile to `aida-vm`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
