### PR TITLE
Renew connection between `aida-vm-sdb` and the throughput eval script

### DIFF
--- a/executor/extension/progress_tracker_test.go
+++ b/executor/extension/progress_tracker_test.go
@@ -1,6 +1,8 @@
 package extension
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -42,64 +44,54 @@ func TestProgressTrackerExtension_LoggingHappens(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		// scheduled logging
 		db.EXPECT().GetMemoryUsage(),
 		log.EXPECT().Noticef(progressTrackerReportFormat,
 			6, int64(0), uint64(0),
 			MatchRate(gomock.All(executor.Gt(7), executor.Lt(9)), "txRate"),
 			MatchRate(gomock.All(executor.Gt(700), executor.Lt(900)), "gasRate"),
+			MatchRate(gomock.All(executor.Gt(7), executor.Lt(9)), "txRate"),
+			MatchRate(gomock.All(executor.Gt(700), executor.Lt(900)), "gasRate"),
+		),
+		db.EXPECT().GetMemoryUsage(),
+		log.EXPECT().Noticef(progressTrackerReportFormat,
+			8, int64(0), uint64(0),
+			MatchRate(gomock.All(executor.Gt(1), executor.Lt(2)), "txRate"),
+			MatchRate(gomock.All(executor.Gt(180), executor.Lt(220)), "gasRate"),
+			MatchRate(gomock.All(executor.Gt(4), executor.Lt(6)), "txRate"),
+			MatchRate(gomock.All(executor.Gt(400), executor.Lt(600)), "gasRate"),
 		),
 	)
 
-	ext.PreRun(executor.State{
-		Block:       4,
-		Transaction: 0,
-		State:       db,
-		Substate:    s,
-	})
+	ext.PreRun(executor.State{})
 
 	// first processed block
-	ext.PostTransaction(executor.State{
-		Block:       4,
-		Transaction: 0,
-		State:       db,
-		Substate:    s,
-	})
-	ext.PostTransaction(executor.State{
-		Block:       4,
-		Transaction: 1,
-		State:       db,
-		Substate:    s,
-	})
+	ext.PostTransaction(executor.State{Substate: s})
+	ext.PostTransaction(executor.State{Substate: s})
 	ext.PostBlock(executor.State{
-		Block:       5,
-		Transaction: 0,
-		State:       db,
-		Substate:    s,
+		Block:    5,
+		State:    db,
+		Substate: s,
 	})
 
 	time.Sleep(500 * time.Millisecond)
 
 	// second processed block
-	ext.PostTransaction(executor.State{
-		Block:       5,
-		Transaction: 0,
-		State:       db,
-		Substate:    s,
-	})
-	ext.PostTransaction(executor.State{
-		Block:       5,
-		Transaction: 1,
-		State:       db,
-		Substate:    s,
-	})
+	ext.PostTransaction(executor.State{Substate: s})
+	ext.PostTransaction(executor.State{Substate: s})
 	ext.PostBlock(executor.State{
-		Block:       6,
-		Transaction: 0,
-		State:       db,
-		Substate:    s,
+		Block:    6,
+		State:    db,
+		Substate: s,
 	})
 
+	time.Sleep(500 * time.Millisecond)
+
+	ext.PostTransaction(executor.State{Substate: s})
+	ext.PostBlock(executor.State{
+		Block:    8,
+		State:    db,
+		Substate: s,
+	})
 }
 
 func TestProgressTrackerExtension_FirstLoggingIsIgnored(t *testing.T) {
@@ -144,5 +136,13 @@ func TestProgressTrackerExtension_FirstLoggingIsIgnored(t *testing.T) {
 		State:       db,
 		Substate:    s,
 	})
+}
 
+func Test_LoggingFormatMatchesRubyScript(t *testing.T) {
+	// NOTE: keep this in sync with the pattern used by scripts/run_throughput_eval.rb
+	pattern := `Track: block \d+, memory \d+, disk \d+, interval_tx_rate \d+.\d*, interval_gas_rate \d+.\d*, overall_tx_rate \d+.\d*, overall_gas_rate \d+.\d*`
+	example := fmt.Sprintf(progressTrackerReportFormat, 1, 2, 3, 4.5, 6.7, 8.9, 0.1)
+	if match, err := regexp.Match(pattern, []byte(example)); !match || err != nil {
+		t.Errorf("Logging format '%v' does not match required format '%v'; err %v", example, pattern, err)
+	}
 }


### PR DESCRIPTION
## Description

Renews the connection between `aida-vm-sdb` and the evaluation script by
 - updating the script to enable progress tracking
 - extending the collected output to cover interval and overall performance data

## Type of change

- [x] New feature (non-breaking change which adds functionality)
