### PR TITLE
Change go-opera dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ aida-rpc: carmen tosca
 
 aida-stochastic-sdb: carmen tosca
 	GOPROXY=$(GOPROXY) \
-	GOPRIVATE=github.com/Fantom-foundation/Carmen,github.com/Fantom-foundation/go-opera-fvm \
+	GOPRIVATE=github.com/Fantom-foundation/Carmen \
 	go build -ldflags "-s -w -X 'github.com/Fantom-foundation/Aida/utils.GitCommit=$(BUILD_COMMIT)'" \
 	-o $(GO_BIN)/aida-stochastic-sdb \
 	./cmd/aida-stochastic-sdb
@@ -62,7 +62,7 @@ aida-vm-sdb: carmen tosca
 
 aida-vm: carmen tosca
 	GOPROXY=$(GOPROXY) \
-	GOPRIVATE=github.com/Fantom-foundation/Carmen,github.com/Fantom-foundation/go-opera-fvm \
+	GOPRIVATE=github.com/Fantom-foundation/Carmen \
 	go build -ldflags "-s -w -X 'github.com/Fantom-foundation/Aida/utils.GitCommit=$(BUILD_COMMIT)'" \
 	-o $(GO_BIN)/aida-vm \
 	./cmd/aida-vm

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Fantom-foundation/Substate v0.0.0-20240117110940-3ffd9c344809
 	github.com/Fantom-foundation/Tosca v0.0.0-20230527064715-aa1fc97baebe
 	github.com/Fantom-foundation/go-opera v1.1.1-rc.2
-	github.com/Fantom-foundation/lachesis-base v0.0.0-20221208123620-82a6d15f995c
+	github.com/Fantom-foundation/lachesis-base v0.0.0-20230817040848-1326ba9aa59b
 	github.com/dsnet/compress v0.0.1
 	github.com/ethereum/go-ethereum v1.11.6
 	github.com/fatih/color v1.15.0
@@ -146,6 +146,6 @@ replace github.com/ethereum/evmc/v10 => ./tosca/third_party/evmc
 
 replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230331085425-52296093a646
 
-replace github.com/Fantom-foundation/go-opera => github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20230523093256-e592c59c5996
+replace github.com/Fantom-foundation/go-opera => github.com/Fantom-foundation/go-opera v1.1.3-rc.5
 
 replace github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -70,10 +70,10 @@ github.com/Fantom-foundation/Substate v0.0.0-20240117110940-3ffd9c344809 h1:3ufC
 github.com/Fantom-foundation/Substate v0.0.0-20240117110940-3ffd9c344809/go.mod h1:HjYEJRhJV7l6j+i2LI5mxtpYf55TSfE2SI26T2J3P90=
 github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230331085425-52296093a646 h1:wlo+TbNH2ZekB7uFMR69Z13ie6LvVdIIERXXojEc0ws=
 github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230331085425-52296093a646/go.mod h1:Hu8U9SrXP6ABqtSNfJHw8lRGnr6tyma9PNZvwTweDjQ=
-github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20230523093256-e592c59c5996 h1:YzgxEAK3dCLNvmY1pgLEgPuPOsGHFMxT6QLpZnXuxM8=
-github.com/Fantom-foundation/go-opera-substate v1.0.1-0.20230523093256-e592c59c5996/go.mod h1:qby4+H/H4DzhsQADpib01uxmECmlSJJyPozppP+Pbsk=
-github.com/Fantom-foundation/lachesis-base v0.0.0-20221208123620-82a6d15f995c h1:hgy6GWSddbPyLxRLMykSEImCqv+XuXgLYbqOgI1CBvk=
-github.com/Fantom-foundation/lachesis-base v0.0.0-20221208123620-82a6d15f995c/go.mod h1:YWx9D/y+WCiOkxjw+0FTMQAerfGfhfL/LMEMWp0f3Bw=
+github.com/Fantom-foundation/go-opera v1.1.3-rc.5 h1:6srYIDYHOFqSGU3lVvSHq4q1z/aD0cr9jpZXmj8hrFE=
+github.com/Fantom-foundation/go-opera v1.1.3-rc.5/go.mod h1:0FOob0cYxJE1xbJJ0OGDouuL6AZwcCFUkavDXAgMRQ0=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20230817040848-1326ba9aa59b h1:/9+Cau3cWaKy9fQk/NWq3RJKrwEjgrhME6ACy4RjLns=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20230817040848-1326ba9aa59b/go.mod h1:Ogv5etzSmM2rQ4eN3OfmyitwWaaPjd4EIDiW/NAbYGk=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=


### PR DESCRIPTION
## Description

Remove dependencies to `go-opera-substate` and replace with  `go-opera`. Aida doesn't depend on go-opera-substate specific functions. It uses go-opera for the follows:
- execute of ApplyMessage
- RPC execution (resend of erroneous requests)
- Opera's evmstore state (a variant of geth statedb)

## Type of change

Please delete options that are not relevant.

- [x] Refactoring (changes that do NOT affect functionality)
