### PR TITLE
fix missing statedb path

### DIFF
--- a/cmd/aida-rpc/run_rpc.go
+++ b/cmd/aida-rpc/run_rpc.go
@@ -76,7 +76,7 @@ func run(
 	if stateDb == nil {
 		extensionList = append(
 			extensionList,
-			statedb.MakeStateDbManager[*rpc.RequestAndResults](cfg),
+			statedb.MakeStateDbManager[*rpc.RequestAndResults](cfg, ""),
 			statedb.MakeArchiveBlockChecker[*rpc.RequestAndResults](cfg),
 			logger.MakeDbLogger[*rpc.RequestAndResults](cfg),
 		)

--- a/cmd/aida-sdb/trace/replay.go
+++ b/cmd/aida-sdb/trace/replay.go
@@ -77,7 +77,7 @@ func replay(
 		logger.MakeProgressLogger[[]operation.Operation](cfg, 0),
 		profiler.MakeMemoryUsagePrinter[[]operation.Operation](cfg),
 		profiler.MakeMemoryProfiler[[]operation.Operation](cfg),
-		statedb.MakeStateDbManager[[]operation.Operation](cfg),
+		statedb.MakeStateDbManager[[]operation.Operation](cfg, ""),
 		primer.MakeStateDbPrimer[[]operation.Operation](cfg),
 	}
 

--- a/cmd/aida-sdb/trace/replay_substate.go
+++ b/cmd/aida-sdb/trace/replay_substate.go
@@ -79,7 +79,7 @@ func replaySubstate(
 	}
 
 	if stateDb == nil {
-		extensionList = append(extensionList, statedb.MakeStateDbManager[txcontext.TxContext](cfg))
+		extensionList = append(extensionList, statedb.MakeStateDbManager[txcontext.TxContext](cfg, ""))
 	}
 
 	if cfg.DbImpl == "memory" {

--- a/cmd/aida-vm-adb/run_vm_adb.go
+++ b/cmd/aida-vm-adb/run_vm_adb.go
@@ -56,7 +56,7 @@ func run(
 	if stateDb == nil {
 		extensionList = append(
 			extensionList,
-			statedb.MakeStateDbManager[txcontext.TxContext](cfg),
+			statedb.MakeStateDbManager[txcontext.TxContext](cfg, ""),
 			statedb.MakeArchiveBlockChecker[txcontext.TxContext](cfg),
 			logger.MakeDbLogger[txcontext.TxContext](cfg),
 		)

--- a/cmd/aida-vm-sdb/run_substate.go
+++ b/cmd/aida-vm-sdb/run_substate.go
@@ -52,7 +52,7 @@ func runSubstates(
 	if stateDb == nil {
 		extensionList = append(
 			extensionList,
-			statedb.MakeStateDbManager[txcontext.TxContext](cfg),
+			statedb.MakeStateDbManager[txcontext.TxContext](cfg, ""),
 			statedb.MakeLiveDbBlockChecker[txcontext.TxContext](cfg),
 			logger.MakeDbLogger[txcontext.TxContext](cfg),
 		)

--- a/cmd/aida-vm-sdb/run_tx_generator_test.go
+++ b/cmd/aida-vm-sdb/run_tx_generator_test.go
@@ -83,7 +83,7 @@ func TestVmSdb_TxGenerator_AllTransactionsAreProcessedInOrder(t *testing.T) {
 		db.EXPECT().Close(),
 	)
 
-	if err := runTransactions(cfg, provider, db, processor, []executor.Extension[txcontext.TxContext]{ext}); err != nil {
+	if err := runTransactions(cfg, provider, db, "dummyPath", processor, []executor.Extension[txcontext.TxContext]{ext}); err != nil {
 		t.Errorf("run failed: %v", err)
 	}
 }

--- a/executor/extension/statedb/state_db_manager.go
+++ b/executor/extension/statedb/state_db_manager.go
@@ -12,17 +12,19 @@ import (
 )
 
 // MakeStateDbManager creates a executor.Extension that commits state of StateDb if keep-db is enabled
-func MakeStateDbManager[T any](cfg *utils.Config) executor.Extension[T] {
+func MakeStateDbManager[T any](cfg *utils.Config, knownDbPath string) executor.Extension[T] {
 	return &stateDbManager[T]{
-		cfg: cfg,
-		log: logger.NewLogger(cfg.LogLevel, "Db manager"),
+		cfg:    cfg,
+		log:    logger.NewLogger(cfg.LogLevel, "Db manager"),
+		dbPath: knownDbPath,
 	}
 }
 
 type stateDbManager[T any] struct {
 	extension.NilExtension[T]
-	cfg *utils.Config
-	log logger.Logger
+	cfg    *utils.Config
+	log    logger.Logger
+	dbPath string // state db path if the  db is created out side of this extension
 }
 
 func (m *stateDbManager[T]) PreRun(_ executor.State[T], ctx *executor.Context) error {
@@ -32,6 +34,8 @@ func (m *stateDbManager[T]) PreRun(_ executor.State[T], ctx *executor.Context) e
 		if err != nil {
 			return err
 		}
+	} else {
+		ctx.StateDbPath = m.dbPath
 	}
 
 	if !m.cfg.ShadowDb {

--- a/executor/extension/statedb/state_db_manager_test.go
+++ b/executor/extension/statedb/state_db_manager_test.go
@@ -19,7 +19,7 @@ import (
 func TestStateDbManager_DbClosureWithoutKeepDb(t *testing.T) {
 	cfg := &utils.Config{}
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	mockCtrl := gomock.NewController(t)
 	mockStateDB := state.NewMockStateDB(mockCtrl)
@@ -46,7 +46,7 @@ func TestStateDbManager_DbClosureWithKeepDb(t *testing.T) {
 	cfg.KeepDb = true
 	cfg.ChainID = utils.MainnetChainID
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	mockCtrl := gomock.NewController(t)
 	mockStateDB := state.NewMockStateDB(mockCtrl)
@@ -77,7 +77,7 @@ func TestStateDbManager_DoNotKeepDb(t *testing.T) {
 	cfg.KeepDb = false
 	cfg.ChainID = utils.MainnetChainID
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	state := executor.State[any]{
 		Block: 0,
@@ -111,7 +111,7 @@ func TestStateDbManager_KeepDbAndDoesntUnderflowBellowZero(t *testing.T) {
 	cfg.KeepDb = true
 	cfg.ChainID = utils.MainnetChainID
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	state := executor.State[any]{
 		Block: 0,
@@ -145,7 +145,7 @@ func TestStateDbManager_StateDbInfoExistence(t *testing.T) {
 	cfg.KeepDb = true
 	cfg.ChainID = utils.MainnetChainID
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	state := executor.State[any]{
 		Block: 0,
@@ -182,7 +182,7 @@ func TestStateDbManager_NonExistentStateDbSrc(t *testing.T) {
 	cfg.KeepDb = true
 	cfg.ChainID = utils.MainnetChainID
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	state := executor.State[any]{
 		Block: 0,
@@ -210,7 +210,7 @@ func TestStateDbManager_StateDbSrcStateDbIsReadOnly(t *testing.T) {
 	cfg.KeepDb = true
 	cfg.ChainID = utils.MainnetChainID
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	state0 := executor.State[any]{
 		Block: 0,
@@ -243,7 +243,7 @@ func TestStateDbManager_StateDbSrcStateDbIsReadOnly(t *testing.T) {
 	cfg.KeepDb = false
 	cfg.SrcDbReadonly = true
 
-	ext = MakeStateDbManager[any](cfg)
+	ext = MakeStateDbManager[any](cfg, "")
 
 	ctx = &executor.Context{}
 
@@ -290,7 +290,7 @@ func TestStateDbManager_UsingExistingSourceDb(t *testing.T) {
 	cfg.KeepDb = true
 	cfg.ChainID = utils.MainnetChainID
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	state0 := executor.State[any]{
 		Block: 0,
@@ -321,7 +321,7 @@ func TestStateDbManager_UsingExistingSourceDb(t *testing.T) {
 	cfg.DbTmp = tmpOutDir
 	cfg.StateDbSrc = sourcePath
 
-	ext = MakeStateDbManager[any](cfg)
+	ext = MakeStateDbManager[any](cfg, "")
 
 	ctx = &executor.Context{}
 
@@ -383,7 +383,7 @@ func TestStateDbManager_StateDbBlockNumberDecrements(t *testing.T) {
 	cfg.KeepDb = true
 	cfg.ChainID = utils.MainnetChainID
 
-	ext := MakeStateDbManager[any](cfg)
+	ext := MakeStateDbManager[any](cfg, "")
 
 	state := executor.State[any]{
 		Block: 10,


### PR DESCRIPTION
## Description

This PR fixes an issue of missing state-db path for tx-generator tool.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
