### PR TITLE
Remove aida-db requirement from flags

### DIFF
--- a/cmd/aida-stochastic-sdb/stochastic/replay.go
+++ b/cmd/aida-stochastic-sdb/stochastic/replay.go
@@ -39,7 +39,6 @@ var StochasticReplayCommand = cli.Command{
 		&utils.TraceFlag,
 		&utils.ShadowDbImplementationFlag,
 		&utils.ShadowDbVariantFlag,
-		&utils.AidaDbFlag,
 		&logger.LogLevelFlag,
 	},
 	Description: `


### PR DESCRIPTION
## Description

`aida-stochastic-sdb` tool does not require substate as its input. Thus it doesn't use Aida-Db. This PR remote the requirement of aida-db flag.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)