### PR TITLE
Fix last keyword

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -47,6 +47,8 @@ const (
 	AidaDbRepositoryEthereumUrl = "https://aida.ethereum.repository.fantom.network"
 )
 
+const maxLastBlock = math.MaxUint64 - 1 // we decrease the value by one because params are always +1
+
 var (
 	FirstOperaBlock     uint64 // id of the first block in substate
 	AidaDbRepositoryUrl string // url of the Aida DB repository
@@ -68,7 +70,7 @@ var keywordBlocks = map[ChainID]map[string]uint64{
 		"berlin":    37_455_223,
 		"london":    37_534_833,
 		"first":     0,
-		"last":      math.MaxUint64 - 1, // we decrease the value by one because params are always +1
+		"last":      maxLastBlock,
 		"lastpatch": 0,
 	},
 	TestnetChainID: {
@@ -77,7 +79,7 @@ var keywordBlocks = map[ChainID]map[string]uint64{
 		"berlin":    1_559_470,
 		"london":    7_513_335,
 		"first":     0,
-		"last":      math.MaxUint64 - 1, // we decrease the value by one because params are always +1
+		"last":      maxLastBlock,
 		"lastpatch": 0,
 	},
 	// ethereum fork blocks are not stored in this structure as ethereum has already prepared config

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -149,7 +149,7 @@ func TestUtilsConfig_SetBlockRange(t *testing.T) {
 		t.Fatalf("Failed to parse first block; expected: %d, have: %d", 0, first)
 	}
 
-	if last != math.MaxUint64-1 {
+	if last != maxLastBlock {
 		t.Fatalf("Failed to parse last block; expected: %v, have: %v", uint64(math.MaxUint64), last)
 	}
 
@@ -163,7 +163,7 @@ func TestUtilsConfig_SetBlockRange(t *testing.T) {
 		t.Fatalf("Failed to parse first block; expected: %d, have: %d", 0, first)
 	}
 
-	if last != math.MaxUint64-1 {
+	if last != maxLastBlock {
 		t.Fatalf("Failed to parse last block; expected: %v, have: %v", uint64(math.MaxUint64), last)
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes `last` block keyword. When `last` is used as argument, we put `MaxUint` causing overflowing because last params are always +1 cause setting "cfg.Last" to 0.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)