### PR TITLE
Remove redundant explicit dbTmp mkdirs

### DIFF
--- a/utildb/opera.go
+++ b/utildb/opera.go
@@ -80,15 +80,6 @@ func (opera *aidaOpera) init() error {
 }
 
 func createTmpDir(cfg *utils.Config) (string, error) {
-	if cfg.DbTmp != "" {
-		// create a parents of temporary directory
-		err := os.MkdirAll(cfg.DbTmp, 0755)
-		if err != nil {
-			return "", fmt.Errorf("failed to create %s directory; %s", cfg.DbTmp, err)
-		}
-	}
-
-	//fName := fmt.Sprintf("%v/%v-%v", cfg.DbTmp, "tmp_aida_db_*", rand.Int())
 	// create a temporary working directory
 	fName, err := os.MkdirTemp(cfg.DbTmp, "aida_db_tmp_*")
 	if err != nil {

--- a/utildb/update.go
+++ b/utildb/update.go
@@ -55,12 +55,6 @@ func Update(cfg *utils.Config) error {
 		return nil
 	}
 
-	// create a parents of temporary directory
-	err = os.MkdirAll(cfg.DbTmp, 0755)
-	if err != nil {
-		return fmt.Errorf("failed to create %s directory; %s", cfg.DbTmp, err)
-	}
-
 	var str string
 	for _, p := range patches {
 		str += " "


### PR DESCRIPTION
## Description

Remove redundant dbTmp assignments/initializations apart from `config.go`

## Issue
https://github.com/Fantom-foundation/Aida/issues/847

## Type of change
- [ ] Refactoring (changes that do NOT affect functionality)