### PR TITLE
RegisterRun now first on extension list when running apps.

### DIFF
--- a/cmd/aida-vm-sdb/run_substate.go
+++ b/cmd/aida-vm-sdb/run_substate.go
@@ -45,6 +45,11 @@ func runSubstates(
 ) error {
 	// order of extensionList has to be maintained
 	var extensionList = []executor.Extension[txcontext.TxContext]{
+		register.MakeRegisterProgress(cfg, 100_000),
+		// RegisterProgress should be the first on the list = last to receive PostRun.
+		// This is because it collects the error and records it externally.
+		// If not, error that happen afterwards (e.g. on top of) will not be correctly recorded.
+
 		profiler.MakeCpuProfiler[txcontext.TxContext](cfg),
 		profiler.MakeDiagnosticServer[txcontext.TxContext](cfg),
 	}
@@ -61,11 +66,6 @@ func runSubstates(
 	extensionList = append(extensionList, extra...)
 
 	extensionList = append(extensionList, []executor.Extension[txcontext.TxContext]{
-		register.MakeRegisterProgress(cfg, 100_000),
-		// RegisterProgress should be the first on the list = last to receive PostRun.
-		// This is because it collects the error and records it externally.
-		// If not, error that happen afterwards (e.g. on top of) will not be correcly recorded.
-
 		profiler.MakeThreadLocker[txcontext.TxContext](),
 		aidadb.MakeAidaDbManager[txcontext.TxContext](cfg),
 		profiler.MakeVirtualMachineStatisticsPrinter[txcontext.TxContext](cfg),


### PR DESCRIPTION
Currently RegisterRun is not the first on the extension list, thus potentially not capturing some errors from any extension that is above it.
Credit to @petr-hanzl for the heads up.
