### PR TITLE
Metadata now records runtime onPostRun.

### DIFF
--- a/executor/extension/register/metadata.go
+++ b/executor/extension/register/metadata.go
@@ -13,7 +13,7 @@ import (
 const (
 	MetadataCreateTableIfNotExist = `
 		CREATE TABLE IF NOT EXISTS metadata (
-			key STRING NOT NULL,
+			key STRING NOT NULL PRIMARY KEY,
 			value STRING NUT NULL
 		)
 	`
@@ -104,6 +104,10 @@ func MakeRunMetadata(connection string, id *RunIdentity) (*RunMetadata, error) {
 
 func (rm *RunMetadata) Print() {
 	rm.ps.Print()
+}
+
+func (rm *RunMetadata) Close() {
+	rm.ps.Close()
 }
 
 func (rm *RunMetadata) bash(cmd string) (string, error) {

--- a/executor/extension/register/register_progress.go
+++ b/executor/extension/register/register_progress.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+	"strconv"
 
 	"github.com/Fantom-foundation/Aida/executor"
 	"github.com/Fantom-foundation/Aida/executor/extension"
@@ -72,6 +73,7 @@ func MakeRegisterProgress(cfg *utils.Config, reportFrequency int) executor.Exten
 	if err != nil {
 		rp.log.Debugf("Unable to create run metadata because %s.", err)
 	} else {
+		rp.meta = rm	
 		rm.Print()
 	}
 
@@ -104,6 +106,7 @@ type registerProgress struct {
 	memory       *state.MemoryUsage
 
 	id *RunIdentity
+	meta *RunMetadata
 }
 
 func (rp *registerProgress) PreRun(_ executor.State[*substate.Substate], ctx *executor.Context) error {
@@ -149,6 +152,10 @@ func (rp *registerProgress) PostRun(_ executor.State[*substate.Substate], ctx *e
 	rp.ps.Print()
 	rp.Reset()
 	rp.ps.Close()
+
+	rp.meta.meta["Runtime"] = strconv.Itoa(int(time.Since(rp.startOfRun).Seconds()))
+	rp.meta.Print()
+	rp.meta.Close()
 
 	return nil
 }

--- a/executor/extension/register/register_progress_test.go
+++ b/executor/extension/register/register_progress_test.go
@@ -25,6 +25,12 @@ const (
 		from stats
 		where start>=:start and end<=:end;
 	`
+	sqlite3SelectFromMetadata string = `
+		select key, value
+		from metadata
+		where key=:key;
+	`
+
 )
 
 type query struct {
@@ -41,6 +47,15 @@ type statsResponse struct {
 	GasRate        float64 `db:"gas_rate"`
 	OverallTxRate  float64 `db:"overall_tx_rate"`
 	OverallGasRate float64 `db:"overall_gas_rate"`
+}
+
+type metadataQuery struct {
+	Key	         string     `db:"key"`
+}
+
+type metadataResponse struct {
+	Key	         string     `db:"key"`
+	Value            string     `db:"value"`
 }
 
 func TestRegisterProgress_DoNothingIfDisabled(t *testing.T) {
@@ -74,8 +89,18 @@ func TestRegisterProgress_InsertToDbIfEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create stats table at database %s.\n%s", connection, err)
 	}
+	
+	_, err = sDb.Exec(MetadataCreateTableIfNotExist)
+	if err != nil {
+		t.Fatalf("Unable to create metadata table at database %s.\n%s", connection, err)
+	}
 
 	stmt, err := sDb.PrepareNamed(sqlite3SelectFromStats)
+	if err != nil {
+		t.Fatalf("Failed to prepare statement using db at %s. \n%s", connection, err)
+	}
+
+	meta, err := sDb.PrepareNamed(sqlite3SelectFromMetadata)
 	if err != nil {
 		t.Fatalf("Failed to prepare statement using db at %s. \n%s", connection, err)
 	}
@@ -147,6 +172,20 @@ func TestRegisterProgress_InsertToDbIfEnabled(t *testing.T) {
 		t.Errorf("Expected #Row: %d, Actual #Row: %d", expectedRowCount, len(stats))
 	}
 
+	// Check that metadata is not duplicated
+	ms := []metadataResponse{}
+	meta.Select(&ms, metadataQuery{"Processor"})
+	if len(ms) != 1 {
+		t.Errorf("Expected runtime to be recorded once, Actual: #Row: %d", len(ms))
+	}
+
+	// check if runtime is recorded after postrun
+	meta.Select(&ms, metadataQuery{"Runtime"})
+	if len(ms) != 1 {
+		t.Errorf("Expected runtime to be recorded once, Actual: #Row: %d", len(ms))
+	}
+
+	meta.Close()
 	stmt.Close()
 	sDb.Close()
 }


### PR DESCRIPTION
In metadata, additionally records runtime after run is finished.

- [ ] New feature (non-breaking change which adds functionality)