### PR TITLE
Refactor config value retrieval

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -102,101 +102,105 @@ type Config struct {
 	AppName     string
 	CommandName string
 
+	// user defined values by arguments
 	First uint64 // first block
 	Last  uint64 // last block
 
-	AidaDb                 string         // directory to profiling database containing substate, update, delete accounts data
-	ArchiveMaxQueryAge     int            // the maximum age for archive queries (in blocks)
-	ArchiveMode            bool           // enable archive mode
-	ArchiveQueryRate       int            // the queries per second send to the archive
-	ArchiveVariant         string         // selects the implementation variant of the archive
-	BalanceRange           int64          // balance range for stochastic simulation/replay
-	BasicBlockProfiling    bool           // enable profiling of basic block
-	BlockLength            uint64         // length of a block in number of transactions
-	CPUProfile             string         // pprof cpu profile output file name
-	CPUProfilePerInterval  bool           // a different CPU profile is taken per 100k block interval
-	Cache                  int            // Cache for StateDb or Priming
-	CarmenSchema           int            // the current DB schema ID to use in Carmen
-	ChainID                ChainID        // Blockchain ID (mainnet: 250/testnet: 4002)
-	ChannelBufferSize      int            // set a buffer size for profiling channel
-	CompactDb              bool           // compact database after merging
-	ContinueOnFailure      bool           // continue validation when an error detected
-	ContractNumber         int64          // number of contracts to create
-	DbComponent            string         // options for util-db info are 'all', 'substate', 'delete', 'update', 'state-hash'
-	DbImpl                 string         // storage implementation
-	DbLogging              string         // set to true if all DB operations should be logged
-	DbTmp                  string         // path to temporary database
-	DbVariant              string         // database variant
-	Debug                  bool           // enable trace debug flag
-	DebugFrom              uint64         // the first block to print trace debug
-	DeleteSourceDbs        bool           // delete source databases
-	DeletionDb             string         // directory of deleted account database
-	DiagnosticServer       int64          // if not zero, the port used for hosting a HTTP server for performance diagnostics
-	ErrorLogging           string         // if defined, error logging to file is enabled
-	Genesis                string         // genesis file
-	IncludeStorage         bool           // represents a flag for contract storage inclusion in an operation
-	IsExistingStateDb      bool           // this is true if we are using an existing StateDb
-	KeepDb                 bool           // set to true if db is kept after run
-	KeysNumber             int64          // number of keys to generate
-	LogLevel               string         // level of the logging of the app action
-	MaxNumErrors           int            // maximum number of errors when ContinueOnFailure is enabled
-	MaxNumTransactions     int            // the maximum number of processed transactions
-	MemoryBreakdown        bool           // enable printing of memory breakdown
-	MemoryProfile          string         // capture the memory heap profile into the file
-	MicroProfiling         bool           // enable micro-profiling of EVM
-	NoHeartbeatLogging     bool           // disables heartbeat logging
-	NonceRange             int            // nonce range for stochastic simulation/replay
-	OnlySuccessful         bool           // only runs transactions that have been successful
-	OperaBinary            string         // path to opera binary
-	OperaDb                string         // path to opera database
-	Output                 string         // output directory for aida-db patches or path to events.json file in stochastic generation
-	PathToStateDb          string         // Path to a working state-db directory
-	PrimeRandom            bool           // enable randomized priming
-	PrimeThreshold         int            // set account threshold before commit
-	Profile                bool           // enable micro profiling
-	ProfileBlocks          bool           // enables block profiler extension
-	ProfileDB              string         // profile db for parallel transaction execution
-	ProfileDepth           int            // 0 = Interval, 1 = Interval+Block, 2 = Interval+Block+Tx
-	ProfileEVMCall         bool           // enable profiling for EVM call
-	ProfileFile            string         // output file containing profiling result
-	ProfileInterval        uint64         // interval of printing profile result
-	ProfileSqlite3         string         // output profiling results to sqlite3 DB
-	ProfilingDbName        string         // set a database name for storing micro-profiling results
-	RandomSeed             int64          // set random seed for stochastic testing
-	RpcRecordingFile       string         // path to source file with recorded RPC requests
-	ShadowDb               bool           // defines we want to open an existing db as shadow
-	ShadowImpl             string         // implementation of the shadow DB to use, empty if disabled
-	ShadowVariant          string         // database variant of the shadow DB to be used
-	SkipMetadata           bool           // skip metadata insert/getting into AidaDb
-	SkipPriming            bool           // skip priming of the state DB
-	SkipStateHashScrapping bool           // if enabled, then state-hashes are not loaded from rpc
-	SnapshotDepth          int            // depth of snapshot history
-	SourceTableName        string         // represents the name of a source DB table
-	SrcDbReadonly          bool           // if false, make a copy the source statedb
-	StateDbSrc             string         // directory to load an existing State DB data
-	StateValidationMode    ValidationMode // state validation mode
-	SubstateDb             string         // substate directory
-	SyncPeriodLength       uint64         // length of a sync-period in number of blocks
-	TargetBlock            uint64         // represents the ID of target block to be reached by state evolve process or in dump state
-	TargetDb               string         // represents the path of a target DB
-	TargetEpoch            uint64         // represents the ID of target epoch to be reached by autogen patch generator
-	Trace                  bool           // trace flag
-	TraceDirectory         string         // name of trace directory
-	TraceFile              string         // name of trace file
-	TrackProgress          bool           // enables track progress logging
-	TransactionLength      uint64         // determines indirectly the length of a transaction
-	TrieRootHash           string         // represents a hash of a state trie root to be decoded
-	UpdateBufferSize       uint64         // cache size in Bytes
-	UpdateDb               string         // update-set directory
-	UpdateOnFailure        bool           // if enabled and continue-on-failure is also enabled, this updates any error found in StateDb
-	UpdateType             string         // download datatype
-	Validate               bool           // validate validate aida-db
-	ValidateStateHashes    bool           // if this is true state hash validation is enabled in Executor
-	ValidateTxState        bool           // validate stateDB before and after transaction
-	ValuesNumber           int64          // number of values to generate
-	VmImpl                 string         // vm implementation (geth/lfvm)
-	Workers                int            // number of worker threads
-	WorldStateDb           string         // path to worldstate
+	// internal values
+	IsExistingStateDb   bool           // this is true if we are using an existing StateDb
+	PathToStateDb       string         // Path to a working state-db directory
+	SrcDbReadonly       bool           // if false, make a copy the source statedb
+	StateValidationMode ValidationMode // state validation mode
+
+	// user defined values by flags
+	AidaDb                 string  // directory to profiling database containing substate, update, delete accounts data
+	ArchiveMaxQueryAge     int     // the maximum age for archive queries (in blocks)
+	ArchiveMode            bool    // enable archive mode
+	ArchiveQueryRate       int     // the queries per second send to the archive
+	ArchiveVariant         string  // selects the implementation variant of the archive
+	BalanceRange           int64   // balance range for stochastic simulation/replay
+	BasicBlockProfiling    bool    // enable profiling of basic block
+	BlockLength            uint64  // length of a block in number of transactions
+	Cache                  int     // Cache for StateDb or Priming
+	CarmenSchema           int     // the current DB schema ID to use in Carmen
+	ChainID                ChainID // Blockchain ID (mainnet: 250/testnet: 4002)
+	ChannelBufferSize      int     // set a buffer size for profiling channel
+	CompactDb              bool    // compact database after merging
+	ContinueOnFailure      bool    // continue validation when an error detected
+	ContractNumber         int64   // number of contracts to create
+	CPUProfile             string  // pprof cpu profile output file name
+	CPUProfilePerInterval  bool    // a different CPU profile is taken per 100k block interval
+	DbComponent            string  // options for util-db info are 'all', 'substate', 'delete', 'update', 'state-hash'
+	DbImpl                 string  // storage implementation
+	DbLogging              string  // set to true if all DB operations should be logged
+	DbTmp                  string  // path to temporary database
+	DbVariant              string  // database variant
+	Debug                  bool    // enable trace debug flag
+	DebugFrom              uint64  // the first block to print trace debug
+	DeleteSourceDbs        bool    // delete source databases
+	DeletionDb             string  // directory of deleted account database
+	DiagnosticServer       int64   // if not zero, the port used for hosting a HTTP server for performance diagnostics
+	ErrorLogging           string  // if defined, error logging to file is enabled
+	Genesis                string  // genesis file
+	IncludeStorage         bool    // represents a flag for contract storage inclusion in an operation
+	KeepDb                 bool    // set to true if db is kept after run
+	KeysNumber             int64   // number of keys to generate
+	LogLevel               string  // level of the logging of the app action
+	MaxNumErrors           int     // maximum number of errors when ContinueOnFailure is enabled
+	MaxNumTransactions     int     // the maximum number of processed transactions
+	MemoryBreakdown        bool    // enable printing of memory breakdown
+	MemoryProfile          string  // capture the memory heap profile into the file
+	MicroProfiling         bool    // enable micro-profiling of EVM
+	NoHeartbeatLogging     bool    // disables heartbeat logging
+	NonceRange             int     // nonce range for stochastic simulation/replay
+	OnlySuccessful         bool    // only runs transactions that have been successful
+	OperaBinary            string  // path to opera binary
+	OperaDb                string  // path to opera database
+	Output                 string  // output directory for aida-db patches or path to events.json file in stochastic generation
+	PrimeRandom            bool    // enable randomized priming
+	PrimeThreshold         int     // set account threshold before commit
+	Profile                bool    // enable micro profiling
+	ProfileBlocks          bool    // enables block profiler extension
+	ProfileDB              string  // profile db for parallel transaction execution
+	ProfileDepth           int     // 0 = Interval, 1 = Interval+Block, 2 = Interval+Block+Tx
+	ProfileEVMCall         bool    // enable profiling for EVM call
+	ProfileFile            string  // output file containing profiling result
+	ProfileInterval        uint64  // interval of printing profile result
+	ProfileSqlite3         string  // output profiling results to sqlite3 DB
+	ProfilingDbName        string  // set a database name for storing micro-profiling results
+	RandomSeed             int64   // set random seed for stochastic testing
+	RpcRecordingFile       string  // path to source file with recorded RPC requests
+	ShadowDb               bool    // defines we want to open an existing db as shadow
+	ShadowImpl             string  // implementation of the shadow DB to use, empty if disabled
+	ShadowVariant          string  // database variant of the shadow DB to be used
+	SkipMetadata           bool    // skip metadata insert/getting into AidaDb
+	SkipPriming            bool    // skip priming of the state DB
+	SkipStateHashScrapping bool    // if enabled, then state-hashes are not loaded from rpc
+	SnapshotDepth          int     // depth of snapshot history
+	SourceTableName        string  // represents the name of a source DB table
+	StateDbSrc             string  // directory to load an existing State DB data
+	SubstateDb             string  // substate directory
+	SyncPeriodLength       uint64  // length of a sync-period in number of blocks
+	TargetBlock            uint64  // represents the ID of target block to be reached by state evolve process or in dump state
+	TargetDb               string  // represents the path of a target DB
+	TargetEpoch            uint64  // represents the ID of target epoch to be reached by autogen patch generator
+	Trace                  bool    // trace flag
+	TraceDirectory         string  // name of trace directory
+	TraceFile              string  // name of trace file
+	TrackProgress          bool    // enables track progress logging
+	TransactionLength      uint64  // determines indirectly the length of a transaction
+	TrieRootHash           string  // represents a hash of a state trie root to be decoded
+	UpdateBufferSize       uint64  // cache size in Bytes
+	UpdateDb               string  // update-set directory
+	UpdateOnFailure        bool    // if enabled and continue-on-failure is also enabled, this updates any error found in StateDb
+	UpdateType             string  // download datatype
+	Validate               bool    // validate validate aida-db
+	ValidateStateHashes    bool    // if this is true state hash validation is enabled in Executor
+	ValidateTxState        bool    // validate stateDB before and after transaction
+	ValuesNumber           int64   // number of values to generate
+	VmImpl                 string  // vm implementation (geth/lfvm)
+	Workers                int     // number of worker threads
+	WorldStateDb           string  // path to worldstate
 }
 
 type configContext struct {
@@ -218,7 +222,7 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 	var err error
 
 	// create config with user flag values, if not set default values are used
-	cfg := createConfigFromFlags(ctx)
+	cfg, specifiedFlags, err := createConfigFromFlags(ctx)
 
 	// create config context for sharing common arguments
 	cc := NewConfigContext(cfg)
@@ -249,7 +253,11 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 		return nil, fmt.Errorf("cannot adjust missing config values; %v", err)
 	}
 
-	cc.reportNewConfig()
+	err = cc.reportNewConfig(specifiedFlags)
+	if err != nil {
+		return nil, fmt.Errorf("cannot report new config; %v", err)
+
+	}
 
 	return cfg, nil
 }
@@ -622,22 +630,41 @@ func OverwriteDbPathsByAidaDb(cfg *Config) {
 }
 
 // reportNewConfig logs out the state of config in current run
-func (cc *configContext) reportNewConfig() {
+func (cc *configContext) reportNewConfig(specifiedFlags map[string]bool) error {
 	cfg := cc.cfg
 	log := cc.log
 
 	log.Noticef("Run config:")
 	log.Infof("Block range: %v to %v", cfg.First, cfg.Last)
+
 	if cfg.MaxNumTransactions >= 0 {
 		log.Noticef("Transaction limit: %d", cfg.MaxNumTransactions)
 	}
-	log.Infof("Chain id: %v (record & run-vm only)", cfg.ChainID)
-	log.Infof("SyncPeriod length: %v", cfg.SyncPeriodLength)
-	log.Noticef("Used VM implementation: %v", cfg.VmImpl)
-	log.Infof("Aida DB directory: %v", cfg.AidaDb)
+	if specifiedFlags[ChainIDFlag.Name] {
+		log.Infof("Chain id: %v (record & run-vm only)", cfg.ChainID)
+	}
+
+	if specifiedFlags[SyncPeriodLengthFlag.Name] {
+		log.Infof("SyncPeriod length: %v", cfg.SyncPeriodLength)
+	}
+
+	if specifiedFlags[VmImplementation.Name] {
+		log.Noticef("Used VM implementation: %v", cfg.VmImpl)
+	}
+
+	if specifiedFlags[StateDbImplementationFlag.Name] {
+		log.Noticef("Used DB implementation: %v", cfg.DbImpl)
+	}
+
+	if specifiedFlags[AidaDbFlag.Name] {
+		log.Infof("Aida DB directory: %v", cfg.AidaDb)
+	}
 
 	// todo move to tx validator once finished
-	log.Infof("validate tx state: %v", cfg.ValidateTxState)
+	if specifiedFlags[ValidateTxStateFlag.Name] {
+		log.Infof("validate tx state: %v", cfg.ValidateTxState)
+	}
+
 	if cfg.Profile {
 		log.Infof("Profiling enabled - at depth: %d", cfg.ProfileDepth)
 		if cfg.ProfileFile != "" {
@@ -654,4 +681,6 @@ func (cc *configContext) reportNewConfig() {
 	if cfg.DbLogging != "" {
 		log.Warning("Db logging enabled, reducing Tx throughput")
 	}
+
+	return nil
 }

--- a/utils/default_config.go
+++ b/utils/default_config.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/Fantom-foundation/Aida/cmd/util-db/flags"
 	"github.com/Fantom-foundation/Aida/logger"
 	substate "github.com/Fantom-foundation/Substate"
@@ -8,160 +11,184 @@ import (
 )
 
 // createConfigFromFlags returns Config instance with user specified values or the default ones
-func createConfigFromFlags(ctx *cli.Context) *Config {
+func createConfigFromFlags(ctx *cli.Context) (*Config, map[string]bool, error) {
 	cfg := &Config{
 		AppName:     ctx.App.HelpName,
 		CommandName: ctx.Command.Name,
-
-		AidaDb:                 getFlagValue(ctx, AidaDbFlag).(string),
-		ArchiveMaxQueryAge:     getFlagValue(ctx, ArchiveMaxQueryAgeFlag).(int),
-		ArchiveMode:            getFlagValue(ctx, ArchiveModeFlag).(bool),
-		ArchiveQueryRate:       getFlagValue(ctx, ArchiveQueryRateFlag).(int),
-		ArchiveVariant:         getFlagValue(ctx, ArchiveVariantFlag).(string),
-		BalanceRange:           getFlagValue(ctx, BalanceRangeFlag).(int64),
-		BasicBlockProfiling:    getFlagValue(ctx, BasicBlockProfilingFlag).(bool),
-		BlockLength:            getFlagValue(ctx, BlockLengthFlag).(uint64),
-		CPUProfile:             getFlagValue(ctx, CpuProfileFlag).(string),
-		CPUProfilePerInterval:  getFlagValue(ctx, CpuProfilePerIntervalFlag).(bool),
-		Cache:                  getFlagValue(ctx, CacheFlag).(int),
-		CarmenSchema:           getFlagValue(ctx, CarmenSchemaFlag).(int),
-		ChainID:                ChainID(getFlagValue(ctx, ChainIDFlag).(int)),
-		ChannelBufferSize:      getFlagValue(ctx, ChannelBufferSizeFlag).(int),
-		CompactDb:              getFlagValue(ctx, CompactDbFlag).(bool),
-		ContinueOnFailure:      getFlagValue(ctx, ContinueOnFailureFlag).(bool),
-		ContractNumber:         getFlagValue(ctx, ContractNumberFlag).(int64),
-		DbComponent:            getFlagValue(ctx, DbComponentFlag).(string),
-		DbImpl:                 getFlagValue(ctx, StateDbImplementationFlag).(string),
-		DbLogging:              getFlagValue(ctx, StateDbLoggingFlag).(string),
-		DbTmp:                  getFlagValue(ctx, DbTmpFlag).(string),
-		DbVariant:              getFlagValue(ctx, StateDbVariantFlag).(string),
-		Debug:                  getFlagValue(ctx, TraceDebugFlag).(bool),
-		DebugFrom:              getFlagValue(ctx, DebugFromFlag).(uint64),
-		DeleteSourceDbs:        getFlagValue(ctx, DeleteSourceDbsFlag).(bool),
-		DeletionDb:             getFlagValue(ctx, DeletionDbFlag).(string),
-		DiagnosticServer:       getFlagValue(ctx, DiagnosticServerFlag).(int64),
-		ErrorLogging:           getFlagValue(ctx, ErrorLoggingFlag).(string),
-		Genesis:                getFlagValue(ctx, GenesisFlag).(string),
-		IncludeStorage:         getFlagValue(ctx, IncludeStorageFlag).(bool),
-		KeepDb:                 getFlagValue(ctx, KeepDbFlag).(bool),
-		KeysNumber:             getFlagValue(ctx, KeysNumberFlag).(int64),
-		LogLevel:               getFlagValue(ctx, logger.LogLevelFlag).(string),
-		MaxNumErrors:           getFlagValue(ctx, MaxNumErrorsFlag).(int),
-		MaxNumTransactions:     getFlagValue(ctx, MaxNumTransactionsFlag).(int),
-		MemoryBreakdown:        getFlagValue(ctx, MemoryBreakdownFlag).(bool),
-		MemoryProfile:          getFlagValue(ctx, MemoryProfileFlag).(string),
-		MicroProfiling:         getFlagValue(ctx, MicroProfilingFlag).(bool),
-		NoHeartbeatLogging:     getFlagValue(ctx, NoHeartbeatLoggingFlag).(bool),
-		NonceRange:             getFlagValue(ctx, NonceRangeFlag).(int),
-		OnlySuccessful:         getFlagValue(ctx, OnlySuccessfulFlag).(bool),
-		OperaBinary:            getFlagValue(ctx, OperaBinaryFlag).(string),
-		OperaDb:                getFlagValue(ctx, OperaDbFlag).(string),
-		Output:                 getFlagValue(ctx, OutputFlag).(string),
-		PrimeRandom:            getFlagValue(ctx, RandomizePrimingFlag).(bool),
-		PrimeThreshold:         getFlagValue(ctx, PrimeThresholdFlag).(int),
-		Profile:                getFlagValue(ctx, ProfileFlag).(bool),
-		ProfileBlocks:          getFlagValue(ctx, ProfileBlocksFlag).(bool),
-		ProfileDB:              getFlagValue(ctx, ProfileDBFlag).(string),
-		ProfileDepth:           getFlagValue(ctx, ProfileDepthFlag).(int),
-		ProfileEVMCall:         getFlagValue(ctx, ProfileEVMCallFlag).(bool),
-		ProfileFile:            getFlagValue(ctx, ProfileFileFlag).(string),
-		ProfileInterval:        getFlagValue(ctx, ProfileIntervalFlag).(uint64),
-		ProfileSqlite3:         getFlagValue(ctx, ProfileSqlite3Flag).(string),
-		ProfilingDbName:        getFlagValue(ctx, ProfilingDbNameFlag).(string),
-		RandomSeed:             getFlagValue(ctx, RandomSeedFlag).(int64),
-		RpcRecordingFile:       getFlagValue(ctx, RpcRecordingFileFlag).(string),
-		ShadowDb:               getFlagValue(ctx, ShadowDb).(bool),
-		ShadowImpl:             getFlagValue(ctx, ShadowDbImplementationFlag).(string),
-		ShadowVariant:          getFlagValue(ctx, ShadowDbVariantFlag).(string),
-		SkipMetadata:           getFlagValue(ctx, flags.SkipMetadata).(bool),
-		SkipPriming:            getFlagValue(ctx, SkipPrimingFlag).(bool),
-		SkipStateHashScrapping: getFlagValue(ctx, SkipStateHashScrappingFlag).(bool),
-		SnapshotDepth:          getFlagValue(ctx, SnapshotDepthFlag).(int),
-		SourceTableName:        getFlagValue(ctx, SourceTableNameFlag).(string),
-		SrcDbReadonly:          false,
-		StateDbSrc:             getFlagValue(ctx, StateDbSrcFlag).(string),
-		StateValidationMode:    EqualityCheck,
-		SubstateDb:             getFlagValue(ctx, substate.SubstateDbFlag).(string),
-		SyncPeriodLength:       getFlagValue(ctx, SyncPeriodLengthFlag).(uint64),
-		TargetBlock:            getFlagValue(ctx, TargetBlockFlag).(uint64),
-		TargetDb:               getFlagValue(ctx, TargetDbFlag).(string),
-		TargetEpoch:            getFlagValue(ctx, TargetEpochFlag).(uint64),
-		Trace:                  getFlagValue(ctx, TraceFlag).(bool),
-		TraceDirectory:         getFlagValue(ctx, TraceDirectoryFlag).(string),
-		TraceFile:              getFlagValue(ctx, TraceFileFlag).(string),
-		TrackProgress:          getFlagValue(ctx, TrackProgressFlag).(bool),
-		TransactionLength:      getFlagValue(ctx, TransactionLengthFlag).(uint64),
-		TrieRootHash:           getFlagValue(ctx, TrieRootHashFlag).(string),
-		UpdateBufferSize:       getFlagValue(ctx, UpdateBufferSizeFlag).(uint64),
-		UpdateDb:               getFlagValue(ctx, UpdateDbFlag).(string),
-		UpdateOnFailure:        getFlagValue(ctx, UpdateOnFailure).(bool),
-		UpdateType:             getFlagValue(ctx, UpdateTypeFlag).(string),
-		Validate:               getFlagValue(ctx, ValidateFlag).(bool),
-		ValidateStateHashes:    getFlagValue(ctx, ValidateStateHashesFlag).(bool),
-		ValidateTxState:        getFlagValue(ctx, ValidateTxStateFlag).(bool),
-		ValuesNumber:           getFlagValue(ctx, ValuesNumberFlag).(int64),
-		VmImpl:                 getFlagValue(ctx, VmImplementation).(string),
-		Workers:                getFlagValue(ctx, substate.WorkersFlag).(int),
-		WorldStateDb:           getFlagValue(ctx, WorldStateFlag).(string),
 	}
 
-	return cfg
+	// string of this map has to exactly match the name of the field in Config struct
+	cfgFlags := map[string]interface{}{
+		"AidaDb":                 AidaDbFlag,
+		"ArchiveMaxQueryAge":     ArchiveMaxQueryAgeFlag,
+		"ArchiveMode":            ArchiveModeFlag,
+		"ArchiveQueryRate":       ArchiveQueryRateFlag,
+		"ArchiveVariant":         ArchiveVariantFlag,
+		"BalanceRange":           BalanceRangeFlag,
+		"BasicBlockProfiling":    BasicBlockProfilingFlag,
+		"BlockLength":            BlockLengthFlag,
+		"Cache":                  CacheFlag,
+		"CarmenSchema":           CarmenSchemaFlag,
+		"ChainID":                ChainIDFlag,
+		"ChannelBufferSize":      ChannelBufferSizeFlag,
+		"CompactDb":              CompactDbFlag,
+		"ContinueOnFailure":      ContinueOnFailureFlag,
+		"ContractNumber":         ContractNumberFlag,
+		"CPUProfile":             CpuProfileFlag,
+		"CPUProfilePerInterval":  CpuProfilePerIntervalFlag,
+		"DbComponent":            DbComponentFlag,
+		"DbImpl":                 StateDbImplementationFlag,
+		"DbLogging":              StateDbLoggingFlag,
+		"DbTmp":                  DbTmpFlag,
+		"DbVariant":              StateDbVariantFlag,
+		"Debug":                  TraceDebugFlag,
+		"DebugFrom":              DebugFromFlag,
+		"DeleteSourceDbs":        DeleteSourceDbsFlag,
+		"DeletionDb":             DeletionDbFlag,
+		"DiagnosticServer":       DiagnosticServerFlag,
+		"ErrorLogging":           ErrorLoggingFlag,
+		"Genesis":                GenesisFlag,
+		"IncludeStorage":         IncludeStorageFlag,
+		"KeepDb":                 KeepDbFlag,
+		"KeysNumber":             KeysNumberFlag,
+		"LogLevel":               logger.LogLevelFlag,
+		"MaxNumErrors":           MaxNumErrorsFlag,
+		"MaxNumTransactions":     MaxNumTransactionsFlag,
+		"MemoryBreakdown":        MemoryBreakdownFlag,
+		"MemoryProfile":          MemoryProfileFlag,
+		"MicroProfiling":         MicroProfilingFlag,
+		"NoHeartbeatLogging":     NoHeartbeatLoggingFlag,
+		"NonceRange":             NonceRangeFlag,
+		"OnlySuccessful":         OnlySuccessfulFlag,
+		"OperaBinary":            OperaBinaryFlag,
+		"OperaDb":                OperaDbFlag,
+		"Output":                 OutputFlag,
+		"PrimeRandom":            RandomizePrimingFlag,
+		"PrimeThreshold":         PrimeThresholdFlag,
+		"Profile":                ProfileFlag,
+		"ProfileBlocks":          ProfileBlocksFlag,
+		"ProfileDB":              ProfileDBFlag,
+		"ProfileDepth":           ProfileDepthFlag,
+		"ProfileEVMCall":         ProfileEVMCallFlag,
+		"ProfileFile":            ProfileFileFlag,
+		"ProfileInterval":        ProfileIntervalFlag,
+		"ProfileSqlite3":         ProfileSqlite3Flag,
+		"ProfilingDbName":        ProfilingDbNameFlag,
+		"RandomSeed":             RandomSeedFlag,
+		"RpcRecordingFile":       RpcRecordingFileFlag,
+		"ShadowDb":               ShadowDb,
+		"ShadowImpl":             ShadowDbImplementationFlag,
+		"ShadowVariant":          ShadowDbVariantFlag,
+		"SkipMetadata":           flags.SkipMetadata,
+		"SkipPriming":            SkipPrimingFlag,
+		"SkipStateHashScrapping": SkipStateHashScrappingFlag,
+		"SnapshotDepth":          SnapshotDepthFlag,
+		"SourceTableName":        SourceTableNameFlag,
+		"StateDbSrc":             StateDbSrcFlag,
+		"SubstateDb":             substate.SubstateDbFlag,
+		"SyncPeriodLength":       SyncPeriodLengthFlag,
+		"TargetBlock":            TargetBlockFlag,
+		"TargetDb":               TargetDbFlag,
+		"TargetEpoch":            TargetEpochFlag,
+		"Trace":                  TraceFlag,
+		"TraceDirectory":         TraceDirectoryFlag,
+		"TraceFile":              TraceFileFlag,
+		"TrackProgress":          TrackProgressFlag,
+		"TransactionLength":      TransactionLengthFlag,
+		"TrieRootHash":           TrieRootHashFlag,
+		"UpdateBufferSize":       UpdateBufferSizeFlag,
+		"UpdateDb":               UpdateDbFlag,
+		"UpdateOnFailure":        UpdateOnFailure,
+		"UpdateType":             UpdateTypeFlag,
+		"Validate":               ValidateFlag,
+		"ValidateStateHashes":    ValidateStateHashesFlag,
+		"ValidateTxState":        ValidateTxStateFlag,
+		"ValuesNumber":           ValuesNumberFlag,
+		"VmImpl":                 VmImplementation,
+		"Workers":                substate.WorkersFlag,
+		"WorldStateDb":           WorldStateFlag,
+	}
+
+	cfgValue := reflect.ValueOf(cfg).Elem()
+
+	specifiedFlags := make(map[string]bool)
+
+	for cfgName, flag := range cfgFlags {
+		value, isSpecified, flagName := getFlagValue(ctx, flag)
+		if isSpecified {
+			specifiedFlags[flagName] = true
+		}
+
+		field := cfgValue.FieldByName(cfgName)
+		if !field.IsValid() {
+			return nil, nil, fmt.Errorf("field %s is not valid", flagName)
+		}
+		if !field.CanSet() {
+			return nil, nil, fmt.Errorf("field %s cannot be set", flagName)
+		}
+
+		field.Set(reflect.ValueOf(value))
+	}
+
+	return cfg, specifiedFlags, nil
 }
 
 // getFlagValue returns value specified by user if flag is present in cli context, otherwise return default flag value
-func getFlagValue(ctx *cli.Context, flag interface{}) interface{} {
+func getFlagValue(ctx *cli.Context, flag interface{}) (interface{}, bool, string) {
 	cmdFlags := ctx.Command.Flags
 	for _, cmdFlag := range cmdFlags {
 		switch f := flag.(type) {
 		case cli.IntFlag:
 			if cmdFlag.Names()[0] == f.Name {
-				return ctx.Int(f.Name)
+				if cmdFlag.Names()[0] == ChainIDFlag.Name {
+					return ChainID(ctx.Int(f.Name)), true, f.Name
+				}
+				return ctx.Int(f.Name), true, f.Name
 			}
 
 		case cli.Uint64Flag:
 			if cmdFlag.Names()[0] == UpdateBufferSizeFlag.Name {
-				return ctx.Uint64(f.Name) * 1_000_000
+				return ctx.Uint64(f.Name) * 1_000_000, true, f.Name
 			} else if cmdFlag.Names()[0] == f.Name {
-				return ctx.Uint64(f.Name)
+				return ctx.Uint64(f.Name), true, f.Name
 			}
 
 		case cli.Int64Flag:
 			if cmdFlag.Names()[0] == f.Name {
-				return ctx.Int64(f.Name)
+				return ctx.Int64(f.Name), true, f.Name
 			}
 
 		case cli.StringFlag:
 			if cmdFlag.Names()[0] == f.Name {
-				return ctx.String(f.Name)
+				return ctx.String(f.Name), true, f.Name
 			}
 
 		case cli.PathFlag:
 			if cmdFlag.Names()[0] == f.Name {
-				return ctx.Path(f.Name)
+				return ctx.Path(f.Name), true, f.Name
 			}
 
 		case cli.BoolFlag:
 			if cmdFlag.Names()[0] == f.Name {
-				return ctx.Bool(f.Name)
+				return ctx.Bool(f.Name), true, f.Name
 			}
 		}
 	}
 
-	// If flag not found, return the default value of the flag
+	// If flag not found, return the default value of the flag and false
 	switch f := flag.(type) {
 	case cli.IntFlag:
-		return f.Value
+		return f.Value, false, f.Name
 	case cli.Uint64Flag:
-		return f.Value
+		return f.Value, false, f.Name
 	case cli.Int64Flag:
-		return f.Value
+		return f.Value, false, f.Name
 	case cli.StringFlag:
-		return f.Value
+		return f.Value, false, f.Name
 	case cli.PathFlag:
-		return f.Value
+		return f.Value, false, f.Name
 	case cli.BoolFlag:
-		return f.Value
+		return f.Value, false, f.Name
 	}
-
-	return nil
+	return nil, false, ""
 }


### PR DESCRIPTION
## Description

This PR is (currently) ****PROOF OF CONCEPT**** (tests are missing). The config could be rewritten so that it is more modular.

After this change of structure we can print just the relevant values for the command printing only the flags which are actually used by it. It could be done by iterating over `specifiedFlags` https://github.com/Fantom-foundation/Aida/blob/bff9c34d8254272cf50f7d086211723ed5f53193/utils/config.go#L633 
There could either be generic message for each config value or there could be a map with predefined notifications.

@Lubomir-Jahn what do you think? If it works could you please expand on my initial work and finish this off?

## Issues

This will solve https://github.com/Fantom-foundation/Aida/issues/886 for not just `chainid` but for every flag.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)