### PR TITLE
Fix priming to block zero

### DIFF
--- a/executor/extension/statedb/statedb_primer.go
+++ b/executor/extension/statedb/statedb_primer.go
@@ -35,6 +35,10 @@ func (p *stateDbPrimer[T]) PreRun(_ executor.State[T], ctx *executor.Context) er
 		return nil
 	}
 
+	if p.cfg.First == 0 {
+		return nil
+	}
+
 	p.log.Noticef("Priming to block %v", p.cfg.First-1)
 	if err := utils.LoadWorldStateAndPrime(ctx.State, p.cfg, p.cfg.First-1); err != nil {
 		return err

--- a/executor/extension/statedb/statedb_primer_test.go
+++ b/executor/extension/statedb/statedb_primer_test.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestProgressLoggerExtension_NoPrimerIsCreatedIfDisabled(t *testing.T) {
+func TestStateDbPrimerExtension_NoPrimerIsCreatedIfDisabled(t *testing.T) {
 	cfg := &utils.Config{}
 	cfg.SkipPriming = true
 
@@ -21,7 +21,7 @@ func TestProgressLoggerExtension_NoPrimerIsCreatedIfDisabled(t *testing.T) {
 
 }
 
-func TestProgressLoggerExtension_PrimingDoesNotTriggerForExistingStateDb(t *testing.T) {
+func TestStateDbPrimerExtension_PrimingDoesNotTriggerForExistingStateDb(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	log := logger.NewMockLogger(ctrl)
 
@@ -37,7 +37,7 @@ func TestProgressLoggerExtension_PrimingDoesNotTriggerForExistingStateDb(t *test
 
 }
 
-func TestProgressLoggerExtension_PrimingDoesTriggerForNonExistingStateDb(t *testing.T) {
+func TestStateDbPrimerExtension_PrimingDoesTriggerForNonExistingStateDb(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	log := logger.NewMockLogger(ctrl)
 
@@ -51,4 +51,21 @@ func TestProgressLoggerExtension_PrimingDoesTriggerForNonExistingStateDb(t *test
 	ext := makeStateDbPrimer[any](cfg, log)
 
 	ext.PreRun(executor.State[any]{}, &executor.Context{})
+}
+
+func TestStateDbPrimerExtension_AttemptToPrimeBlockZeroDoesNotFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	log := logger.NewMockLogger(ctrl)
+
+	cfg := &utils.Config{}
+	cfg.SkipPriming = false
+	cfg.StateDbSrc = ""
+	cfg.First = 0
+
+	ext := makeStateDbPrimer[any](cfg, log)
+
+	err := ext.PreRun(executor.State[any]{}, &executor.Context{})
+	if err != nil {
+		t.Errorf("priming should not happen hence should not fail")
+	}
 }


### PR DESCRIPTION
## Description

This PR fixes a bug in which an attempt to prime to block 0 results in priming to `MaxUint64`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
