### PR TITLE
Matej/fix command run deadlock on fail

### DIFF
--- a/cmd/util-db/db/opera.go
+++ b/cmd/util-db/db/opera.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 
 	"github.com/Fantom-foundation/Aida/cmd/util-worldstate/state"
+	"github.com/Fantom-foundation/Aida/logger"
 	"github.com/Fantom-foundation/Aida/utils"
 	wsOpera "github.com/Fantom-foundation/Aida/world-state/db/opera"
-	"github.com/op/go-logging"
 	"github.com/urfave/cli/v2"
 )
 
@@ -20,12 +20,12 @@ type aidaOpera struct {
 	firstEpoch, lastEpoch uint64
 	ctx                   *cli.Context
 	cfg                   *utils.Config
-	log                   *logging.Logger
+	log                   logger.Logger
 	isNew                 bool
 }
 
 // newAidaOpera returns new instance of Opera
-func newAidaOpera(ctx *cli.Context, cfg *utils.Config, log *logging.Logger) *aidaOpera {
+func newAidaOpera(ctx *cli.Context, cfg *utils.Config, log logger.Logger) *aidaOpera {
 	return &aidaOpera{
 		ctx: ctx,
 		cfg: cfg,

--- a/cmd/util-db/db/utils.go
+++ b/cmd/util-db/db/utils.go
@@ -56,7 +56,7 @@ func MustCloseDB(db ethdb.Database) {
 }
 
 // runCommand wraps cmd execution to distinguish whether to display its output
-func runCommand(cmd *exec.Cmd, resultChan chan string, stopChan chan struct{}, log *logging.Logger) error {
+func runCommand(cmd *exec.Cmd, resultChan chan string, stopChan chan struct{}, log logger.Logger) error {
 	if resultChan != nil {
 		defer close(resultChan)
 	}
@@ -122,7 +122,7 @@ func runCommand(cmd *exec.Cmd, resultChan chan string, stopChan chan struct{}, l
 }
 
 // killCommand terminates command gracefully first and then forcefully
-func killCommand(cmd *exec.Cmd, log *logging.Logger, done chan error) error {
+func killCommand(cmd *exec.Cmd, log logger.Logger, done chan error) error {
 	// A stop signal was received; terminate the command.
 	// Attempting to interrupt command gracefully first.
 	// Create a timeout with a 1-minute duration.
@@ -149,7 +149,7 @@ func killCommand(cmd *exec.Cmd, log *logging.Logger, done chan error) error {
 }
 
 // processScannedCommandOutput output and send it to resultChan if it is listening and keep lastOutputMessagesChan updated
-func processScannedCommandOutput(message string, resultChan chan string, log *logging.Logger, lastOutputMessagesChan chan string) {
+func processScannedCommandOutput(message string, resultChan chan string, log logger.Logger, lastOutputMessagesChan chan string) {
 	if resultChan != nil {
 		resultChan <- message
 	}
@@ -169,7 +169,7 @@ func processScannedCommandOutput(message string, resultChan chan string, log *lo
 }
 
 // processCommandResult is used to process command result
-func processCommandResult(err error, ok bool, scanner *bufio.Scanner, lastOutputMessagesChan chan string, resultChan chan string, cmd *exec.Cmd, log *logging.Logger) error {
+func processCommandResult(err error, ok bool, scanner *bufio.Scanner, lastOutputMessagesChan chan string, resultChan chan string, cmd *exec.Cmd, log logger.Logger) error {
 	if !ok {
 		return fmt.Errorf("unexpected doneChan closed error while executing Command %v; %v", cmd, err)
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -69,6 +69,8 @@ type Logger interface {
 	Debug(args ...interface{})
 	// Debugf logs a message using DEBUG as log level.
 	Debugf(format string, args ...interface{})
+
+	IsEnabledFor(level logging.Level) bool
 }
 
 // NewLogger provides a new instance of the Logger based on context flags.

--- a/logger/logger_mocks.go
+++ b/logger/logger_mocks.go
@@ -11,6 +11,7 @@ package logger
 import (
 	reflect "reflect"
 
+	logging "github.com/op/go-logging"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -200,6 +201,20 @@ func (mr *MockLoggerMockRecorder) Infof(format any, args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{format}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockLogger)(nil).Infof), varargs...)
+}
+
+// IsEnabledFor mocks base method.
+func (m *MockLogger) IsEnabledFor(level logging.Level) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEnabledFor", level)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEnabledFor indicates an expected call of IsEnabledFor.
+func (mr *MockLoggerMockRecorder) IsEnabledFor(level any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabledFor", reflect.TypeOf((*MockLogger)(nil).IsEnabledFor), level)
 }
 
 // Notice mocks base method.


### PR DESCRIPTION
## Description

This PR fixes commandRun deadlock which occures when command fails, but the error is not propagated and whole program ends up i halt.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
