### PR TITLE
Remove git branch param from jenkinsfile post block

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,6 @@ pipeline {
                 string(name: 'duration', value: "${currentBuild.duration}"),
                 string(name: 'url', value: "$currentBuild.absoluteUrl"),
                 string(name: 'user', value: env.CHANGE_AUTHOR),
-                string(name: 'branch', value: env.BRANCH_NAME),
             ]
         }
     }


### PR DESCRIPTION
## Description

Removes git branch parameter from jenkinsfile post block as it is no longer used in slack notification pipeline

## Type of change

- [x] Refactoring (changes that do NOT affect functionality)
