### PR TITLE
Add db-logging extension to aida-rpc

### DIFF
--- a/cmd/aida-rpc/run_rpc.go
+++ b/cmd/aida-rpc/run_rpc.go
@@ -72,6 +72,7 @@ func run(
 			extensionList,
 			statedb.MakeStateDbManager[*rpc.RequestAndResults](cfg),
 			statedb.MakeArchiveBlockChecker[*rpc.RequestAndResults](cfg),
+			logger.MakeDbLogger[*rpc.RequestAndResults](cfg),
 		)
 
 	}


### PR DESCRIPTION
## Description

Add a missing db-logging extension in RPC.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)