### PR TITLE
Matej/optimalize generate deletion memory

### DIFF
--- a/utildb/gen_deleted_accounts.go
+++ b/utildb/gen_deleted_accounts.go
@@ -1,7 +1,6 @@
 package utildb
 
 import (
-	"errors"
 	"time"
 
 	"github.com/Fantom-foundation/Aida/logger"
@@ -132,8 +131,5 @@ func GenDeletedAccountsAction(cfg *utils.Config, ddb *substate.DestroyedAccountD
 	// explicitly set to nil to release memory as soon as possible
 	deleteHistory = nil
 
-	cfg.MemoryProfile = "/var/opera/Aida/profile-before-iterator-release.dat"
-	err2 := utils.StartMemoryProfile(cfg)
-
-	return errors.Join(err, err2)
+	return err
 }

--- a/utildb/generate.go
+++ b/utildb/generate.go
@@ -293,20 +293,8 @@ func (g *Generator) processDeletedAccounts(ddb *substate.DestroyedAccountDB) err
 		return fmt.Errorf("cannot doGenerations deleted accounts; %v", err)
 	}
 
-	g.Cfg.MemoryProfile = "/var/opera/Aida/profile-after-iterator-release.dat"
-	err = utils.StartMemoryProfile(g.Cfg)
-	if err != nil {
-		return err
-	}
-
 	// explicitly release code cache
 	state.ReleaseCache()
-
-	g.Cfg.MemoryProfile = "/var/opera/Aida/profile-after-cache-release.dat"
-	err = utils.StartMemoryProfile(g.Cfg)
-	if err != nil {
-		return err
-	}
 
 	g.Log.Noticef("Deleted accounts generated successfully. It took: %v", time.Since(start).Round(1*time.Second))
 	g.Log.Noticef("Total elapsed time: %v", time.Since(g.start).Round(1*time.Second))


### PR DESCRIPTION
## Description

This PR fixes memory leak from NewSubstateIterator. 0-65M iteration in deleted account generation inside autogen, had 35GB in memory with cached codes list. Explicit release of this global variable map was added.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)