### PR TITLE
Apply minor fixes in progress logger and tracker

### DIFF
--- a/cmd/aida-vm-sdb/main.go
+++ b/cmd/aida-vm-sdb/main.go
@@ -71,6 +71,8 @@ var RunVMApp = cli.App{
 		//&utils.ValidateWorldStateFlag,
 		&utils.ValidateFlag,
 		&logger.LogLevelFlag,
+		&utils.NoHeartbeatLoggingFlag,
+		&utils.TrackProgressFlag,
 	},
 	Description: `
 The aida-vm-sdb command requires two arguments: <blockNumFirst> <blockNumLast>

--- a/cmd/aida-vm-sdb/run_vm_sdb.go
+++ b/cmd/aida-vm-sdb/run_vm_sdb.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/Fantom-foundation/Aida/executor"
 	"github.com/Fantom-foundation/Aida/executor/extension"
 	"github.com/Fantom-foundation/Aida/state"
@@ -56,7 +58,8 @@ func run(config *utils.Config, provider executor.SubstateProvider, stateDb state
 		[]executor.Extension{
 			extension.MakeCpuProfiler(config),
 			extension.MakeVirtualMachineStatisticsPrinter(config),
-			extension.MakeProgressLogger(config, 100),
+			extension.MakeProgressLogger(config, 15*time.Second),
+			extension.MakeProgressTracker(config, 100_000),
 			extension.MakeStateDbPreparator(),
 			extension.MakeTxValidator(config),
 			extension.MakeStateHashValidator(config),

--- a/executor/matcher.go
+++ b/executor/matcher.go
@@ -34,6 +34,16 @@ func WithSubstate(substate *substate.Substate) gomock.Matcher {
 	return withSubstate{substate}
 }
 
+// Lt matches every value less than the given limit.
+func Lt(limit float64) gomock.Matcher {
+	return lt{limit}
+}
+
+// Gt matches every value greater than the given limit.
+func Gt(limit float64) gomock.Matcher {
+	return gt{limit}
+}
+
 // ----------------------------------------------------------------------------
 
 type atBlock struct {
@@ -104,4 +114,30 @@ func (m withSubstate) Matches(value any) bool {
 
 func (m withSubstate) String() string {
 	return fmt.Sprintf("with substate %p", m.substate)
+}
+
+type lt struct {
+	limit float64
+}
+
+func (m lt) Matches(value any) bool {
+	v, ok := value.(float64)
+	return ok && v < m.limit
+}
+
+func (m lt) String() string {
+	return fmt.Sprintf("less than %v", m.limit)
+}
+
+type gt struct {
+	limit float64
+}
+
+func (m gt) Matches(value any) bool {
+	v, ok := value.(float64)
+	return ok && v > m.limit
+}
+
+func (m gt) String() string {
+	return fmt.Sprintf("greater than %v", m.limit)
 }


### PR DESCRIPTION
## Description

Some minor fixes in the logger:
 - fixed the integration in `aida-vm-sdb`
 - fixed that the progress logger was printing the same value for Tx/s and Gas/s
 - corrected the output of the progress logger to use MGas/s instead of Gas/s
 - added test coverage for the reported transaction and gas rates
 - some minor code cleanups

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
