### PR TITLE
Fail app with caught panic

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -232,7 +232,7 @@ func (e *executor[T]) Run(params Params, processor Processor[T], extensions []Ex
 		// Skip PostRun actions if a panic occurred. In such a case there is no guarantee
 		// on the state of anything, and PostRun operations may deadlock or cause damage.
 		if r := recover(); r != nil {
-			e.log.Panic(r)
+			panic(r)
 		}
 		err = errors.Join(
 			err,

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -726,12 +726,17 @@ func TestProcessor_APanicInAnExecutorSkipsPostRunActions_InSequentialExecution(t
 	extension.EXPECT().PreBlock(gomock.Any(), gomock.Any())
 	extension.EXPECT().PreTransaction(gomock.Any(), gomock.Any())
 
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("program must panic")
+		}
+	}()
+
 	stop := "stop"
 	processor.EXPECT().Process(gomock.Any(), gomock.Any()).Do(func(any, any) {
 		panic(stop)
 	})
-
-	log.EXPECT().Error(stop)
 
 	newExecutor[any](provider, log).Run(
 		Params{From: 10, To: 11},
@@ -757,12 +762,17 @@ func TestProcessor_APanicInAnExecutorSkipsPostRunActions_InTransactionLevelParal
 	extension.EXPECT().PreRun(gomock.Any(), gomock.Any())
 	extension.EXPECT().PreTransaction(gomock.Any(), gomock.Any())
 
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("program must panic")
+		}
+	}()
+
 	stop := "stop"
 	processor.EXPECT().Process(gomock.Any(), gomock.Any()).Do(func(any, any) {
 		panic(stop)
 	})
-
-	log.EXPECT().Error(stop)
 
 	newExecutor[any](provider, log).Run(
 		Params{From: 10, To: 11, NumWorkers: 2, ParallelismGranularity: TransactionLevel},
@@ -789,12 +799,17 @@ func TestProcessor_APanicInAnExecutorSkipsPostRunActions_InBlockLevelParallelExe
 	extension.EXPECT().PreBlock(gomock.Any(), gomock.Any())
 	extension.EXPECT().PreTransaction(gomock.Any(), gomock.Any())
 
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("program must panic")
+		}
+	}()
+
 	stop := "stop"
 	processor.EXPECT().Process(gomock.Any(), gomock.Any()).Do(func(any, any) {
 		panic(stop)
 	})
-
-	log.EXPECT().Error(stop)
 
 	newExecutor[any](provider, log).Run(
 		Params{From: 10, To: 11, NumWorkers: 2, ParallelismGranularity: BlockLevel},
@@ -904,11 +919,17 @@ func TestProcessor_PanicCaughtInPreRunIsProperlyLogged(t *testing.T) {
 	extension := NewMockExtension[any](ctrl)
 	log := logger.NewMockLogger(ctrl)
 
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("program must panic")
+		}
+	}()
+
 	gomock.InOrder(
 		extension.EXPECT().PreRun(gomock.Any(), gomock.Any()).Do(func(any, any) {
 			panic("stop")
 		}),
-		log.EXPECT().Error("sending forward recovered panic from PreRun; stop"),
 	)
 
 	executor := newExecutor[any](substate, log)
@@ -937,13 +958,19 @@ func TestProcessor_PanicCaughtInPreBlockIsProperlyLogged(t *testing.T) {
 			return nil
 		})
 
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("program must panic")
+		}
+	}()
+
 	gomock.InOrder(
 		extension.EXPECT().PreRun(gomock.Any(), gomock.Any()),
 		log.EXPECT().Debugf(gomock.Any(), gomock.Any()),
 		extension.EXPECT().PreBlock(gomock.Any(), gomock.Any()).Do(func(any, any) {
 			panic("stop")
 		}),
-		log.EXPECT().Error("sending forward recovered panic from PreBlock; stop"),
 	)
 
 	executor := newExecutor[any](substate, log)
@@ -972,6 +999,13 @@ func TestProcessor_PanicCaughtInPreTransactionIsProperlyLogged(t *testing.T) {
 			return nil
 		})
 
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("program must panic")
+		}
+	}()
+
 	gomock.InOrder(
 		extension.EXPECT().PreRun(gomock.Any(), gomock.Any()),
 		log.EXPECT().Debugf(gomock.Any(), gomock.Any()),
@@ -979,7 +1013,6 @@ func TestProcessor_PanicCaughtInPreTransactionIsProperlyLogged(t *testing.T) {
 		extension.EXPECT().PreTransaction(gomock.Any(), gomock.Any()).Do(func(any, any) {
 			panic("stop")
 		}),
-		log.EXPECT().Error("sending forward recovered panic from PreTransaction; stop"),
 	)
 
 	executor := newExecutor[any](substate, log)
@@ -1008,6 +1041,13 @@ func TestProcessor_PanicCaughtInPostTransactionIsProperlyLogged(t *testing.T) {
 			return nil
 		})
 
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("program must panic")
+		}
+	}()
+
 	gomock.InOrder(
 		extension.EXPECT().PreRun(gomock.Any(), gomock.Any()),
 		log.EXPECT().Debugf(gomock.Any(), gomock.Any()),
@@ -1017,7 +1057,6 @@ func TestProcessor_PanicCaughtInPostTransactionIsProperlyLogged(t *testing.T) {
 		extension.EXPECT().PostTransaction(gomock.Any(), gomock.Any()).Do(func(any, any) {
 			panic("stop")
 		}),
-		log.EXPECT().Error("sending forward recovered panic from PostTransaction; stop"),
 	)
 
 	executor := newExecutor[any](substate, log)
@@ -1046,6 +1085,13 @@ func TestProcessor_PanicCaughtInPostBlockIsProperlyLogged(t *testing.T) {
 			return nil
 		})
 
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("program must panic")
+		}
+	}()
+
 	gomock.InOrder(
 		extension.EXPECT().PreRun(gomock.Any(), gomock.Any()),
 		log.EXPECT().Debugf(gomock.Any(), gomock.Any()),
@@ -1056,7 +1102,6 @@ func TestProcessor_PanicCaughtInPostBlockIsProperlyLogged(t *testing.T) {
 		extension.EXPECT().PostBlock(gomock.Any(), gomock.Any()).Do(func(any, any) {
 			panic("stop")
 		}),
-		log.EXPECT().Error("sending forward recovered panic from PostBlock; stop"),
 	)
 
 	executor := newExecutor[any](substate, log)


### PR DESCRIPTION
## Description

This PR panics the app if panic is caught in any of the extensions.
In this case Panic is usefull since we will know where the first panic happened. It also exits the app with code 2 which fails Jenkins.

Fixes #851 

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
