### PR TITLE
Add support for running Archive Queries while processing History

### DIFF
--- a/cmd/aida-vm-sdb/main.go
+++ b/cmd/aida-vm-sdb/main.go
@@ -34,6 +34,8 @@ var RunVMApp = cli.App{
 
 		// ArchiveDb
 		&utils.ArchiveModeFlag,
+		&utils.ArchiveQueryRateFlag,
+		&utils.ArchiveMaxQueryAgeFlag,
 		&utils.ArchiveVariantFlag,
 
 		// ShadowDb

--- a/cmd/aida-vm-sdb/run_vm_sdb.go
+++ b/cmd/aida-vm-sdb/run_vm_sdb.go
@@ -73,6 +73,7 @@ func run(
 		profiler.MakeMemoryUsagePrinter[*substate.Substate](cfg),
 		profiler.MakeMemoryProfiler[*substate.Substate](cfg),
 		statedb.MakeStateDbPrepper(),
+		statedb.MakeArchiveInquirer(cfg),
 		validator.MakeStateHashValidator[*substate.Substate](cfg),
 		statedb.MakeBlockEventEmitter[*substate.Substate](),
 		profiler.MakeOperationProfiler[*substate.Substate](cfg),

--- a/executor/extension/statedb/archive_inquirer.go
+++ b/executor/extension/statedb/archive_inquirer.go
@@ -1,0 +1,309 @@
+package statedb
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Fantom-foundation/Aida/executor"
+	"github.com/Fantom-foundation/Aida/executor/extension"
+	"github.com/Fantom-foundation/Aida/logger"
+	"github.com/Fantom-foundation/Aida/state"
+	"github.com/Fantom-foundation/Aida/utils"
+	substate "github.com/Fantom-foundation/Substate"
+)
+
+// MakeArchiveInquirer creates an extension running historic queries against
+// archive states in the background to the main executor process.
+func MakeArchiveInquirer(config *utils.Config) executor.Extension[*substate.Substate] {
+	return makeArchiveInquirer(config, logger.NewLogger(config.LogLevel, "Archive Inquirer"), 10)
+}
+
+func makeArchiveInquirer(config *utils.Config, log logger.Logger, maxErrors int) executor.Extension[*substate.Substate] {
+	if config.ArchiveQueryRate <= 0 {
+		return extension.NilExtension[*substate.Substate]{}
+	}
+	if maxErrors <= 0 {
+		maxErrors = 1
+	}
+	return &archiveInquirer{
+		config:    config,
+		log:       log,
+		throttler: newThrottler(config.ArchiveQueryRate),
+		finished:  utils.MakeEvent(),
+		history:   newBuffer[historicTransaction](config.ArchiveMaxQueryAge),
+		maxErrors: maxErrors,
+	}
+}
+
+type archiveInquirer struct {
+	extension.NilExtension[*substate.Substate]
+
+	config *utils.Config
+	log    logger.Logger
+	state  state.StateDB
+
+	// Buffer for historic queries to sample from
+	history      *circularBuffer[historicTransaction]
+	historyMutex sync.Mutex
+
+	// Worker control
+	throttler *throttler
+	finished  utils.Event
+	done      sync.WaitGroup
+
+	// Counters for throughput reporting
+	transactionCounter         atomic.Uint64
+	gasCounter                 atomic.Uint64
+	totalQueryTimeMilliseconds atomic.Uint64
+
+	// A recording of all encountered errors
+	errors      []error
+	errorsMutex sync.Mutex
+	maxErrors   int
+}
+
+func (i *archiveInquirer) PreRun(_ executor.State[*substate.Substate], context *executor.Context) error {
+	if !i.config.ArchiveMode {
+		i.finished.Signal()
+		return fmt.Errorf("can not run archive queries without enabled archive (missing --%s flag)", utils.ArchiveModeFlag.Name)
+	}
+	i.state = context.State
+	numWorkers := i.config.Workers
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+	i.done.Add(1 + numWorkers)
+	for j := 0; j < numWorkers; j++ {
+		go i.runInquiry()
+	}
+	go i.runProgressReport()
+	return nil
+}
+
+func (i *archiveInquirer) PostTransaction(state executor.State[*substate.Substate], _ *executor.Context) error {
+	// We only sample the very first transaction in each block since other transactions
+	// may depend on the effects of its predecessors in the same block.
+	if state.Transaction != 0 {
+		return nil
+	}
+
+	// If too many errors have been encountered, abort the run.
+	i.errorsMutex.Lock()
+	if len(i.errors) >= i.maxErrors {
+		err := errors.Join(i.errors...)
+		i.errorsMutex.Unlock()
+		return err
+	}
+	i.errorsMutex.Unlock()
+
+	// Add current transaction as a candidate for replays.
+	i.historyMutex.Lock()
+	defer i.historyMutex.Unlock()
+	i.history.Add(historicTransaction{
+		block:    state.Block - 1,
+		number:   state.Transaction,
+		substate: state.Data,
+	})
+	return nil
+}
+
+func (i *archiveInquirer) PostRun(executor.State[*substate.Substate], *executor.Context, error) error {
+	i.finished.Signal()
+	i.done.Wait()
+
+	if len(i.errors) > 0 {
+		return errors.Join(i.errors...)
+	}
+	return nil
+}
+
+func (i *archiveInquirer) getRandomTransaction(rnd *rand.Rand) (historicTransaction, bool) {
+	i.historyMutex.Lock()
+	defer i.historyMutex.Unlock()
+	size := i.history.Size()
+	if size == 0 {
+		return historicTransaction{}, false
+	}
+	return i.history.Get(int(rnd.Int31n(int32(size)))), true
+}
+
+func (i *archiveInquirer) runInquiry() {
+	defer i.done.Done()
+	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+	for !i.finished.HasHappened() {
+		if i.throttler.shouldRunNow() {
+			i.doInquiry(rnd)
+		} else {
+			select {
+			case <-time.After(10 * time.Millisecond):
+				// nothing
+			case <-i.finished.Wait():
+				return
+			}
+		}
+	}
+}
+
+func (i *archiveInquirer) doInquiry(rnd *rand.Rand) {
+	// Pick a random transaction that is covered by the current archive block height.
+	transaction, found := i.getRandomTransaction(rnd)
+	for found {
+		height, empty, err := i.state.GetArchiveBlockHeight()
+		if err != nil {
+			i.log.Warningf("failed to obtain archive block height: %v", err)
+			return
+		}
+		if !empty && uint64(transaction.block) <= height {
+			break
+		}
+		transaction, found = i.getRandomTransaction(rnd)
+	}
+	if !found {
+		return
+	}
+
+	// Perform historic query.
+	archive, err := i.state.GetArchiveState(uint64(transaction.block))
+	if err != nil {
+		i.registerError(fmt.Errorf("failed to obtain access to archive at block height %d: %v", transaction.block, err))
+		return
+	}
+	defer archive.Release()
+
+	start := time.Now()
+	_, err = utils.ProcessTx(
+		archive,
+		i.config,
+		uint64(transaction.block),
+		transaction.number,
+		transaction.substate,
+	)
+	if err != nil {
+		i.registerError(fmt.Errorf("failed to re-run transaction %d/%d: %v", transaction.block, transaction.number, err))
+	}
+	duration := time.Since(start)
+
+	i.transactionCounter.Add(1)
+	i.gasCounter.Add(transaction.substate.Result.GasUsed)
+	i.totalQueryTimeMilliseconds.Add(uint64(duration.Milliseconds()))
+}
+
+func (i *archiveInquirer) runProgressReport() {
+	defer i.done.Done()
+	lastTime := time.Now()
+	lastTx := uint64(0)
+	lastGas := uint64(0)
+	lastDuration := uint64(0)
+
+	start := time.Now()
+	ticker := time.NewTicker(15 * time.Second)
+	for {
+		select {
+		case now := <-ticker.C:
+			curTx := i.transactionCounter.Load()
+			curGas := i.gasCounter.Load()
+			curDuration := i.totalQueryTimeMilliseconds.Load()
+
+			i.errorsMutex.Lock()
+			numErrors := len(i.errors)
+			i.errorsMutex.Unlock()
+
+			delta := now.Sub(lastTime).Seconds()
+			tps := float64(curTx-lastTx) / delta
+			gps := float64(curGas-lastGas) / delta
+			averageDuration := float64(curDuration-lastDuration) / float64(curTx-lastTx)
+			i.log.Infof("Archive throughput: t=%ds, %.2f Tx/s, %.2f MGas/s, average duration %.2f ms, number of errors %d",
+				int(now.Sub(start).Round(time.Second).Seconds()), tps, gps/10e6, averageDuration, numErrors,
+			)
+
+			lastTime = now
+			lastTx = curTx
+			lastGas = curGas
+			lastDuration = curDuration
+		case <-i.finished.Wait():
+			return
+		}
+	}
+}
+
+func (i *archiveInquirer) registerError(err error) {
+	i.errorsMutex.Lock()
+	i.errors = append(i.errors, err)
+	if len(i.errors) >= i.maxErrors {
+		i.finished.Signal()
+	}
+	i.errorsMutex.Unlock()
+	i.log.Warning(err)
+}
+
+type historicTransaction struct {
+	block    int
+	number   int
+	substate *substate.Substate
+}
+
+type circularBuffer[T any] struct {
+	data []T
+	head int
+}
+
+func newBuffer[T any](capacity int) *circularBuffer[T] {
+	return &circularBuffer[T]{
+		data: make([]T, 0, capacity),
+	}
+}
+
+func (b *circularBuffer[T]) Size() int {
+	return len(b.data)
+}
+
+func (b *circularBuffer[T]) Add(element T) {
+	if cap(b.data) == 0 {
+		return
+	}
+	if len(b.data) < cap(b.data) {
+		b.data = append(b.data, element)
+		return
+	}
+	b.data[b.head] = element
+	b.head = (b.head + 1) % cap(b.data)
+}
+
+func (b *circularBuffer[T]) Get(pos int) T {
+	return b.data[pos]
+}
+
+type throttler struct {
+	transactionsPerSecond int
+	lastUpdate            time.Time
+	pending               float64
+	mutex                 sync.Mutex
+}
+
+func newThrottler(rate int) *throttler {
+	return &throttler{
+		transactionsPerSecond: rate,
+		lastUpdate:            time.Now(),
+	}
+}
+
+func (t *throttler) shouldRunNow() bool {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	if t.pending < 1 {
+		// Replenish pending transactions.
+		now := time.Now()
+		delta := now.Sub(t.lastUpdate)
+		t.lastUpdate = now
+		t.pending += float64(t.transactionsPerSecond) * delta.Seconds()
+	}
+	if t.pending >= 1 {
+		t.pending -= 1
+		return true
+	}
+	return false
+}

--- a/executor/extension/statedb/archive_inquirer_test.go
+++ b/executor/extension/statedb/archive_inquirer_test.go
@@ -1,0 +1,298 @@
+package statedb
+
+import (
+	"math/big"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/Fantom-foundation/Aida/executor"
+	"github.com/Fantom-foundation/Aida/executor/extension"
+	"github.com/Fantom-foundation/Aida/logger"
+	"github.com/Fantom-foundation/Aida/state"
+	"github.com/Fantom-foundation/Aida/utils"
+	substate "github.com/Fantom-foundation/Substate"
+	"github.com/ethereum/go-ethereum/common"
+	"go.uber.org/mock/gomock"
+)
+
+func TestArchiveInquirer_DisabledIfNoQueryRateIsGiven(t *testing.T) {
+	config := utils.Config{}
+	ext := MakeArchiveInquirer(&config)
+	if _, ok := ext.(extension.NilExtension[*substate.Substate]); !ok {
+		t.Errorf("inquirer should not be active by default")
+	}
+}
+
+func TestArchiveInquirer_ReportsErrorIfNoArchiveIsPresent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	logger := logger.NewMockLogger(ctrl)
+	config := utils.Config{}
+	config.ArchiveQueryRate = 100
+	ext := makeArchiveInquirer(&config, logger, 10)
+
+	state := executor.State[*substate.Substate]{}
+	if err := ext.PreRun(state, nil); err == nil {
+		t.Errorf("expected an error, got nothing")
+	}
+	if err := ext.PostRun(state, nil, nil); err != nil {
+		t.Errorf("failed to shut down gracefully, got %v", err)
+	}
+}
+
+func TestArchiveInquirer_CanStartUpAndShutdownGracefully(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	logger := logger.NewMockLogger(ctrl)
+	db := state.NewMockStateDB(ctrl)
+
+	config := utils.Config{}
+	config.ArchiveMode = true
+	config.ArchiveQueryRate = 100
+	ext := makeArchiveInquirer(&config, logger, 10)
+
+	state := executor.State[*substate.Substate]{}
+	context := executor.Context{State: db}
+
+	if err := ext.PreRun(state, &context); err != nil {
+		t.Errorf("failed PreRun, got %v", err)
+	}
+	if err := ext.PostRun(state, nil, nil); err != nil {
+		t.Errorf("failed to shut down gracefully, got %v", err)
+	}
+}
+
+func TestArchiveInquirer_RunsRandomTransactionsInBackground(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	logger := logger.NewMockLogger(ctrl)
+	db := state.NewMockStateDB(ctrl)
+	archive := state.NewMockNonCommittableStateDB(ctrl)
+
+	config := utils.Config{}
+	config.ArchiveMode = true
+	config.ArchiveQueryRate = 100
+	config.ArchiveMaxQueryAge = 100
+	config.ChainID = utils.TestnetChainID
+
+	state := executor.State[*substate.Substate]{}
+	context := executor.Context{State: db}
+
+	substate1 := makeValidSubstate()
+	substate2 := makeValidSubstate()
+
+	db.EXPECT().GetArchiveBlockHeight().AnyTimes().Return(uint64(14), false, nil)
+	db.EXPECT().GetArchiveState(uint64(12)).MinTimes(1).Return(archive, nil)
+	db.EXPECT().GetArchiveState(uint64(14)).MinTimes(1).Return(archive, nil)
+
+	archive.EXPECT().BeginTransaction(gomock.Any()).MinTimes(1)
+	archive.EXPECT().Prepare(gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().Snapshot().AnyTimes()
+	archive.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(big.NewInt(1000))
+	archive.EXPECT().GetNonce(gomock.Any()).AnyTimes().Return(uint64(0))
+	archive.EXPECT().SetNonce(gomock.Any(), gomock.Any()).AnyTimes().Return()
+	archive.EXPECT().GetCodeHash(gomock.Any()).AnyTimes().Return(common.Hash{})
+	archive.EXPECT().SubBalance(gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().CreateAccount(gomock.Any()).AnyTimes()
+	archive.EXPECT().AddBalance(gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().SetCode(gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().GetRefund().AnyTimes()
+	archive.EXPECT().RevertToSnapshot(gomock.Any()).AnyTimes()
+	archive.EXPECT().EndTransaction().AnyTimes()
+	archive.EXPECT().Release().MinTimes(1)
+
+	ext := makeArchiveInquirer(&config, logger, 10)
+	if err := ext.PreRun(state, &context); err != nil {
+		t.Errorf("failed PreRun, got %v", err)
+	}
+
+	// Add two transaction to the pool
+	state.Block = 13
+	state.Transaction = 0
+	state.Data = substate1
+	if err := ext.PostTransaction(state, &context); err != nil {
+		t.Fatalf("failed to add transaction to pool: %v", err)
+	}
+
+	state.Block = 15
+	state.Transaction = 0
+	state.Data = substate2
+	if err := ext.PostTransaction(state, &context); err != nil {
+		t.Fatalf("failed to add transaction to pool: %v", err)
+	}
+
+	time.Sleep(time.Second)
+
+	if err := ext.PostRun(state, nil, nil); err != nil {
+		t.Errorf("failed to shut down gracefully, got %v", err)
+	}
+}
+
+func makeValidSubstate() *substate.Substate {
+	// This Substate is a minimal substate that can be successfully processed.
+	return &substate.Substate{
+		Env: &substate.SubstateEnv{
+			GasLimit: 100_000_000,
+		},
+		Message: &substate.SubstateMessage{
+			Gas:      100_000,
+			GasPrice: big.NewInt(0),
+			Value:    big.NewInt(0),
+		},
+		Result: &substate.SubstateResult{
+			GasUsed: 1,
+		},
+	}
+}
+
+func TestArchiveInquirer_QueryErrorsAreCollected(t *testing.T) {
+	const maxErrors = 10
+	ctrl := gomock.NewController(t)
+	logger := logger.NewMockLogger(ctrl)
+	db := state.NewMockStateDB(ctrl)
+	archive := state.NewMockNonCommittableStateDB(ctrl)
+
+	config := utils.Config{}
+	config.ArchiveMode = true
+	config.ArchiveQueryRate = 100
+	config.ArchiveMaxQueryAge = 100
+	config.ChainID = utils.TestnetChainID
+
+	state := executor.State[*substate.Substate]{}
+	context := executor.Context{State: db}
+
+	substate := makeInvalidSubstate()
+
+	logger.EXPECT().Warning(gomock.Any()).AnyTimes()
+
+	db.EXPECT().GetArchiveBlockHeight().AnyTimes().Return(uint64(14), false, nil)
+	db.EXPECT().GetArchiveState(gomock.Any()).MinTimes(1).Return(archive, nil)
+
+	archive.EXPECT().BeginTransaction(gomock.Any()).MinTimes(1)
+	archive.EXPECT().Prepare(gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().Snapshot().AnyTimes()
+	archive.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(big.NewInt(1000))
+	archive.EXPECT().GetNonce(gomock.Any()).AnyTimes().Return(uint64(0))
+	archive.EXPECT().SetNonce(gomock.Any(), gomock.Any()).AnyTimes().Return()
+	archive.EXPECT().GetCodeHash(gomock.Any()).AnyTimes().Return(common.Hash{})
+	archive.EXPECT().SubBalance(gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().CreateAccount(gomock.Any()).AnyTimes()
+	archive.EXPECT().AddBalance(gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().SetCode(gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().GetRefund().AnyTimes()
+	archive.EXPECT().RevertToSnapshot(gomock.Any()).AnyTimes()
+	archive.EXPECT().EndTransaction().AnyTimes()
+	archive.EXPECT().Release().MinTimes(1)
+
+	ext := makeArchiveInquirer(&config, logger, maxErrors)
+	if err := ext.PreRun(state, &context); err != nil {
+		t.Errorf("failed PreRun, got %v", err)
+	}
+
+	state.Block = 15
+	state.Transaction = 0
+	state.Data = substate
+	if err := ext.PostTransaction(state, &context); err != nil {
+		t.Fatalf("failed to add transaction to pool: %v", err)
+	}
+
+	time.Sleep(time.Second)
+
+	err := ext.PostRun(state, nil, nil)
+	if err == nil {
+		t.Fatalf("execution errors have not been collected")
+	}
+
+	errors := err.(interface{ Unwrap() []error }).Unwrap()
+	if want, got := len(errors), maxErrors; want != got {
+		t.Errorf("unexpected number of errors, wanted %d, got %d", want, got)
+	}
+}
+
+func makeInvalidSubstate() *substate.Substate {
+	// This Substate is a minimal substate that can be successfully processed.
+	return &substate.Substate{
+		Env: &substate.SubstateEnv{},
+		Message: &substate.SubstateMessage{
+			GasPrice: big.NewInt(12),
+		},
+		Result: &substate.SubstateResult{
+			GasUsed: 1,
+		},
+	}
+}
+
+func TestCircularBuffer_EnforcesSize(t *testing.T) {
+	for _, size := range []int{0, 1, 2, 10, 50} {
+		buffer := newBuffer[int](size)
+		for i := 0; i < 100; i++ {
+			want := i
+			if i > size {
+				want = size
+			}
+			if got := buffer.Size(); want != got {
+				t.Errorf("expected size, wanted %d, got %d", want, got)
+			}
+			buffer.Add(0)
+		}
+	}
+}
+
+func TestCircularBuffer_GetReturnsValueAtPosition(t *testing.T) {
+	buffer := newBuffer[int](3)
+	buffer.Add(1)
+	buffer.Add(2)
+	buffer.Add(3)
+	for i := 0; i < buffer.Size(); i++ {
+		if want, got := i+1, buffer.Get(i); want != got {
+			t.Errorf("unexpected element at position %d: want %d, got %d", i, want, got)
+		}
+	}
+}
+
+func TestCircularBuffer_CyclesThroughContent(t *testing.T) {
+	buffer := newBuffer[int](3)
+	if want, got := []int{}, buffer.data; !slices.Equal(want, got) {
+		t.Errorf("unexpected content, wanted %v, got %v", want, got)
+	}
+
+	buffer.Add(1)
+	if want, got := []int{1}, buffer.data; !slices.Equal(want, got) {
+		t.Errorf("unexpected content, wanted %v, got %v", want, got)
+	}
+	buffer.Add(2)
+	if want, got := []int{1, 2}, buffer.data; !slices.Equal(want, got) {
+		t.Errorf("unexpected content, wanted %v, got %v", want, got)
+	}
+	buffer.Add(3)
+	if want, got := []int{1, 2, 3}, buffer.data; !slices.Equal(want, got) {
+		t.Errorf("unexpected content, wanted %v, got %v", want, got)
+	}
+	buffer.Add(4)
+	if want, got := []int{4, 2, 3}, buffer.data; !slices.Equal(want, got) {
+		t.Errorf("unexpected content, wanted %v, got %v", want, got)
+	}
+	buffer.Add(5)
+	if want, got := []int{4, 5, 3}, buffer.data; !slices.Equal(want, got) {
+		t.Errorf("unexpected content, wanted %v, got %v", want, got)
+	}
+}
+
+func TestThrottler_ProducesEventsInExpectedRate(t *testing.T) {
+	const testPeriod = 500 * time.Millisecond
+	for _, rate := range []int{5, 10, 100, 1000} {
+		throttler := *newThrottler(rate)
+
+		count := 0
+		start := time.Now()
+		for time.Since(start) < testPeriod {
+			if throttler.shouldRunNow() {
+				count++
+			}
+		}
+
+		expected := float64(rate) * float64(testPeriod) / float64(time.Second)
+		diff := float64(count) - expected
+		if diff > 2 || diff < -2 {
+			t.Errorf("failed to reproduce rate %d, did %d events in %v", rate, count, testPeriod)
+		}
+	}
+}

--- a/utils/config.go
+++ b/utils/config.go
@@ -97,6 +97,8 @@ type Config struct {
 
 	APIRecordingSrcFile   string         // path to source file with recorded API data
 	ArchiveMode           bool           // enable archive mode
+	ArchiveQueryRate      int            // the queries per second send to the archive
+	ArchiveMaxQueryAge    int            // the maximum age for archive queries (in blocks)
 	ArchiveVariant        string         // selects the implementation variant of the archive
 	BlockLength           uint64         // length of a block in number of transactions
 	BalanceRange          int64          // balance range for stochastic simulation/replay

--- a/utils/default_config.go
+++ b/utils/default_config.go
@@ -15,6 +15,8 @@ func createConfigFromFlags(ctx *cli.Context) *Config {
 
 		APIRecordingSrcFile:   getFlagValue(ctx, APIRecordingSrcFileFlag).(string),
 		ArchiveMode:           getFlagValue(ctx, ArchiveModeFlag).(bool),
+		ArchiveQueryRate:      getFlagValue(ctx, ArchiveQueryRateFlag).(int),
+		ArchiveMaxQueryAge:    getFlagValue(ctx, ArchiveMaxQueryAgeFlag).(int),
 		ArchiveVariant:        getFlagValue(ctx, ArchiveVariantFlag).(string),
 		BlockLength:           getFlagValue(ctx, BlockLengthFlag).(uint64),
 		BalanceRange:          getFlagValue(ctx, BalanceRangeFlag).(int64),

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -13,6 +13,15 @@ var (
 		Name:  "archive",
 		Usage: "set node type to archival mode. If set, the node keep all the EVM state history; otherwise the state history will be pruned.",
 	}
+	ArchiveQueryRateFlag = cli.IntFlag{
+		Name:  "archive-query-rate",
+		Usage: "sets the number of queries send to the archive per second, disabled if 0 or negative",
+	}
+	ArchiveMaxQueryAgeFlag = cli.IntFlag{
+		Name:  "archive-max-query-age",
+		Usage: "sets an upper limit for the number of blocks an archive query may be lagging behind the head block",
+		Value: 100_000,
+	}
 	ArchiveVariantFlag = cli.StringFlag{
 		Name:  "archive-variant",
 		Usage: "set the archive implementation variant for the selected DB implementation, ignored if not running in archive mode",

--- a/utils/tx_processor.go
+++ b/utils/tx_processor.go
@@ -249,7 +249,7 @@ func handleErrorOnExit(err *error, errMsg *strings.Builder, newErrors *int, cont
 	}
 	numErrors := NumErrors.Add(int32(*newErrors))
 	if numErrors > MaxErrors {
-		*err = fmt.Errorf("%w\nToo many errors...", *err)
+		*err = fmt.Errorf("too many errors (%d), stopping run", numErrors)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR introduces an extension to `aida-vm-sdb` performing historic queries to the archive in the background while new blocks are added by the executor.

The extension introduces two additional command line parameters:
 - `--archive-query-rate` to specify the number of queries per second to be sent to the archive
 - `--archive-max-query-age` to specify the maximum age of transactions to be sent to the archive

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Open TODOs:

- [x] with this new tool a race condition in Carmen was discovered which needs to be fixed before merging (fixed in [#599](https://github.com/Fantom-foundation/Carmen/pull/599))
