### PR TITLE
Removed Errorneous Continue when Extracting Gz

### DIFF
--- a/utildb/update.go
+++ b/utildb/update.go
@@ -635,10 +635,8 @@ func extractTarGz(tarGzFile, outputFolder string) error {
 
 		// Make sure that output file does not overwrite existing files
 		_, err = os.Stat(targetPath)
-		if err != nil && errors.Is(err, os.ErrNotExist) { // check if not exist is clearer than check if exists
-			continue
-		} else {
-			return fmt.Errorf("Tarfile is attempting to overwrite existing file: %s", targetPath)
+		if err == nil && !errors.Is(err, os.ErrNotExist) { // if file already exists
+			return fmt.Errorf("Tarfile is attempting to overwrite existing file: %s; (%v)", targetPath, err)
 		}
 
 		// Check if it's a directory

--- a/utildb/update.go
+++ b/utildb/update.go
@@ -635,7 +635,7 @@ func extractTarGz(tarGzFile, outputFolder string) error {
 
 		// Make sure that output file does not overwrite existing files
 		_, err = os.Stat(targetPath)
-		if err == nil && !errors.Is(err, os.ErrNotExist) { // if file already exists
+		if err == nil || os.IsExist(err) {
 			return fmt.Errorf("Tarfile is attempting to overwrite existing file: %s; (%v)", targetPath, err)
 		}
 

--- a/utildb/update.go
+++ b/utildb/update.go
@@ -636,7 +636,7 @@ func extractTarGz(tarGzFile, outputFolder string) error {
 		// Make sure that output file does not overwrite existing files
 		_, err = os.Stat(targetPath)
 		if err == nil || os.IsExist(err) {
-			return fmt.Errorf("Tarfile is attempting to overwrite existing file: %s; (%v)", targetPath, err)
+			return fmt.Errorf("Tarfile is attempting to overwrite existing file. This may have happened due to previous failed attempt to extract the file - consider removing the folder %s", targetPath)
 		}
 
 		// Check if it's a directory


### PR DESCRIPTION
`util-db update --db-tmp tmp --aida-db tmp/aida-db --chainid 4002` failed to extract the content of the patch.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)