### PR TITLE
Reduce unit tests in state package

### DIFF
--- a/state/carmen_test.go
+++ b/state/carmen_test.go
@@ -30,7 +30,7 @@ func TestCarmenState_MakeCarmenStateDBInvalid(t *testing.T) {
 
 // TestCarmenState_InitCloseCarmenDB test closing db immediately after initialization
 func TestCarmenState_InitCloseCarmenDB(t *testing.T) {
-	for _, tc := range GetCarmenStateTestCases() {
+	for _, tc := range GetAllCarmenConfigurations() {
 		t.Run(tc.String(), func(t *testing.T) {
 			csDB, err := MakeCarmenStateDB(t.TempDir(), tc.Variant, tc.Archive, 1)
 			if errors.Is(err, carmen.UnsupportedConfiguration) {

--- a/state/carmen_test_enviroment.go
+++ b/state/carmen_test_enviroment.go
@@ -19,7 +19,8 @@ func (c CarmenStateTestCase) String() string {
 	return fmt.Sprintf("DB Variant: %s, Schema: %d, Archive type: %v", c.Variant, c.Schema, c.Archive)
 }
 
-func GetCarmenStateTestCases() []CarmenStateTestCase {
+// All combinations of carmen db configuration for testing db creation/close function in Aida
+func GetAllCarmenConfigurations() []CarmenStateTestCase {
 	archives := []string{
 		"none",
 		"leveldb",
@@ -40,6 +41,29 @@ func GetCarmenStateTestCases() []CarmenStateTestCase {
 				})
 			}
 		}
+	}
+
+	return testCases
+}
+
+// A combination of carmen db configuration for testing interface
+func GetCarmenStateTestCases() []CarmenStateTestCase {
+	archives := []string{
+		"none",
+		"leveldb",
+	}
+
+	variant := "go-file"
+	schema := 3
+
+	var testCases []CarmenStateTestCase
+
+	for _, archive := range archives {
+		testCases = append(testCases, CarmenStateTestCase{
+			Variant: variant,
+			Schema:  schema,
+			Archive: archive,
+		})
 	}
 
 	return testCases


### PR DESCRIPTION
## Description

Reduce number of carmen configuration combinations tested to reduce test runtime. Some combinations are redundant as the goal is to evaluate Aida interface.

## Type of change

- [x] Adds or updates testing
