### PR TITLE
Add DbManager to Transaction Generator

### DIFF
--- a/cmd/aida-vm-sdb/run_tx_generator.go
+++ b/cmd/aida-vm-sdb/run_tx_generator.go
@@ -49,6 +49,7 @@ func runTransactions(
 		tracker.MakeBlockProgressTracker(cfg, 100),
 		profiler.MakeMemoryUsagePrinter[txcontext.TxContext](cfg),
 		profiler.MakeMemoryProfiler[txcontext.TxContext](cfg),
+		statedb.MakeStateDbManager[txcontext.TxContext](cfg),
 		statedb.MakeTxGeneratorBlockEventEmitter[txcontext.TxContext](),
 	}
 

--- a/cmd/aida-vm-sdb/run_tx_generator_test.go
+++ b/cmd/aida-vm-sdb/run_tx_generator_test.go
@@ -78,6 +78,9 @@ func TestVmSdb_TxGenerator_AllTransactionsAreProcessedInOrder(t *testing.T) {
 		ext.EXPECT().PostTransaction(executor.AtTransaction[txcontext.TxContext](4, 1), gomock.Any()),
 		ext.EXPECT().PostRun(executor.AtBlock[txcontext.TxContext](4), gomock.Any(), nil),
 		db.EXPECT().EndBlock(),
+
+		// db_manager closes the db
+		db.EXPECT().Close(),
 	)
 
 	if err := runTransactions(cfg, provider, db, processor, []executor.Extension[txcontext.TxContext]{ext}); err != nil {

--- a/executor/extension/statedb/state_db_manager.go
+++ b/executor/extension/statedb/state_db_manager.go
@@ -27,9 +27,11 @@ type stateDbManager[T any] struct {
 
 func (m *stateDbManager[T]) PreRun(_ executor.State[T], ctx *executor.Context) error {
 	var err error
-	ctx.State, ctx.StateDbPath, err = utils.PrepareStateDB(m.cfg)
-	if err != nil {
-		return err
+	if ctx.State == nil {
+		ctx.State, ctx.StateDbPath, err = utils.PrepareStateDB(m.cfg)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !m.cfg.ShadowDb {


### PR DESCRIPTION
## Description

This PR adds `state_db_manager` extension to `transaction generator`. Even though the extension does not create the Db, we still need to close it and remove it after the run and this is handled by the `manager`.


## Type of change

- [ ] New feature (non-breaking change which adds functionality)

