### PR TITLE
F1 Scripts now access metadata when making report

### DIFF
--- a/scripts/analytics/rmd/f1.rmd
+++ b/scripts/analytics/rmd/f1.rmd
@@ -2,16 +2,7 @@
 title: "F1 Report - Transaction Processing Time"
 date: "`r Sys.Date()`"
 params:
-  HwInfo: (Hardware Info)
-  OsInfo: (OS Info)
-  Machine: (Machine Info)
-  GoInfo: (GO Info)
-  GitHash: (GithubKey)
-  StateDB: (StateDB)
-  VM: (VM)
-  db: /var/opera/Aida/tmp-rapolt/register/s5-f1.db
-  first: 479327
-  last: 22832168
+  db: /var/opera/Aida/tmp-rapolt/register/s5-f1-test.db
 ---
 
 ```{r, include = FALSE}
@@ -23,26 +14,48 @@ library(gt)
 # open database
 con <- dbConnect(SQLite(), params$db)
 
+# Fetch RunMetadata
+Metadata <- dbReadTable(con, 'metadata')
+
+first <- Metadata %>% filter(key == "First")
+last <- Metadata %>% filter(key == "Last")
+
 # load block and transaction tables into data frames and exclude lachesis transition block
-TxData <- dbReadTable(con, 'stats') %>% filter(start >= params$first & end <= params$last)
+TxData <- dbReadTable(con, 'stats') %>% filter(start >= as.integer(first$value) & end <= as.integer(last$value))
 
 # close database connection
 dbDisconnect(con)
 ```
 
+```{r, echo=FALSE, message=FALSE}
+hostname <- Metadata %>% filter(key == "Hostname")
+ip <- Metadata %>% filter(key == "IpAddress")
+processor <- Metadata %>% filter(key == "Processor")
+memory <- Metadata %>% filter(key == "Memory")
+disks <- Metadata %>% filter(key == "Disks")
+OsInfo <- Metadata %>% filter(key == "Os")
+GoInfo <- Metadata %>% filter(key == "GoVersion")
+aidaHash <- Metadata %>% filter(key == "AidaGitHash")
+dbImpl <- Metadata %>% filter(key == "DbImpl")
+dbVariant <- Metadata %>% filter(key == "DbVariant")
+carmenSchema <- Metadata %>% filter(key == "CarmenSchema")
+vmImpl <- Metadata %>% filter(key == "VmImpl")
+```
+
 ## 1. Experimental Setup
-The experiment is run on the machine `r params$Machine`, which is a `r params$HwInfo` computer.
-The operating system is `r params$OsInfo`.
-The system has installed `r params$GoInfo`.
-The github hash of the Aida repository is `r params$GitHash`.
-For this experiment, we use **`r params$StateDB`** as a StateDB and **`r params$VM`** as a virtual machine.
-The data set for this experiment is stored in the database `r params$db`.
+The experiment is run on the machine **`r hostname$value`**(**`r ip$value`**), which is a **`r processor$value`**, **`r memory$value`**, disks: **`r disks$value`** computer.
+The operating system is **`r OsInfo$value`**.
+The system has installed **`r GoInfo$value`**.
+The github hash of the Aida repository is **`r aidaHash$value`**.
+For this experiment, we use **`r dbImpl$value`**(**`r dbVariant$value`** **`r carmenSchema$value`**) as a StateDB and **`r vmImpl$value`** as a virtual machine.  
+The data set for this experiment is stored in the database **`r params$db`**.
 
 ## 2. Memory and Disk Usage
 
 ```{r, echo=FALSE, message=FALSE}
 maxMemory <- TxData %>% filter(memory == max(memory))
-maxDisk <- TxData %>% filter(disk == max(disk))
+maxLiveDisk <- TxData %>% filter(live_disk == max(live_disk))
+maxArchiveDisk <- TxData %>% filter(archive_disk == max(archive_disk))
 ```
 
 The experiment was conducted for the block range from **`r format(min(TxData$start),big.mark=",")`**  to **`r format(max(TxData$end),big.mark=",")`**.
@@ -56,11 +69,11 @@ TxData %>% mutate(memory = as.numeric(memory)) %>%
    labs(x="Block Height", y="Ram Consumption (Bytes)", title="Memory Usage")
 ```
 
-Max Disk Usage throughout the run is **`r format(maxMemory$disk, big.mark=",")`** bytes at block height **`r format(maxMemory$start, big.mark=",")`**
+Max Disk Usage throughout the run is **`r format(maxLiveDisk$live_disk, big.mark=",")`** bytes at block height **`r format(maxLiveDisk$start, big.mark=",")`**
 
 ```{r, echo=FALSE, message=FALSE, fig.width=12, fig.height=8}
-TxData %>% mutate(disk = as.numeric(disk)) %>%
-   ggplot(aes(x = start, y = disk)) +
+TxData %>% mutate(live_disk = as.numeric(live_disk)) %>%
+   ggplot(aes(x = start, y = live_disk)) +
    geom_point(alpha=0.3) +
    labs(x="Block Height", y="Disk Consumption (Bytes)", title="Disk Usage")
 ```

--- a/scripts/analytics/rmd/gen_processing_reports.sh
+++ b/scripts/analytics/rmd/gen_processing_reports.sh
@@ -3,7 +3,7 @@
 #    gen_processing_reports.sh -  script for generating the block processing reports
 #
 # Synopsis: 
-#    gen_processing_report.sh <db-impl> <db-variant> <carmen-schema> <vm-impl> <output-dir>
+#    gen_processing_report.sh <output-dir>
 #
 # Description: 
 #    Produces block processing reports in the HTML format.
@@ -13,60 +13,16 @@
 # 
 
 # check the number of command line arguments
-if [ "$#" -ne 5 ]; then
+if [ "$#" -ne 1 ]; then
     echo "Invalid number of command line arguments supplied"
     exit 1
 fi
 
 # assign variables for command line arguments
-dbimpl=$1
-dbvariant=$2
-carmenschema=$3
-vmimpl=$4
-outputdir=$5
+outputdir=$1
 
-# logging 
-log() {
-    echo "$(date) $1" | tee -a "$outputdir/gen_processing_reports.log"
-}
-
-#  HardwareDescription() queries the hardware configuration of the server.
-HardwareDescription()  {
-    processor=`cat /proc/cpuinfo | grep "^model name" | head -n 1 | awk -F': ' '{print $2}'`
-    memory=`free | grep "^Mem:" | awk '{printf("%dGB RAM\n", $2/1024/1024)}'` 
-    disks=`hwinfo  --disk | grep Model | awk -F ': \"' '{if (NR > 1) printf(", "); printf("%s", substr($2,1,length($2)-1));}  END {printf("\n")}'`
-    echo "$processor, $memory, disks: $disks"
-}
-
-# OperatingSystemDescription() queries the operating system of the server.
-OperatingSystemDescription() {
-    bash -lic 'source /etc/*-release; echo $DISTRIB_DESCRIPTION'
-}
-
-## GitHash() queries the git hash of the Aida repository
-GitHash() {
-   git rev-parse HEAD
-}
-
-## GoVersion() queries the Go version installed on the server
-GoVersion() {
-    go version
-}
-
-## Machine() queries machine name and IP address of server
-Machine() {
-    echo "`hostname`(`curl -s api.ipify.org`)"
-}
-
-# query the configuration
-log "query configuration ..."
-hw=`HardwareDescription`
-os=`OperatingSystemDescription`
-machine=`Machine`
-gh=`GitHash`
-go=`GoVersion`
-statedb="$dbimpl($dbvariant $carmenschema)"
-
-log "render s3 report ..."
-/home/rapolt/dev/aida/scripts/analytics/rmd/knit.R -p "GitHash='$gh', HwInfo='$hw', OsInfo='$os', Machine='$machine', GoInfo='$go', VM='$vmimpl', StateDB='$statedb'" \
-                 -d /var/opera/Aida/tmp-rapolt/register/s5-f1.db -f html -o test.html -O $outputdir /home/rapolt/dev/aida/scripts/analytics/rmd/f1.rmd
+log "render f1 report ..."
+/home/rapolt/dev/aida/scripts/analytics/rmd/knit.R \
+                 -d /var/opera/Aida/tmp-rapolt/register/s5-f1-test.db \
+		 -f html -o test.html \
+		 -O $outputdir /home/rapolt/dev/aida/scripts/analytics/rmd/f1.rmd


### PR DESCRIPTION
F1 scripts now used the collected metadata rather than figuring out the environment at the start of report generation.

TODO: have a separate script that checks the metadata if the run fails -> print fail report.

- [ ] New feature (non-breaking change which adds functionality)
