### PR TITLE
Consolidate recorder prepper

### DIFF
--- a/cmd/aida-sdb/record.go
+++ b/cmd/aida-sdb/record.go
@@ -66,7 +66,7 @@ func record(
 		tracker.MakeProgressLogger[*substate.Substate](cfg, 0),
 		tracker.MakeProgressTracker(cfg, 0),
 		statedb.MakeTemporaryStatePrepper(cfg),
-		statedb.MakeTemporaryProxyRecorderPrepper(cfg),
+		statedb.MakeProxyRecorderPrepper(cfg),
 	}
 
 	extensions = append(extensions, extra...)

--- a/executor/extension/statedb/proxy_recorder_prepper.go
+++ b/executor/extension/statedb/proxy_recorder_prepper.go
@@ -12,13 +12,13 @@ import (
 	substate "github.com/Fantom-foundation/Substate"
 )
 
-// MakeTemporaryProxyRecorderPrepper creates an extension which
+// MakeProxyRecorderPrepper creates an extension which
 // creates a temporary RecorderProxy before each transaction
-func MakeTemporaryProxyRecorderPrepper(cfg *utils.Config) executor.Extension[*substate.Substate] {
-	return makeTemporaryProxyRecorderPrepper(cfg)
+func MakeProxyRecorderPrepper(cfg *utils.Config) executor.Extension[*substate.Substate] {
+	return makeProxyRecorderPrepper(cfg)
 }
 
-func makeTemporaryProxyRecorderPrepper(cfg *utils.Config) *proxyRecorderPrepper {
+func makeProxyRecorderPrepper(cfg *utils.Config) *proxyRecorderPrepper {
 	return &proxyRecorderPrepper{
 		cfg: cfg,
 	}

--- a/executor/extension/statedb/proxy_recorder_prepper_test.go
+++ b/executor/extension/statedb/proxy_recorder_prepper_test.go
@@ -18,7 +18,7 @@ func TestTemporaryProxyRecorderPrepper_PreTransactionCreatesRecorderProxy(t *tes
 	cfg.TraceFile = path
 	cfg.SyncPeriodLength = 1
 
-	p := MakeTemporaryProxyRecorderPrepper(cfg)
+	p := MakeProxyRecorderPrepper(cfg)
 
 	ctx := &executor.Context{}
 
@@ -50,7 +50,7 @@ func TestProxyRecorderPrepper_PreBlockWritesABeginBlockOperation(t *testing.T) {
 	cfg.TraceFile = path
 	cfg.SyncPeriodLength = 1
 
-	p := makeTemporaryProxyRecorderPrepper(cfg)
+	p := makeProxyRecorderPrepper(cfg)
 
 	ctx := &executor.Context{}
 
@@ -89,7 +89,7 @@ func TestProxyRecorderPrepper_PostBlockWritesAnEndBlockOperation(t *testing.T) {
 	cfg.TraceFile = path
 	cfg.SyncPeriodLength = 1
 
-	p := makeTemporaryProxyRecorderPrepper(cfg)
+	p := makeProxyRecorderPrepper(cfg)
 
 	ctx := &executor.Context{}
 
@@ -128,7 +128,7 @@ func TestProxyRecorderPrepper_PostRunWritesAnEndSynchPeriodOperation(t *testing.
 	cfg.TraceFile = path
 	cfg.SyncPeriodLength = 1
 
-	p := MakeTemporaryProxyRecorderPrepper(cfg)
+	p := MakeProxyRecorderPrepper(cfg)
 
 	ctx := &executor.Context{}
 
@@ -164,7 +164,7 @@ func TestProxyRecorderPrepper_PreTransactionCreatesNewLoggerProxy(t *testing.T) 
 	ctx := new(executor.Context)
 	ctx.State = db
 
-	ext := MakeTemporaryProxyRecorderPrepper(cfg)
+	ext := MakeProxyRecorderPrepper(cfg)
 
 	// ctx.State is not yet a RecorderProxy hence PreTransaction assigns it
 	err := ext.PreTransaction(executor.State[*substate.Substate]{}, ctx)
@@ -189,7 +189,7 @@ func TestProxyRecorderPrepper_PreTransactionDoesNotCreateNewLoggerProxy(t *testi
 	ctx := new(executor.Context)
 	ctx.State = db
 
-	ext := MakeTemporaryProxyRecorderPrepper(cfg)
+	ext := MakeProxyRecorderPrepper(cfg)
 
 	// first call PreTransaction to assign the proxy
 	err := ext.PreTransaction(executor.State[*substate.Substate]{}, ctx)


### PR DESCRIPTION
## Description

This PR is inspired by #889 where we had to fix `dbLogging` by potentionally assign the proxy in every `PreTransaction`.
`recorderProxy` is now assigned in `PreTransaction` only if not already leading to potentional speed increase.

## Type of change

- [ ] Refactoring (changes that do NOT affect functionality)
