### PR TITLE
Fix getBlockHash returns unexpected missing hash error

### DIFF
--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -231,10 +231,8 @@ func (s *TxProcessor) processPseudoTx(ws txcontext.WorldState, db state.VmStateD
 // prepareBlockCtx creates a block context for evm call from given BlockEnvironment.
 func prepareBlockCtx(inputEnv txcontext.BlockEnvironment, hashError *error) *vm.BlockContext {
 	getHash := func(num uint64) common.Hash {
-		h := inputEnv.GetBlockHash(num)
-		if h == (common.Hash{}) {
-			*hashError = fmt.Errorf("hash for block %v was not found", num)
-		}
+		var h common.Hash
+		h, *hashError = inputEnv.GetBlockHash(num)
 		return h
 	}
 

--- a/txcontext/block_environment.go
+++ b/txcontext/block_environment.go
@@ -24,7 +24,7 @@ type BlockEnvironment interface {
 	GetTimestamp() uint64
 
 	// GetBlockHash returns the hash of the block with the given number.
-	GetBlockHash(blockNumber uint64) common.Hash
+	GetBlockHash(blockNumber uint64) (common.Hash, error)
 
 	// GetBaseFee returns the base fee for transactions in the current block.
 	GetBaseFee() *big.Int

--- a/txcontext/substate/block_environment.go
+++ b/txcontext/substate/block_environment.go
@@ -1,6 +1,7 @@
 package substate
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/Fantom-foundation/Aida/txcontext"
@@ -20,11 +21,15 @@ type blockEnvironment struct {
 	*substate.SubstateEnv
 }
 
-func (e *blockEnvironment) GetBlockHash(block uint64) common.Hash {
+func (e *blockEnvironment) GetBlockHash(block uint64) (common.Hash, error) {
 	if e.BlockHashes == nil {
-		return common.Hash{}
+		return common.Hash{}, fmt.Errorf("getHash(%d) invoked, no blockhashes provided", block)
 	}
-	return e.BlockHashes[block]
+	h, ok := e.BlockHashes[block]
+	if !ok {
+		return common.Hash(h), fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", block)
+	}
+	return common.Hash(h), nil
 }
 
 func (e *blockEnvironment) GetCoinbase() common.Address {

--- a/txcontext/substate/newsubstate/block_environment.go
+++ b/txcontext/substate/newsubstate/block_environment.go
@@ -1,6 +1,7 @@
 package newsubstate
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/Fantom-foundation/Aida/txcontext"
@@ -16,11 +17,15 @@ type blockEnvironment struct {
 	*substate.Env
 }
 
-func (e *blockEnvironment) GetBlockHash(block uint64) common.Hash {
+func (e *blockEnvironment) GetBlockHash(block uint64) (common.Hash, error) {
 	if e.BlockHashes == nil {
-		return common.Hash{}
+		return common.Hash{}, fmt.Errorf("getHash(%d) invoked, no blockhashes provided", block)
 	}
-	return common.Hash(e.BlockHashes[block])
+	h, ok := e.BlockHashes[block]
+	if !ok {
+		return common.Hash(h), fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", block)
+	}
+	return common.Hash(h), nil
 }
 
 func (e *blockEnvironment) GetCoinbase() common.Address {


### PR DESCRIPTION
## Description

Revert getBlockHash to the original code. Make getBlockHash returns both hash and an error.

Fixes #954 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)