### PR TITLE
Add missing default validate values to config

### DIFF
--- a/utils/default_config.go
+++ b/utils/default_config.go
@@ -73,6 +73,8 @@ func createConfigFromFlags(ctx *cli.Context) *Config {
 		OperaBinary:            getFlagValue(ctx, OperaBinaryFlag).(string),
 		ValuesNumber:           getFlagValue(ctx, ValuesNumberFlag).(int64),
 		Validate:               getFlagValue(ctx, ValidateFlag).(bool),
+		ValidateTxState:        getFlagValue(ctx, ValidateTxStateFlag).(bool),
+		ValidateWorldState:     getFlagValue(ctx, ValidateWorldStateFlag).(bool),
 		VmImpl:                 getFlagValue(ctx, VmImplementation).(string),
 		Workers:                getFlagValue(ctx, substate.WorkersFlag).(int),
 		WorldStateDb:           getFlagValue(ctx, WorldStateFlag).(string),


### PR DESCRIPTION
## Description

The --validate-tx flag had never been added to the default config. Hence, regardless whether the flag was set, the value was always false. In this PR, the --validate-tx flag is now read by createConfigFromFlags().

TODO: apply validate extensions to aida-vm-sdb, aida-vm-adb, aida-vm

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)