### PR TITLE
Fix eth tests prime

### DIFF
--- a/executor/extension/statedb/eth_state_test_scope_event_emitter.go
+++ b/executor/extension/statedb/eth_state_test_scope_event_emitter.go
@@ -31,7 +31,7 @@ type ethStateScopeEventEmitter struct {
 }
 
 func (e ethStateScopeEventEmitter) PreTransaction(s executor.State[txcontext.TxContext], ctx *executor.Context) error {
-	if err := ctx.State.BeginBlock(uint64(s.Block)); err != nil {
+	if err := ctx.State.BeginBlock(uint64(s.Block + 1)); err != nil {
 		return err
 	}
 	return ctx.State.BeginTransaction(uint32(s.Transaction))

--- a/executor/extension/statedb/eth_state_test_scope_event_emitter_test.go
+++ b/executor/extension/statedb/eth_state_test_scope_event_emitter_test.go
@@ -32,7 +32,7 @@ func TestEthStateScopeEventEmitter_PreTransactionCallsBeginBlockAndBeginTransact
 
 	ext := ethStateScopeEventEmitter{}
 
-	db.EXPECT().BeginBlock(uint64(1))
+	db.EXPECT().BeginBlock(uint64(2))
 	db.EXPECT().BeginTransaction(uint32(1))
 
 	st := executor.State[txcontext.TxContext]{Block: 1, Transaction: 1, Data: ethtest.CreateTestData(t)}


### PR DESCRIPTION
## Description

This PR fixes `vm-sdb ethtest` tool. The bug was introduced by newest Carmen API which changed how `BeginBlock` and `StartBulkload` interacts with block numbers. Now that `BeginBlock` is necessary even for small database, this caused a block number issue when calling `BeginBlock` after priming.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

