### PR TITLE
Increase thresh-hold for abort tests.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -928,7 +928,7 @@ func TestProcessor_ProcessErrorAbortsProcessing_TransactionLevelParallelism(t *t
 
 	stop := fmt.Errorf("stop!")
 	processor.EXPECT().Process(AtBlock[any](4), gomock.Any()).Return(stop)
-	processor.EXPECT().Process(gomock.Any(), gomock.Any()).MaxTimes(20)
+	processor.EXPECT().Process(gomock.Any(), gomock.Any()).MaxTimes(200)
 
 	err := NewExecutor[any](substate, "DEBUG").Run(
 		Params{To: 1000, NumWorkers: 2, ParallelismGranularity: TransactionLevel},
@@ -958,7 +958,7 @@ func TestProcessor_ProcessErrorAbortsProcessing_BlockLevelParallelism(t *testing
 
 	stop := fmt.Errorf("stop!")
 	processor.EXPECT().Process(AtBlock[any](4), gomock.Any()).Return(stop)
-	processor.EXPECT().Process(gomock.Any(), gomock.Any()).MaxTimes(20)
+	processor.EXPECT().Process(gomock.Any(), gomock.Any()).MaxTimes(200)
 
 	err := NewExecutor[any](substate, "DEBUG").Run(
 		Params{To: 1000, NumWorkers: 2, ParallelismGranularity: BlockLevel},
@@ -987,14 +987,14 @@ func TestProcessor_PreEventErrorAbortsProcessing_TransactionLevelParallelism(t *
 			return nil
 		})
 
-	processor.EXPECT().Process(gomock.Any(), gomock.Any()).MaxTimes(20)
+	processor.EXPECT().Process(gomock.Any(), gomock.Any()).MaxTimes(200)
 
 	stop := fmt.Errorf("stop!")
 	extension.EXPECT().PreTransaction(AtBlock[any](4), gomock.Any()).Return(stop)
 
 	extension.EXPECT().PreRun(gomock.Any(), gomock.Any())
-	extension.EXPECT().PreTransaction(gomock.Any(), gomock.Any()).MaxTimes(20)
-	extension.EXPECT().PostTransaction(gomock.Any(), gomock.Any()).MaxTimes(20)
+	extension.EXPECT().PreTransaction(gomock.Any(), gomock.Any()).MaxTimes(200)
+	extension.EXPECT().PostTransaction(gomock.Any(), gomock.Any()).MaxTimes(200)
 	extension.EXPECT().PostRun(gomock.Any(), gomock.Any(), WithError(stop))
 
 	err := NewExecutor[any](substate, "DEBUG").Run(


### PR DESCRIPTION
## Description

This PR rises thresh-hold for abort tests.
These tests used sporadicly fail thanks to the thresh-hold being too small.

Fixes #1076 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Adds or updates testing
