### PR TITLE
Call begin/end tx for historic transactions

### DIFF
--- a/cmd/aida-rpc/rpc_test.go
+++ b/cmd/aida-rpc/rpc_test.go
@@ -69,19 +69,27 @@ func TestRpc_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 	gomock.InOrder(
 		// Req 1
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archiveOne, nil),
+		archiveOne.EXPECT().BeginTransaction(uint32(1)),
 		archiveOne.EXPECT().GetBalance(common.HexToAddress(testingAddress)).Return(new(big.Int).SetInt64(1)),
+		archiveOne.EXPECT().EndTransaction(),
 		archiveOne.EXPECT().Release(),
 		// Req 2
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archiveTwo, nil),
+		archiveTwo.EXPECT().BeginTransaction(uint32(2)),
 		archiveTwo.EXPECT().GetBalance(common.HexToAddress(testingAddress)).Return(new(big.Int).SetInt64(1)),
+		archiveTwo.EXPECT().EndTransaction(),
 		archiveTwo.EXPECT().Release(),
 		// Req 3
 		db.EXPECT().GetArchiveState(uint64(3)).Return(archiveThree, nil),
+		archiveThree.EXPECT().BeginTransaction(uint32(1)),
 		archiveThree.EXPECT().GetNonce(common.HexToAddress(testingAddress)).Return(uint64(1)),
+		archiveThree.EXPECT().EndTransaction(),
 		archiveThree.EXPECT().Release(),
 		// Req 4
 		db.EXPECT().GetArchiveState(uint64(4)).Return(archiveFour, nil),
+		archiveFour.EXPECT().BeginTransaction(uint32(0)),
 		archiveFour.EXPECT().GetCode(common.HexToAddress(testingAddress)).Return(hexutil.MustDecode("0x10")),
+		archiveFour.EXPECT().EndTransaction(),
 		archiveFour.EXPECT().Release(),
 	)
 
@@ -126,25 +134,33 @@ func TestRpc_AllDbEventsAreIssuedInOrder_Parallel(t *testing.T) {
 	gomock.InOrder(
 		// Req 1
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archiveOne, nil),
+		archiveOne.EXPECT().BeginTransaction(uint32(1)),
 		archiveOne.EXPECT().GetBalance(common.HexToAddress(testingAddress)).Return(new(big.Int).SetInt64(1)),
+		archiveOne.EXPECT().EndTransaction(),
 		archiveOne.EXPECT().Release(),
 	)
 	gomock.InOrder(
 		// Req 2
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archiveTwo, nil),
+		archiveTwo.EXPECT().BeginTransaction(uint32(2)),
 		archiveTwo.EXPECT().GetBalance(common.HexToAddress(testingAddress)).Return(new(big.Int).SetInt64(1)),
+		archiveTwo.EXPECT().EndTransaction(),
 		archiveTwo.EXPECT().Release(),
 	)
 	gomock.InOrder(
 		// Req 3
 		db.EXPECT().GetArchiveState(uint64(3)).Return(archiveThree, nil),
+		archiveThree.EXPECT().BeginTransaction(uint32(1)),
 		archiveThree.EXPECT().GetNonce(common.HexToAddress(testingAddress)).Return(uint64(1)),
+		archiveThree.EXPECT().EndTransaction(),
 		archiveThree.EXPECT().Release(),
 	)
 	gomock.InOrder(
 		// Req 4
 		db.EXPECT().GetArchiveState(uint64(4)).Return(archiveFour, nil),
+		archiveFour.EXPECT().BeginTransaction(uint32(0)),
 		archiveFour.EXPECT().GetCode(common.HexToAddress(testingAddress)).Return(hexutil.MustDecode("0x10")),
+		archiveFour.EXPECT().EndTransaction(),
 		archiveFour.EXPECT().Release(),
 	)
 
@@ -193,30 +209,38 @@ func TestRpc_AllTransactionsAreProcessedInOrder_Sequential(t *testing.T) {
 
 		// Req 1
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archive, nil),
+		archive.EXPECT().BeginTransaction(uint32(1)),
 		ext.EXPECT().PreTransaction(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
 		processor.EXPECT().Process(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
 		ext.EXPECT().PostTransaction(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
+		archive.EXPECT().EndTransaction(),
 		archive.EXPECT().Release(),
 
 		// Req 2
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archive, nil),
+		archive.EXPECT().BeginTransaction(uint32(2)),
 		ext.EXPECT().PreTransaction(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
 		processor.EXPECT().Process(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
 		ext.EXPECT().PostTransaction(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
+		archive.EXPECT().EndTransaction(),
 		archive.EXPECT().Release(),
 
 		// Req 3
 		db.EXPECT().GetArchiveState(uint64(3)).Return(archive, nil),
+		archive.EXPECT().BeginTransaction(uint32(1)),
 		ext.EXPECT().PreTransaction(executor.AtBlock[*rpc.RequestAndResults](3), gomock.Any()),
 		processor.EXPECT().Process(executor.AtBlock[*rpc.RequestAndResults](3), gomock.Any()),
 		ext.EXPECT().PostTransaction(executor.AtBlock[*rpc.RequestAndResults](3), gomock.Any()),
+		archive.EXPECT().EndTransaction(),
 		archive.EXPECT().Release(),
 
 		// Block 4
 		db.EXPECT().GetArchiveState(uint64(4)).Return(archive, nil),
+		archive.EXPECT().BeginTransaction(uint32(0)),
 		ext.EXPECT().PreTransaction(executor.AtBlock[*rpc.RequestAndResults](4), gomock.Any()),
 		processor.EXPECT().Process(executor.AtBlock[*rpc.RequestAndResults](4), gomock.Any()),
 		ext.EXPECT().PostTransaction(executor.AtBlock[*rpc.RequestAndResults](4), gomock.Any()),
+		archive.EXPECT().EndTransaction(),
 		archive.EXPECT().Release(),
 
 		ext.EXPECT().PostRun(executor.AtBlock[*rpc.RequestAndResults](5), gomock.Any(), nil),
@@ -231,7 +255,9 @@ func TestRpc_AllTransactionsAreProcessed_Parallel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	provider := executor.NewMockProvider[*rpc.RequestAndResults](ctrl)
 	db := state.NewMockStateDB(ctrl)
-	archive := state.NewMockNonCommittableStateDB(ctrl)
+	archiveOne := state.NewMockNonCommittableStateDB(ctrl)
+	archiveTwo := state.NewMockNonCommittableStateDB(ctrl)
+	archiveThree := state.NewMockNonCommittableStateDB(ctrl)
 	ext := executor.NewMockExtension[*rpc.RequestAndResults](ctrl)
 	processor := executor.NewMockProcessor[*rpc.RequestAndResults](ctrl)
 
@@ -240,7 +266,7 @@ func TestRpc_AllTransactionsAreProcessed_Parallel(t *testing.T) {
 		Last:     4,
 		ChainID:  utils.MainnetChainID,
 		LogLevel: "Critical",
-		Workers:  4,
+		Workers:  2,
 	}
 
 	// Simulate the execution of four requests in three blocks.
@@ -249,9 +275,8 @@ func TestRpc_AllTransactionsAreProcessed_Parallel(t *testing.T) {
 		DoAndReturn(func(_ int, _ int, consumer executor.Consumer[*rpc.RequestAndResults]) error {
 			// Block 2
 			consumer(executor.TransactionInfo[*rpc.RequestAndResults]{Block: 2, Transaction: 1, Data: reqBlockTwo})
-			consumer(executor.TransactionInfo[*rpc.RequestAndResults]{Block: 2, Transaction: 2, Data: reqBlockTwo})
 			// Block 3
-			consumer(executor.TransactionInfo[*rpc.RequestAndResults]{Block: 3, Transaction: 1, Data: reqBlockThree})
+			consumer(executor.TransactionInfo[*rpc.RequestAndResults]{Block: 3, Transaction: 2, Data: reqBlockThree})
 			// Block 4
 			consumer(executor.TransactionInfo[*rpc.RequestAndResults]{Block: 4, Transaction: 0, Data: reqBlockFour})
 			return nil
@@ -268,41 +293,39 @@ func TestRpc_AllTransactionsAreProcessed_Parallel(t *testing.T) {
 	gomock.InOrder(
 		pre,
 		// Req 1
-		db.EXPECT().GetArchiveState(uint64(2)).Return(archive, nil),
+		db.EXPECT().GetArchiveState(uint64(2)).Return(archiveOne, nil),
+		archiveOne.EXPECT().BeginTransaction(uint32(1)),
 		ext.EXPECT().PreTransaction(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
 		processor.EXPECT().Process(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
 		ext.EXPECT().PostTransaction(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
-		archive.EXPECT().Release(),
+		archiveOne.EXPECT().EndTransaction(),
+		archiveOne.EXPECT().Release(),
 		post,
 	)
+
 	gomock.InOrder(
 		pre,
 		// Req 2
-		db.EXPECT().GetArchiveState(uint64(2)).Return(archive, nil),
-		ext.EXPECT().PreTransaction(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
-		processor.EXPECT().Process(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
-		ext.EXPECT().PostTransaction(executor.AtBlock[*rpc.RequestAndResults](2), gomock.Any()),
-		archive.EXPECT().Release(),
-		post,
-	)
-	gomock.InOrder(
-		pre,
-		// Req 3
-		db.EXPECT().GetArchiveState(uint64(3)).Return(archive, nil),
+		db.EXPECT().GetArchiveState(uint64(3)).Return(archiveTwo, nil),
+		archiveTwo.EXPECT().BeginTransaction(uint32(2)),
 		ext.EXPECT().PreTransaction(executor.AtBlock[*rpc.RequestAndResults](3), gomock.Any()),
 		processor.EXPECT().Process(executor.AtBlock[*rpc.RequestAndResults](3), gomock.Any()),
 		ext.EXPECT().PostTransaction(executor.AtBlock[*rpc.RequestAndResults](3), gomock.Any()),
-		archive.EXPECT().Release(),
+		archiveTwo.EXPECT().EndTransaction(),
+		archiveTwo.EXPECT().Release(),
 		post,
 	)
+
 	gomock.InOrder(
 		pre,
-		// Req 4
-		db.EXPECT().GetArchiveState(uint64(4)).Return(archive, nil),
+		// Req 3
+		db.EXPECT().GetArchiveState(uint64(4)).Return(archiveThree, nil),
+		archiveThree.EXPECT().BeginTransaction(uint32(0)),
 		ext.EXPECT().PreTransaction(executor.AtBlock[*rpc.RequestAndResults](4), gomock.Any()),
 		processor.EXPECT().Process(executor.AtBlock[*rpc.RequestAndResults](4), gomock.Any()),
 		ext.EXPECT().PostTransaction(executor.AtBlock[*rpc.RequestAndResults](4), gomock.Any()),
-		archive.EXPECT().Release(),
+		archiveThree.EXPECT().EndTransaction(),
+		archiveThree.EXPECT().Release(),
 		post,
 	)
 
@@ -340,7 +363,9 @@ func TestRpc_ValidationDoesNotFailOnValidTransaction_Sequential(t *testing.T) {
 
 	gomock.InOrder(
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archive, nil),
+		archive.EXPECT().BeginTransaction(uint32(1)),
 		archive.EXPECT().GetBalance(common.HexToAddress(testingAddress)).Return(new(big.Int).SetInt64(1)),
+		archive.EXPECT().EndTransaction(),
 		archive.EXPECT().Release(),
 	)
 
@@ -380,7 +405,9 @@ func TestRpc_ValidationDoesNotFailOnValidTransaction_Parallel(t *testing.T) {
 
 	gomock.InOrder(
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archive, nil),
+		archive.EXPECT().BeginTransaction(uint32(1)),
 		archive.EXPECT().GetBalance(common.HexToAddress(testingAddress)).Return(new(big.Int).SetInt64(1)),
+		archive.EXPECT().EndTransaction(),
 		archive.EXPECT().Release(),
 	)
 
@@ -420,7 +447,9 @@ func TestRpc_ValidationFailsOnValidTransaction_Sequential(t *testing.T) {
 
 	gomock.InOrder(
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archive, nil),
+		archive.EXPECT().BeginTransaction(uint32(1)),
 		archive.EXPECT().GetBalance(common.HexToAddress(testingAddress)).Return(new(big.Int).SetInt64(2)),
+		archive.EXPECT().EndTransaction(),
 		archive.EXPECT().Release(),
 	)
 
@@ -464,7 +493,9 @@ func TestRpc_ValidationFailsOnValidTransaction_Parallel(t *testing.T) {
 
 	gomock.InOrder(
 		db.EXPECT().GetArchiveState(uint64(2)).Return(archive, nil),
+		archive.EXPECT().BeginTransaction(uint32(1)),
 		archive.EXPECT().GetBalance(common.HexToAddress(testingAddress)).Return(new(big.Int).SetInt64(2)),
+		archive.EXPECT().EndTransaction(),
 		archive.EXPECT().Release(),
 	)
 

--- a/executor/extension/statedb/temporary_archive_prepper.go
+++ b/executor/extension/statedb/temporary_archive_prepper.go
@@ -17,6 +17,8 @@
 package statedb
 
 import (
+	"fmt"
+
 	"github.com/Fantom-foundation/Aida/executor"
 	"github.com/Fantom-foundation/Aida/executor/extension"
 	"github.com/Fantom-foundation/Aida/rpc"
@@ -40,12 +42,13 @@ func (r *temporaryArchivePrepper) PreTransaction(state executor.State[*rpc.Reque
 		return err
 	}
 
-	return nil
+	return ctx.Archive.BeginTransaction(uint32(state.Transaction))
 }
 
 // PostTransaction releases temporary Archive.
 func (r *temporaryArchivePrepper) PostTransaction(_ executor.State[*rpc.RequestAndResults], ctx *executor.Context) error {
-	ctx.Archive.Release()
-
-	return nil
+	if err := ctx.Archive.EndTransaction(); err != nil {
+		return fmt.Errorf("cannot end transaction; %w", err)
+	}
+	return ctx.Archive.Release()
 }

--- a/rpc/evm.go
+++ b/rpc/evm.go
@@ -168,7 +168,7 @@ func (e *EvmExecutor) sendCall() (*evmcore.ExecutionResult, error) {
 
 	executionResult, err = evmcore.ApplyMessage(evm, msg, gp)
 	if executionResult.Err != nil {
-		return nil, fmt.Errorf("execution returned err; %w", err)
+		return nil, fmt.Errorf("execution returned err; %w", executionResult.Err)
 	}
 
 	if hashErr != nil {

--- a/rpc/execute.go
+++ b/rpc/execute.go
@@ -34,12 +34,9 @@ const falsyContract = "0xe0c38b2a8d09aad53f1c67734b9a95e43d5981c0"
 func Execute(block uint64, rec *RequestAndResults, archive state.NonCommittableStateDB, cfg *utils.Config) txcontext.Result {
 	switch rec.Query.MethodBase {
 	case "getBalance":
-
 		return executeGetBalance(rec.Query.Params[0], archive)
-
 	case "getTransactionCount":
 		return executeGetTransactionCount(rec.Query.Params[0], archive)
-
 	case "call":
 		if rec.Timestamp == 0 {
 			return nil
@@ -57,10 +54,8 @@ func Execute(block uint64, rec *RequestAndResults, archive state.NonCommittableS
 		// that means recorded result and result returned by StateDB are not comparable
 	case "getCode":
 		return executeGetCode(rec.Query.Params[0], archive)
-
 	case "getStorageAt":
 		return executeGetStorageAt(rec.Query.Params, archive)
-
 	default:
 		break
 	}
@@ -91,9 +86,15 @@ func executeCall(evm *EvmExecutor) *result {
 	var gasUsed uint64
 
 	exRes, err := evm.sendCall()
-	if exRes != nil {
-		gasUsed = exRes.UsedGas
+	if exRes == nil {
+		return &result{
+			gasUsed: 0,
+			result:  []byte{},
+			err:     err,
+		}
 	}
+
+	gasUsed = exRes.UsedGas
 
 	// this situation can happen if request is valid but the response from EVM is empty
 	// EVM returns nil instead of an empty result

--- a/state/carmen.go
+++ b/state/carmen.go
@@ -121,11 +121,7 @@ func (s *carmenStateDB) HasSuicided(addr common.Address) bool {
 }
 
 func (s *carmenStateDB) GetBalance(addr common.Address) *big.Int {
-	if balance := s.txCtx.GetBalance(carmen.Address(addr)); balance != nil {
-		return balance
-	}
-
-	return big.NewInt(0)
+	return s.txCtx.GetBalance(carmen.Address(addr))
 }
 
 func (s *carmenStateDB) AddBalance(addr common.Address, value *big.Int) {

--- a/state/carmen.go
+++ b/state/carmen.go
@@ -121,7 +121,11 @@ func (s *carmenStateDB) HasSuicided(addr common.Address) bool {
 }
 
 func (s *carmenStateDB) GetBalance(addr common.Address) *big.Int {
-	return s.txCtx.GetBalance(carmen.Address(addr))
+	if balance := s.txCtx.GetBalance(carmen.Address(addr)); balance != nil {
+		return balance
+	}
+
+	return big.NewInt(0)
 }
 
 func (s *carmenStateDB) AddBalance(addr common.Address, value *big.Int) {


### PR DESCRIPTION
## Description

This PR fixes `aida-rpc` with adding calls to `BeginTx` and `EndTx` to `temporaryArchivePrepper` and correctly catching error from EVM (this error is not fatal could be expected - this is decided in `rpcComparator`).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
