### PR TITLE
Add validate state hash to Jenkins PR testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,14 +71,26 @@ pipeline {
                 sh "rm -rf ${TRACEDIR}"
             }
         }
-        stage('aida-vm-sdb validate') {
+
+        stage('aida-vm-sdb validate-state-hash') {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
-                    sh "build/aida-vm-sdb ${VM} ${STORAGE} ${AIDADB} ${PRIME} --validate-state-hash --keep-db --archive --archive-variant ldb --validate-tx --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --update-buffer-size 4000 --continue-on-failure ${FROMBLOCK} ${TOBLOCK} "
+                    sh "build/aida-vm-sdb ${VM} ${STORAGE} ${AIDADB} ${PRIME} --validate-state-hash --carmen-schema 5 --archive --archive-variant ldb --validate-tx --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --update-buffer-size 4000 --continue-on-failure ${FROMBLOCK} ${TOBLOCK} "
                 }
                 sh "rm -rf *.dat"
             }
         }
+
+        stage('aida-vm-sdb') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
+                    sh "build/aida-vm-sdb ${VM} ${STORAGE} ${AIDADB} ${PRIME} --keep-db --archive --archive-variant ldb --validate-tx --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --update-buffer-size 4000 --continue-on-failure ${FROMBLOCK} ${TOBLOCK} "
+                }
+                sh "rm -rf *.dat"
+            }
+        }
+
+
 
         stage('aida-vm-adb') {
             steps {


### PR DESCRIPTION
## Description

This PR adds `--validate-state-hash` to `vm-sdb` job. Carmen is currently reliant on this thus we should always make sure it works.

This can only be merged after #725 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
