### PR TITLE
Skip receipt validation of pseudo transactions

### DIFF
--- a/executor/extension/validator/transaction_validator.go
+++ b/executor/extension/validator/transaction_validator.go
@@ -145,7 +145,8 @@ func (v *stateDbValidator) runPostTxValidation(tool string, db state.VmStateDB, 
 		}
 	}
 
-	if v.target.Receipt {
+	// TODO remove state.Transaction < 99999 after patch aida-db
+	if v.target.Receipt && state.Transaction < 99999 {
 		if err := v.validateReceipt(res, state.Data.GetReceipt()); err != nil {
 			err = fmt.Errorf("%v err:\nvm-result error at block %v tx %v; %v", tool, state.Block, state.Transaction, err)
 			if v.isErrFatal(err, errOutput) {


### PR DESCRIPTION
## Description

Substate of block 4564025 contains log and gas used which should be empty. This workaround skips receipt validation of pseudo transactions and allow aida test to resume.

Fixes #960 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
