### PR TITLE
RegisterProgress can be configured onPreBlock/onPreTransaction

### DIFF
--- a/cmd/aida-vm-sdb/run_tx_generator.go
+++ b/cmd/aida-vm-sdb/run_tx_generator.go
@@ -48,7 +48,7 @@ func runTransactions(
 	var extensionList = []executor.Extension[txcontext.TxContext]{
 		profiler.MakeVirtualMachineStatisticsPrinter[txcontext.TxContext](cfg),
 		statedb.MakeStateDbManager[txcontext.TxContext](cfg, stateDbPath),
-		register.MakeRegisterProgress(cfg, 100_000),
+		register.MakeRegisterProgress(cfg, 0),
 		// RegisterProgress should be the as top-most as possible on the list
 		// In this case, after StateDb is created.
 		// Any error that happen in extension above it will not be correctly recorded.

--- a/executor/extension/register/register_progress.go
+++ b/executor/extension/register/register_progress.go
@@ -68,7 +68,7 @@ func MakeRegisterProgress(cfg *utils.Config, reportFrequency int) executor.Exten
 	if reportFrequency == 0 {
 		switch {
 		case cfg.CommandName == TxGeneratorCommandName && cfg.BlockLength != 0:
-			reportFrequency = int(math.Ceil(float64(500) / float64(cfg.BlockLength)))
+			reportFrequency = int(math.Ceil(float64(50_000) / float64(cfg.BlockLength)))
 		default:
 			reportFrequency = RegisterProgressDefaultReportFrequency
 		}


### PR DESCRIPTION
Currently, RegisterProgress always do print on PreBlock.
However in tx-generator, there are complications such that the signal-to-print can only be done on PreTransaction.

In response, RegisterProgress now has additional configuration "WhenToPrint", which defaults to OnPreBlock.
Any command under "tx-generator" will instead uses OnPreTransaction.


- [ ] Bug fix (non-breaking change which fixes an issue)
