### PR TITLE
Add lock to prevent generation after failed autogen run

### DIFF
--- a/cmd/util-db/db/autogen.go
+++ b/cmd/util-db/db/autogen.go
@@ -1,7 +1,9 @@
 package db
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"time"
 
@@ -44,12 +46,59 @@ func autogen(ctx *cli.Context) error {
 		return err
 	}
 
+	locked, err := getLock(cfg)
+	if err != nil {
+		return err
+	}
+	if locked != "" {
+		return fmt.Errorf("GENERATION BLOCKED: autogen failed in last run; %v", locked)
+	}
+
 	g, err := newGenerator(ctx, cfg)
 	if err != nil {
 		return err
 	}
+	err = autogenRun(cfg, g)
+	if err != nil {
+		errLock := setLock(cfg, err.Error())
+		if errLock != nil {
+			return fmt.Errorf("%v; %v", errLock, err)
+		}
+	}
+	return err
+}
 
-	err = g.opera.init()
+// setLock creates lockfile in case of error while generating
+func setLock(cfg *utils.Config, message string) error {
+	lockFile := cfg.AidaDb + ".autogen.lock"
+
+	// Write the string to the file
+	err := os.WriteFile(lockFile, []byte(message), 0655)
+	if err != nil {
+		return fmt.Errorf("error writing to lock file %v; %v", lockFile, err)
+	} else {
+		return nil
+	}
+}
+
+// getLock checks existence and contents of lockfile
+func getLock(cfg *utils.Config) (string, error) {
+	lockFile := cfg.AidaDb + ".autogen.lock"
+
+	// Read lockfile contents
+	content, err := os.ReadFile(lockFile)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("error reading from file; %v", err)
+	}
+
+	return string(content), nil
+}
+
+// autogenRun is used to record/update aida-db
+func autogenRun(cfg *utils.Config, g *generator) error {
+	err := g.opera.init()
 	if err != nil {
 		return err
 	}

--- a/cmd/util-db/db/utils.go
+++ b/cmd/util-db/db/utils.go
@@ -86,7 +86,6 @@ func runCommand(cmd *exec.Cmd, resultChan chan string, log *logging.Logger) erro
 	scanner := bufio.NewScanner(merged)
 
 	lastOutputMessagesChan := make(chan string, commandOutputLimit)
-	defer close(lastOutputMessagesChan)
 	for scanner.Scan() {
 		m := scanner.Text()
 		if resultChan != nil {
@@ -106,6 +105,7 @@ func runCommand(cmd *exec.Cmd, resultChan chan string, log *logging.Logger) erro
 			}
 		}
 	}
+	close(lastOutputMessagesChan)
 	err = cmd.Wait()
 
 	// command failed


### PR DESCRIPTION
## Description

This PR adds functionality to prevent further corruption/divergion of aida-db, by locking generation using lockfile.

Fixes # (issue)

- [ ] New feature (non-breaking change which adds functionality)