### PR TITLE
set aida-db repo-url before update block range

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -232,7 +232,6 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 		return cfg, fmt.Errorf("unable to parse cli arguments; %v", err)
 	}
 
-
 	adjustMissingConfigValues(cfg)
 
 	reportNewConfig(cfg, log)


### PR DESCRIPTION
## Description

Set aida-db repository url before block range is updated. 

Previously - was done after, resulting in the following warning:  "Cannot get first block of the last patch of given AidaDB; cannot download patches json; error making GET request for /patches.json: Get "/patches.json": unsupported protocol scheme"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
