### PR TITLE
Now also records --db-src and --rpc-recordings when executing aida-rpc

### DIFF
--- a/executor/extension/register/identifier.go
+++ b/executor/extension/register/identifier.go
@@ -60,6 +60,9 @@ func (id *RunIdentity) fetchConfigInfo() (map[string]string, error) {
 		"ArchiveVariant":   id.Cfg.ArchiveVariant,
 		"ChainId":          strconv.Itoa(int(id.Cfg.ChainID)),
 
+		"DbSrc":         id.Cfg.StateDbSrc,
+		"RpcRecordings": id.Cfg.RpcRecordingFile,
+
 		"First": strconv.Itoa(int(id.Cfg.First)),
 		"Last":  strconv.Itoa(int(id.Cfg.Last)),
 


### PR DESCRIPTION
Now also records --db-src and --rpc-recordings when executing aida-rpc
https://github.com/Fantom-foundation/Aida/issues/989

- [ ] New feature (non-breaking change which adds functionality)
