### PR TITLE
Use correct validation mode vm adb

### DIFF
--- a/cmd/aida-vm-adb/run_vm_adb.go
+++ b/cmd/aida-vm-adb/run_vm_adb.go
@@ -19,6 +19,7 @@ func RunVmAdb(ctx *cli.Context) error {
 	}
 
 	cfg.SrcDbReadonly = true
+	cfg.StateValidationMode = utils.SubsetCheck
 
 	// executing archive blocks always calls ArchiveDb with block -1
 	// this condition prevents an incorrect call for block that does not exist (block number -1 in this case)


### PR DESCRIPTION
## Description

This PR sets `vm-adb` validation to `SubstateCheck`.

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
