### PR TITLE
Revert putting register-run first on extension list

### DIFF
--- a/cmd/aida-vm-sdb/run_substate.go
+++ b/cmd/aida-vm-sdb/run_substate.go
@@ -45,11 +45,6 @@ func runSubstates(
 ) error {
 	// order of extensionList has to be maintained
 	var extensionList = []executor.Extension[txcontext.TxContext]{
-		register.MakeRegisterProgress(cfg, 100_000),
-		// RegisterProgress should be the first on the list = last to receive PostRun.
-		// This is because it collects the error and records it externally.
-		// If not, error that happen afterwards (e.g. on top of) will not be correctly recorded.
-
 		profiler.MakeCpuProfiler[txcontext.TxContext](cfg),
 		profiler.MakeDiagnosticServer[txcontext.TxContext](cfg),
 	}
@@ -66,6 +61,11 @@ func runSubstates(
 	extensionList = append(extensionList, extra...)
 
 	extensionList = append(extensionList, []executor.Extension[txcontext.TxContext]{
+		register.MakeRegisterProgress(cfg, 100_000),
+		// RegisterProgress should be the first on the list = last to receive PostRun.
+		// This is because it collects the error and records it externally.
+		// If not, error that happen afterwards (e.g. on top of) will not be correctly recorded.
+
 		profiler.MakeThreadLocker[txcontext.TxContext](),
 		aidadb.MakeAidaDbManager[txcontext.TxContext](cfg),
 		profiler.MakeVirtualMachineStatisticsPrinter[txcontext.TxContext](cfg),


### PR DESCRIPTION
Putting register-run first on extension list causes it to have nil `ctx.stateDbPath`.
Reverting this for the time being.

TODO: refactor error catching as a different extension.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
