### PR TITLE
Fix inquirer data race

### DIFF
--- a/state/carmen.go
+++ b/state/carmen.go
@@ -69,9 +69,8 @@ func MakeCarmenStateDBWithCacheSize(dir string, variant string, schema int, arch
 }
 
 type carmenStateDB struct {
-	db          carmen.Database
-	txCtx       carmen.TransactionContext
-	blockNumber uint64
+	db    carmen.Database
+	txCtx carmen.TransactionContext
 }
 
 type carmenHeadState struct {
@@ -345,9 +344,11 @@ func (s *carmenHeadState) GetArchiveState(block uint64) (NonCommittableStateDB, 
 	}
 
 	return &carmenHistoricState{
-		carmenStateDB: s.carmenStateDB,
-		blkCtx:        historicBlkCtx,
-		blkNumber:     block,
+		carmenStateDB: carmenStateDB{
+			db: s.db,
+		},
+		blkCtx:    historicBlkCtx,
+		blkNumber: block,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

This PR fixes data-race inside `ArchiveInquirer`.
This bug was caused by incorrectly passing a `carmenStateDB` containing `txCtx` which is used by both `carmenHeadState` and `carmenHistoricState`. Now only instance of the database itself is passed and new `carmenStateDB` instance is created hence each `archive-inquiry` receives own `txCtx`.

Fixes #1088 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

