### PR TITLE
Increase node cache size for running Ethereum tests

### DIFF
--- a/executor/extension/statedb/eth_state_test_db_prepper.go
+++ b/executor/extension/statedb/eth_state_test_db_prepper.go
@@ -35,7 +35,7 @@ func (e ethStateTestDbPrepper) PreTransaction(st executor.State[txcontext.TxCont
 	// reduce the cache creation and flush time, and thus to improve
 	// the processing time of each transaction.
 	cfg.CarmenStateCacheSize = 1000
-	cfg.CarmenNodeCacheSize = (1 << 20) // = 1 MiB
+	cfg.CarmenNodeCacheSize = (16 << 20) // = 16 MiB
 	ctx.State, ctx.StateDbPath, err = utils.PrepareStateDB(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statedb; %v", err)

--- a/utils/statedb.go
+++ b/utils/statedb.go
@@ -196,7 +196,7 @@ func makeStateDBVariant(directory, impl, variant, archiveVariant string, carmenS
 		if !cfg.ArchiveMode {
 			archiveVariant = "none"
 		}
-		return state.MakeCarmenStateDBWithCacheSize(directory, variant, carmenSchema, archiveVariant, cfg.CarmenStateCacheSize, cfg.CarmenNodeCacheSize)
+		return state.MakeCarmenStateDBWithCacheSize(directory, variant, carmenSchema, archiveVariant, cfg.CarmenNodeCacheSize, cfg.CarmenNodeCacheSize)
 	}
 	return nil, fmt.Errorf("unknown Db implementation: %v", impl)
 }


### PR DESCRIPTION
## Description

This PR increases the node cache size of LiveDBs utilized for running Ethereum tests in `aida-vm-sdb`. Tests like [GeneralStateTests/stShift/shiftCombinations.json](https://github.com/ethereum/tests/blob/develop/GeneralStateTests/stShift/shiftCombinations.json) seem to require more than the previous 1 MB of cache for working sets.

The PR also fixes the propagation of this parameter to Carmen in the corresponding factory functions.

Fixes [#846](https://github.com/Fantom-foundation/Carmen/issues/846)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)