### PR TITLE
Fix db logging

### DIFF
--- a/cmd/aida-vm/main.go
+++ b/cmd/aida-vm/main.go
@@ -38,6 +38,7 @@ func main() {
 			&logger.LogLevelFlag,
 			&utils.ErrorLoggingFlag,
 			&utils.StateDbImplementationFlag,
+			&utils.StateDbLoggingFlag,
 		},
 	}
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
## Description

This PR fixes `db-logger` Extension:
1) Deadlock caused by not passing output chanel to archive
2) Enabling logger creation in `PreTransaction`.

Fixes #873 

- [ ] Bug fix (non-breaking change which fixes an issue)
