### PR TITLE
Block Processing Report Bug Fixes

### DIFF
--- a/scripts/analytics/rmd/f1.rmd
+++ b/scripts/analytics/rmd/f1.rmd
@@ -41,6 +41,7 @@ maxGasRate <- TxData %>% filter(gas_rate == max(gas_rate)) %>% distinct(gas_rate
 runId <- Metadata %>% filter(key == "RunId")
 runSucceed <- Metadata %>% filter(key == "RunSucceed")
 runtime <- Metadata %>% filter(key == "Runtime")
+runError <- Metadata %>% filter(key == "RunError")
 isRunSuccess <- runSucceed$value == "true"
 
 archiveMode <- Metadata %>% filter(key == "ArchiveMode")
@@ -64,6 +65,10 @@ Run `r runId$value` **`r if(isRunSuccess){
 } else {
 	colorize(paste0("failed"), "red")
 }`**. The runtime is **`r format(round(as.numeric(runtime$value)/3600, 2), digit=3)`** hours.
+
+    `r if(!isRunSuccess) {
+        runError$value
+    }`
 
 ```{r, echo=FALSE, message=FALSE}
 rTx  <- data.frame(Property="Transaction Rate", Mean=fmt(mean(TxData$tx_rate), 1, "TPS", 4), Max=fmt(max(TxData$tx_rate), 1, "TPS", 4))


### PR DESCRIPTION
- Remove disk info from report. Disk metadata is displayed as *** because docker does not have access to disk information.
- Fix max value duplication. Sometimes the max value report is duplicated e.g. "1234, 1234" rather than "1234". This happens when the max value occurs multiple times. Added a unique clause to db fetching.
- all per minute (TPM, GPM) is now displayed as per second.
- Report name changed to "Block Processing Report"
- Double check all the unit in the report.
- MGPS renamed to MGasPS to be in line with the previous report.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)