### PR TITLE
Add pretty printer for Substates

### DIFF
--- a/state/proxy/logger.go
+++ b/state/proxy/logger.go
@@ -282,12 +282,12 @@ func (s *loggingVmStateDb) Prepare(thash common.Hash, ti int) {
 
 func (s *LoggingStateDb) PrepareSubstate(substate *substate.SubstateAlloc, block uint64) {
 	s.state.PrepareSubstate(substate, block)
-	s.writeLog("PrepareSubstate, %v", substate)
+	s.writeLog("PrepareSubstate, %v", PrettySubstateAlloc(*substate))
 }
 
 func (s *loggingVmStateDb) GetSubstatePostAlloc() substate.SubstateAlloc {
 	res := s.db.GetSubstatePostAlloc()
-	s.writeLog("GetSubstatePostAlloc, %v", res)
+	s.writeLog("GetSubstatePostAlloc, %v", PrettySubstateAlloc(res))
 	return res
 }
 

--- a/state/proxy/substate.go
+++ b/state/proxy/substate.go
@@ -1,0 +1,52 @@
+package proxy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	substate "github.com/Fantom-foundation/Substate"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// PrettySubstateAlloc is a wrapper over a SubstateAlloc that adds human
+// readable, stable --and thus diff-able -- pretty printing to it.
+type PrettySubstateAlloc substate.SubstateAlloc
+
+func (a PrettySubstateAlloc) String() string {
+	builder := strings.Builder{}
+	builder.WriteString(fmt.Sprintf("SubstateAlloc{\n\tsize: %d\n", len(a)))
+	keys := []common.Address{}
+	for key := range a {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+
+	builder.WriteString("\tAccounts:\n")
+	for _, key := range keys {
+		builder.WriteString(fmt.Sprintf("\t\t%x: %v\n", key, prettySubstateAccount{a[key]}))
+	}
+	builder.WriteString("}")
+	return builder.String()
+}
+
+type prettySubstateAccount struct {
+	*substate.SubstateAccount
+}
+
+func (a prettySubstateAccount) String() string {
+	builder := strings.Builder{}
+	builder.WriteString(fmt.Sprintf("Account{\n\t\t\tnonce: %d\n\t\t\tbalance %v\n", a.Nonce, a.Balance))
+
+	builder.WriteString("\t\t\tStorage{\n")
+	keys := []common.Hash{}
+	for key := range a.Storage {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+	for _, key := range keys {
+		builder.WriteString(fmt.Sprintf("\t\t\t\t%v=%v\n", key, a.Storage[key]))
+	}
+	builder.WriteString("\t\t\t}\n\t\t}")
+	return builder.String()
+}


### PR DESCRIPTION
## Description

This PR adds a pretty printer for Substates to make them useful in logs. In particular prints of pointers are replaced by readable, normalised, searchable content. This ability significantly simplifies error diagnostic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
