### PR TITLE
Fix delete account from wrong range after priming

### DIFF
--- a/utils/statedb.go
+++ b/utils/statedb.go
@@ -251,6 +251,7 @@ func DeleteDestroyedAccountsFromStateDB(db state.StateDB, cfg *Config, target ui
 	db.BeginTransaction(0)
 	for _, addr := range accounts {
 		db.Suicide(addr)
+		log.Debugf("Perform suicide on %v", addr)
 	}
 	db.EndTransaction()
 	db.EndBlock()

--- a/utils/worldstate_update.go
+++ b/utils/worldstate_update.go
@@ -45,12 +45,14 @@ func GenerateUpdateSet(first uint64, last uint64, cfg *Config) (substate.Substat
 			if !(err == nil || errors.Is(err, leveldb.ErrNotFound)) {
 				return update, deletedAccounts, fmt.Errorf("failed to get deleted account. %v", err)
 			}
-			// reset storage
-			deletedAccounts = append(deletedAccounts, destroyed...)
-			deletedAccounts = append(deletedAccounts, resurrected...)
-
-			ClearAccountStorage(update, destroyed)
-			ClearAccountStorage(update, resurrected)
+			// reset storagea
+			if len(destroyed) > 0 {
+				deletedAccounts = append(deletedAccounts, destroyed...)
+			}
+			if len(resurrected) > 0 {
+				deletedAccounts = append(deletedAccounts, resurrected...)
+				ClearAccountStorage(update, resurrected)
+			}
 		}
 
 		// merge output substate to update


### PR DESCRIPTION
## Description

This PR fixes an issue where a wrong target block is passed to deletion function after priming. This causes some suicided account not being reset correctly and produces incorrect state hash as a result.
Fixes #720 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Adds or updates testing
