### PR TITLE
Add extension calling Preparing StateDBs before each transaction

### DIFF
--- a/executor/extension/state_prepper.go
+++ b/executor/extension/state_prepper.go
@@ -1,0 +1,22 @@
+package extension
+
+import "github.com/Fantom-foundation/Aida/executor"
+
+// MakeStateDbPreparator creates an executor extension calling PrepareSubstate on
+// an optional StateDB instance before each transaction of an execution. Its main
+// purpose is to support Aida's in-memory DB implementation by feeding it substate
+// information before each transaction in tools like `aida-vm-sdb`.
+func MakeStateDbPreparator() executor.Extension {
+	return &statePreparator{}
+}
+
+type statePreparator struct {
+	NilExtension
+}
+
+func (e *statePreparator) PreTransaction(state executor.State) error {
+	if state.State != nil && state.Substate != nil {
+		state.State.PrepareSubstate(&state.Substate.InputAlloc, uint64(state.Block))
+	}
+	return nil
+}

--- a/executor/extension/state_prepper_test.go
+++ b/executor/extension/state_prepper_test.go
@@ -1,0 +1,48 @@
+package extension
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Aida/executor"
+	"github.com/Fantom-foundation/Aida/state"
+	substate "github.com/Fantom-foundation/Substate"
+	"github.com/ethereum/go-ethereum/common"
+	"go.uber.org/mock/gomock"
+)
+
+func TestStatePrepper_PreparesStateBeforeEachTransaction(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := state.NewMockStateDB(ctrl)
+
+	allocA := substate.SubstateAlloc{common.Address{1}: nil}
+	allocB := substate.SubstateAlloc{common.Address{2}: nil}
+
+	gomock.InOrder(
+		db.EXPECT().PrepareSubstate(&allocA, uint64(5)),
+		db.EXPECT().PrepareSubstate(&allocB, uint64(7)),
+	)
+
+	prepper := MakeStateDbPreparator()
+
+	prepper.PreTransaction(executor.State{
+		Block:    5,
+		State:    db,
+		Substate: &substate.Substate{InputAlloc: allocA},
+	})
+
+	prepper.PreTransaction(executor.State{
+		Block:    7,
+		State:    db,
+		Substate: &substate.Substate{InputAlloc: allocB},
+	})
+}
+
+func TestStatePrepper_DoesNotCrashOnMissingStateOrSubstate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := state.NewMockStateDB(ctrl)
+
+	prepper := MakeStateDbPreparator()
+	prepper.PreTransaction(executor.State{Block: 5})                                 // misses both
+	prepper.PreTransaction(executor.State{Block: 5, State: db})                      // misses the substate
+	prepper.PreTransaction(executor.State{Block: 5, Substate: &substate.Substate{}}) // misses the state
+}

--- a/state/state.go
+++ b/state/state.go
@@ -121,7 +121,7 @@ type StateDB interface {
 
 	// Used to initiate the state DB for the next transaction.
 	// This is mainly for development purposes to support in-memory DB implementations.
-	PrepareSubstate(*substate.SubstateAlloc, uint64)
+	PrepareSubstate(substate *substate.SubstateAlloc, block uint64)
 
 	// Used to retrieve the shadow DB (if there is one) for testing purposes so that
 	// the shadow DB can be used to query state directly. If there is no shadow DB,


### PR DESCRIPTION
## Description

Adds an extension feeding substate information to the StateDB before each transaction. This is required to support Aida's in-memory DB.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
