### PR TITLE
Check whether temp directory exists in config

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -255,6 +255,15 @@ func setAidaDbRepositoryUrl(chainId ChainID) error {
 	return nil
 }
 
+// directoryExists returns true if a directory exists
+func directoryExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	return true
+
+}
+
 // SetBlockRange checks the validity of a block range and return the first and last block as numbers.
 func SetBlockRange(firstArg string, lastArg string, chainId ChainID) (uint64, uint64, error) {
 	var err error = nil
@@ -522,7 +531,7 @@ func updateConfigBlockRange(args []string, cfg *Config, mode ArgumentMode, log l
 }
 
 // adjustMissingConfigValues fill the missing values in the config
-func adjustMissingConfigValues(cfg *Config) {
+func adjustMissingConfigValues(cfg *Config) error {
 	// set default db variant if not provided.
 	if cfg.DbImpl == "carmen" && cfg.DbVariant == "" {
 		cfg.DbVariant = "go-file"
@@ -530,26 +539,37 @@ func adjustMissingConfigValues(cfg *Config) {
 
 	// --continue-on-failure implicitly enables transaction state validation
 	cfg.ValidateTxState = cfg.Validate || cfg.ValidateTxState || cfg.ContinueOnFailure
-
 	cfg.ValidateWorldState = cfg.Validate || cfg.ValidateWorldState
 
 	if cfg.RandomSeed < 0 {
 		cfg.RandomSeed = int64(rand.Uint32())
 	}
 
-	if _, err := os.Stat(cfg.AidaDb); !os.IsNotExist(err) {
+	// if AidaDB path is given, redirect source path to AidaDB.
+	if found := directoryExists(cfg.AidaDb); found {
 		OverwriteDbPathsByAidaDb(cfg)
 	}
 
-	if _, err := os.Stat(cfg.DeletionDb); os.IsNotExist(err) {
+	// TODO: can be deleted as AidaDB is the default data source.
+	if found := directoryExists(cfg.DeletionDb); found {
+		cfg.HasDeletedAccounts = true
+	} else {
 		cfg.HasDeletedAccounts = false
 	}
+
+	// in-memory StateDB cannot be kept after run.
 	if cfg.KeepDb && strings.Contains(cfg.DbVariant, "memory") {
 		cfg.KeepDb = false
 	}
 	if cfg.First == 0 {
 		cfg.SkipPriming = true
 	}
+
+	// if path doesn't exist, use system temp directory.
+	if found := directoryExists(cfg.DbTmp); !found {
+		cfg.DbTmp = os.TempDir()
+	}
+	return nil
 }
 
 // OverwriteDbPathsByAidaDb overwrites the paths of the DBs by the AidaDb path

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -707,8 +707,7 @@ func TestUtilsConfig_adjustMissingConfigValuesValidationOff(t *testing.T) {
 func TestUtilsConfig_adjustMissingConfigValuesDeletionDb(t *testing.T) {
 	// prepare mock config
 	cfg := &Config{
-		HasDeletedAccounts: true,
-		DeletionDb:         "./test.db",
+		DeletionDb: "./test.db",
 	}
 
 	adjustMissingConfigValues(cfg)
@@ -732,6 +731,21 @@ func TestUtilsConfig_adjustMissingConfigValuesKeepStateDb(t *testing.T) {
 	// checks
 	if cfg.KeepDb {
 		t.Fatalf("failed to adjust KeepDb value; got: %v; expected: %v", cfg.KeepDb, false)
+	}
+}
+
+// TestUtilsConfig_adjustMissingConfigValuesWrongDbTmp tests if temporary db path doesn't exist, system temp location is used instead.
+func TestUtilsConfig_adjustMissingConfigValuesWrongDbTmp(t *testing.T) {
+	// prepare mock config
+	cfg := &Config{
+		DbTmp: "./wrong_path",
+	}
+
+	adjustMissingConfigValues(cfg)
+
+	// checks
+	if cfg.DbTmp != os.TempDir() {
+		t.Fatalf("failed to adjust temporary database location; got: %v; expected: %v", cfg.DbTmp, os.TempDir())
 	}
 }
 

--- a/utils/default_config.go
+++ b/utils/default_config.go
@@ -43,7 +43,7 @@ func createConfigFromFlags(ctx *cli.Context) *Config {
 		DeleteSourceDbs:        getFlagValue(ctx, DeleteSourceDbsFlag).(bool),
 		DiagnosticServer:       getFlagValue(ctx, DiagnosticServerFlag).(int64),
 		CompactDb:              getFlagValue(ctx, CompactDbFlag).(bool),
-		HasDeletedAccounts:     true,
+		HasDeletedAccounts:     false,
 		KeepDb:                 getFlagValue(ctx, KeepDbFlag).(bool),
 		KeysNumber:             getFlagValue(ctx, KeysNumberFlag).(int64),
 		MaxNumTransactions:     getFlagValue(ctx, MaxNumTransactionsFlag).(int),

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -1,6 +1,8 @@
 package utils
 
-import "github.com/urfave/cli/v2"
+import (
+	"github.com/urfave/cli/v2"
+)
 
 // Command line options for common flags in record and replay.
 var (


### PR DESCRIPTION
## Description

The default temp directory is changed to system default. This change introduce a utility function `directoryExists` which return true if a given path exists. This utility function checks existence of aida-db and db temp directory. In the case, db temp directory doesn't exist, program terminates.

Fixes #734 , #600

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)