### PR TITLE
Add missing --validate-state-hash flag

### DIFF
--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -50,6 +50,7 @@ var RunEthTestsCmd = cli.Command{
 		&utils.ChainIDFlag,
 		&utils.ContinueOnFailureFlag,
 		&utils.ValidateFlag,
+		&utils.ValidateStateHashesFlag,
 		&log.LogLevelFlag,
 		&utils.ErrorLoggingFlag,
 	},


### PR DESCRIPTION
## Description

Add a missing validate state hash flag in Ethereum tests tool.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)