### PR TITLE
Fix bug where disk <-> memory were erroneously recorded into db for f1

### DIFF
--- a/executor/extension/register/register_progress.go
+++ b/executor/extension/register/register_progress.go
@@ -200,8 +200,8 @@ func (rp *registerProgress) sqlite3(conn string) (string, string, string, func()
 			values = append(values, []any{
 				rp.interval.Start(),
 				rp.interval.End(),
-				disk,
 				mem,
+				disk,
 				txRate,
 				gasRate,
 				overallTxRate,


### PR DESCRIPTION
Currently, disk was recorded under memory and vice versa.

- [ ] Bug fix (non-breaking change which fixes an issue)
