### PR TITLE
Fix deletion db range of clone type

### DIFF
--- a/utildb/clone.go
+++ b/utildb/clone.go
@@ -118,7 +118,7 @@ func (c *cloner) clone(isFirstGenerationFromGenesis bool) error {
 
 	err := c.readDeletions(firstDeletionBlock)
 	if err != nil {
-		return fmt.Errorf("cannot read deletions; %v"; err)
+		return fmt.Errorf("cannot read deletions; %v", err)
 	}
 	err = c.readSubstate()
 	if err != nil {


### PR DESCRIPTION
## Description

This PR fixes incorrect deletionDb range export when clonning for fully functioning clone type. All deletion records have to be included.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)