### PR TITLE
Add Event synchronization utility

### DIFF
--- a/utils/event.go
+++ b/utils/event.go
@@ -1,0 +1,56 @@
+package utils
+
+// Event is a synchronization primitive for signaling the occurrence of
+// a one-time event. The life cycle of each event is divided in two
+// phases: the time before and the time after the event.
+//
+//	event := MakeEvent()
+//	// The event has not yet occurred
+//	event.Signal()
+//	// The event has occurred, any further signaling has no effect
+//
+// Signaling and checking whether the event has occurred is thread safe.
+// Furthermore, goroutines may wait for the occurrence of the event through
+// a provided channel.
+type Event interface {
+	// HasHappened returns whether the event has already occurred or not.
+	HasHappened() bool
+	// Wait provides a channel which will be closed once the event occurred.
+	Wait() <-chan struct{}
+	// Signal triggers the event.
+	Signal()
+}
+
+func MakeEvent() Event {
+	return event{make(chan struct{})}
+}
+
+type event struct {
+	channel chan struct{}
+}
+
+func (e event) HasHappened() bool {
+	// Tests whether the event has already happened by
+	// attempting to read from the owned channel.
+	select {
+	case <-e.channel:
+		return true
+	default:
+		return false
+	}
+}
+
+func (e event) Wait() <-chan struct{} {
+	return e.channel
+}
+
+func (e event) Signal() {
+	// Atomically checks whether the channel is already closed and
+	// closes the channel if this is not the case.
+	select {
+	case <-e.channel:
+		return
+	default:
+		close(e.channel)
+	}
+}

--- a/utils/event_test.go
+++ b/utils/event_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import "testing"
+
+func TestEvent_IsNotTriggeredAtCreationTime(t *testing.T) {
+	event := MakeEvent()
+	if event.HasHappened() {
+		t.Errorf("fresh event should not be marked as happened")
+	}
+}
+
+func TestEvent_SignalingTheEventMarksItAsHappened(t *testing.T) {
+	event := MakeEvent()
+	if event.HasHappened() {
+		t.Errorf("fresh event should not be marked as happened")
+	}
+	event.Signal()
+	if !event.HasHappened() {
+		t.Errorf("a signaled event should be reported as happened")
+	}
+}
+
+func TestEvent_EventsCanBeSignaledMultipleTimes(t *testing.T) {
+	event := MakeEvent()
+	for i := 0; i < 10; i++ {
+		event.Signal()
+		if !event.HasHappened() {
+			t.Errorf("a signaled event should be reported as happened")
+		}
+	}
+}
+
+func TestEvent_SignalingAnEventReleasesWaitingGoRoutines(t *testing.T) {
+	event := MakeEvent()
+
+	i := 0
+	running := make(chan bool)
+	done := make(chan bool)
+	go func() {
+		i = 1
+		close(running)
+		<-event.Wait()
+		i = 2
+		close(done)
+	}()
+
+	<-running
+	if i != 1 {
+		t.Fatalf("test runner not properly started")
+	}
+	event.Signal()
+	<-done
+	if i != 2 {
+		t.Fatalf("waiting goroutine not released")
+	}
+}


### PR DESCRIPTION
## Description

Adds a synchronization utility for single events. This can be used, for instance, for abort signals.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
