### PR TITLE
Fix eth test

### DIFF
--- a/cmd/aida-vm-sdb/run_eth_test.go
+++ b/cmd/aida-vm-sdb/run_eth_test.go
@@ -173,17 +173,19 @@ func TestVmSdb_Eth_ValidationDoesNotFailOnValidTransaction(t *testing.T) {
 		})
 
 	gomock.InOrder(
-		// Tx 1
-		// Validation
 		db.EXPECT().Exist(common.HexToAddress("0x1")).Return(true),
 		db.EXPECT().GetBalance(gomock.Any()).Return(big.NewInt(1000)),
 		db.EXPECT().GetNonce(common.HexToAddress("0x1")).Return(uint64(1)),
 		db.EXPECT().GetCode(common.HexToAddress("0x1")).Return([]byte{}),
+	)
+	gomock.InOrder(
 		db.EXPECT().Exist(common.HexToAddress("0x2")).Return(true),
 		db.EXPECT().GetBalance(gomock.Any()).Return(big.NewInt(2000)),
 		db.EXPECT().GetNonce(common.HexToAddress("0x2")).Return(uint64(2)),
 		db.EXPECT().GetCode(common.HexToAddress("0x2")).Return([]byte{}),
+	)
 
+	gomock.InOrder(
 		// Tx execution
 		db.EXPECT().BeginBlock(uint64(2)),
 		db.EXPECT().BeginTransaction(uint32(1)),


### PR DESCRIPTION
## Description

This PR fixes sporadic fail on `eth_test` test.
The fail is caused by `WorldState Alloc` (which is a `map`) not being in order, so `gomock.InOrder()` call sometimes failed.

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
