### PR TITLE
ProfilerProxy now always uses do()

### DIFF
--- a/state/proxy/profiler.go
+++ b/state/proxy/profiler.go
@@ -324,7 +324,8 @@ func (p *ProfilerProxy) AddLog(log *types.Log) {
 }
 
 // GetLogs retrieves log entries.
-func (p *ProfilerProxy) GetLogs(hash common.Hash, blockHash common.Hash) (logs []*types.Log) {
+func (p *ProfilerProxy) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	var logs []*types.Log
 	p.do(operation.GetLogsID, func() {
 		logs = p.db.GetLogs(hash, blockHash)
 	})


### PR DESCRIPTION
ProfilerProxy uses two idioms to implement the proxy - 1. direct call 2. uses helper function do().
ProfilerProxy now uses (2) for consistency + it's easier to extend should there be any future implementation.

## Type of change

- [ ] Refactoring (changes that do NOT affect functionality)
