### PR TITLE
Fix block height off by one

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -231,7 +231,7 @@ func (e *executor) runSequential(params Params, processor Processor, extensions 
 		if err := signalPostBlock(*state, context, extensions); err != nil {
 			return err
 		}
-		state.Block = params.To
+		state.Block = params.To - 1
 	}
 
 	return nil
@@ -309,7 +309,7 @@ func (e *executor) runParallel(params Params, processor Processor, extensions []
 		errors.Join(workerErrs...),
 	)
 	if err == nil {
-		state.Block = params.To
+		state.Block = params.To - 1
 	}
 	return err
 }


### PR DESCRIPTION
## Description

StateDb after creation is incorrectly showing +1 block because `params.To` is set to `cfg.Last + 1`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)