### PR TITLE
Bugfix: Uncontrolled data used in path expression

### DIFF
--- a/utildb/mock_server.go
+++ b/utildb/mock_server.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 )
 
@@ -48,7 +49,7 @@ func StartMockServer(baseDir string) error {
 	// Create a custom handler to serve files based on the URL path
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		requestedPath := r.URL.Path
-		filePath := filepath.Join(baseDir, requestedPath[1:]) // Remove the leading "/" in the URL path
+		filePath := path.Clean(filepath.Join(baseDir, requestedPath[1:])) // Remove the leading "/" in the URL path
 
 		// Check if the file exists
 		_, err := os.Stat(filePath)

--- a/utildb/mock_server.go
+++ b/utildb/mock_server.go
@@ -48,7 +48,7 @@ func StartMockServer(baseDir string) error {
 
 	// Create a custom handler to serve files based on the URL path
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		requestedPath := r.URL.Path
+		requestedPath := path.Clean(r.URL.Path)
 		filePath := path.Clean(filepath.Join(baseDir, requestedPath[1:])) // Remove the leading "/" in the URL path
 
 		// Check if the file exists

--- a/utildb/mock_server.go
+++ b/utildb/mock_server.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
 // mock server is tool to test update command
@@ -49,12 +50,9 @@ func StartMockServer(baseDir string) error {
 	// Create a custom handler to serve files based on the URL path
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		requestedPath := path.Clean(r.URL.Path)
-		filePath := path.Clean(filepath.Join(baseDir, requestedPath[1:])) // Remove the leading "/" in the URL path
-
-		// Check if the file exists
-		_, err := os.Stat(filePath)
-		if err != nil {
-			http.Error(w, "File not found", http.StatusNotFound)
+		filePath, err := filepath.Abs(filepath.Join(baseDir, requestedPath[1:])) // Remove the leading "/" in the URL path
+		if err != nil || !strings.HasPrefix(filePath, baseDir) {
+			http.Error(w, "Invalid file name", http.StatusBadRequest)
 			return
 		}
 


### PR DESCRIPTION
Uncontrolled data used in path expression

https://codeql.github.com/codeql-query-help/go/go-path-injection/

Fixes https://github.com/Fantom-foundation/Aida/issues/1110

- [ ] Bug fix (non-breaking change which fixes an issue)