### PR TITLE
Separate jenkins PR tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,10 +78,19 @@ pipeline {
             }
         }
 
-        stage('aida-vm-sdb validate-state-hash') {
+        stage('aida-vm-sdb s5-archive+validate-state-hash') {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
                     sh "build/aida-vm-sdb substate ${VM} ${AIDADB} ${PRIME} ${TMPDB} --db-impl carmen --validate-state-hash --archive --archive-variant s5 --carmen-schema 5 --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --continue-on-failure ${FROMBLOCK} ${TOBLOCK} "
+                }
+                sh "rm -rf *.dat"
+            }
+        }
+
+        stage('aida-vm-sdb validate-tx') {
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
+                    sh "build/aida-vm-sdb substate ${VM} ${AIDADB} ${PRIME} ${TMPDB} --db-impl carmen --validate-tx --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --continue-on-failure ${FROMBLOCK} ${TOBLOCK} "
                 }
                 sh "rm -rf *.dat"
             }


### PR DESCRIPTION
## Description

This PR separates `transaction validation` and `state hash validation` into two different tests. It also adds correct `archive variant` to  the `keep db` test and uses the kept database in other `vm-sdb` and `vm-adb` tests.

Reasoning behind this change is to separate validations their own tests so that if one of them fails, it is clear which validation failed.

## Type of change

- [ ] Refactoring (changes that do NOT affect functionality)