### PR TITLE
Bring back detailed printing

### DIFF
--- a/executor/extension/validator/state_db_validator.go
+++ b/executor/extension/validator/state_db_validator.go
@@ -243,14 +243,15 @@ func (v *stateDbValidator) printAllocationDiffSummary(want, have *substate.Subst
 	for key := range *want {
 		_, present := (*have)[key]
 		if !present {
-			fmt.Printf("    missing key=%v\n", key)
+			v.log.Errorf("\tmissing key=%v\n", key)
+
 		}
 	}
 
 	for key := range *have {
 		_, present := (*want)[key]
 		if !present {
-			fmt.Printf("    extra key=%v\n", key)
+			v.log.Errorf("\textra key=%v\n", key)
 		}
 	}
 
@@ -272,14 +273,14 @@ func (v *stateDbValidator) printAccountDiffSummary(label string, want, have *sub
 	for key, val := range want.Storage {
 		_, present := have.Storage[key]
 		if !present && (val != common.Hash{}) {
-			fmt.Printf("    %s.Storage misses key %v val %v\n", label, key, val)
+			v.log.Errorf("\t%s.Storage misses key %v val %v\n", label, key, val)
 		}
 	}
 
 	for key := range have.Storage {
 		_, present := want.Storage[key]
 		if !present {
-			fmt.Printf("    %s.Storage has extra key %v\n", label, key)
+			v.log.Errorf("\t%s.Storage has extra key %v\n", label, key)
 		}
 	}
 

--- a/executor/extension/validator/state_db_validator_test.go
+++ b/executor/extension/validator/state_db_validator_test.go
@@ -213,6 +213,7 @@ func TestLiveTxValidator_SingleErrorInPostTransactionReturnsErrorWithNoContinueO
 		log.EXPECT().Warning(gomock.Any()),
 		db.EXPECT().GetSubstatePostAlloc().Return(substate.SubstateAlloc{}),
 		log.EXPECT().Errorf("Different %s:\nwant: %v\nhave: %v\n", "substate alloc size", 1, 0),
+		log.EXPECT().Errorf("\tmissing key=%v\n", common.Address{0}),
 	)
 
 	ext.PreRun(executor.State[*substate.Substate]{}, ctx)


### PR DESCRIPTION
## Description

This PR brings back deleted code. If error in `state_db_validator` occurs, we now print the difference between expected and returned value.

Fixes #909 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
