### PR TITLE
Executor logging

### DIFF
--- a/cmd/aida-sdb/record.go
+++ b/cmd/aida-sdb/record.go
@@ -94,7 +94,7 @@ func record(
 
 	extensions = append(extensions, extra...)
 
-	return executor.NewExecutor(provider, cfg).Run(
+	return executor.NewExecutor(provider, cfg.LogLevel).Run(
 		executor.Params{
 			From: int(cfg.First),
 			To:   int(cfg.Last) + 1,

--- a/cmd/aida-vm-adb/run_vm_adb.go
+++ b/cmd/aida-vm-adb/run_vm_adb.go
@@ -72,7 +72,7 @@ func run(
 		tracker.MakeProgressLogger[*substate.Substate](cfg, 0),
 	}
 	extensionList = append(extensionList, extra...)
-	return executor.NewExecutor(provider, cfg).Run(
+	return executor.NewExecutor(provider, cfg.LogLevel).Run(
 		executor.Params{
 			From:                   int(cfg.First),
 			To:                     int(cfg.Last) + 1,

--- a/cmd/aida-vm-sdb/run_vm_sdb.go
+++ b/cmd/aida-vm-sdb/run_vm_sdb.go
@@ -85,7 +85,7 @@ func run(
 	}...,
 	)
 
-	return executor.NewExecutor(provider, cfg).Run(
+	return executor.NewExecutor(provider, cfg.LogLevel).Run(
 		executor.Params{
 			From:  int(cfg.First),
 			To:    int(cfg.Last) + 1,

--- a/cmd/aida-vm/run_vm.go
+++ b/cmd/aida-vm/run_vm.go
@@ -57,7 +57,7 @@ func run(
 	}
 	extensions = append(extensions, extra...)
 
-	return executor.NewExecutor(provider, cfg).Run(
+	return executor.NewExecutor(provider, cfg.LogLevel).Run(
 		executor.Params{
 			From:       int(cfg.First),
 			To:         int(cfg.Last) + 1,

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -80,8 +80,8 @@ type Executor[T any] interface {
 }
 
 // NewExecutor creates a new executor based on the given provider.
-func NewExecutor[T any](provider Provider[T], cfg *utils.Config) Executor[T] {
-	return newExecutor[T](provider, logger.NewLogger(cfg.LogLevel, "Executor"))
+func NewExecutor[T any](provider Provider[T], logLevel string) Executor[T] {
+	return newExecutor[T](provider, logger.NewLogger(logLevel, "Executor"))
 }
 
 func newExecutor[T any](provider Provider[T], log logger.Logger) Executor[T] {


### PR DESCRIPTION
## Description

This PR adds basic logging to `Executor` especially for easier panic tracking in which part of the app the panic occurred.

Fixes #717 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)