### PR TITLE
Remove potentional nilpointer dereference

### DIFF
--- a/executor/extension/tracker/db_logger.go
+++ b/executor/extension/tracker/db_logger.go
@@ -44,7 +44,7 @@ func makeDbLogger[T any](cfg *utils.Config, log logger.Logger) executor.Extensio
 }
 
 // PreRun creates a logging file
-func (l *dbLogger[T]) PreRun(executor.State[T], *executor.Context) error {
+func (l *dbLogger[T]) PreRun(_ executor.State[T], ctx *executor.Context) error {
 	var err error
 	l.file, err = os.Create(l.cfg.DbLogging)
 	if err != nil {
@@ -55,6 +55,11 @@ func (l *dbLogger[T]) PreRun(executor.State[T], *executor.Context) error {
 
 	l.wg.Add(1)
 	go l.doLogging()
+
+	// in some cases, StateDb does not have to be initialized yet
+	if ctx.State != nil {
+		ctx.State = proxy.NewLoggerProxy(ctx.State, l.log, l.input)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description

This PR removes `LoggerProxy` creation from `PreRun` as `StateDb` might not yet be created leading to a nil-pointer dereference.
`PreTransaction` gets called before first tx anyway, so in the end there is no point in incilizing the proxy in `PreRun`

## Type of change

- [ ] Refactoring (changes that do NOT affect functionality)
