### PR TITLE
Enhance eth tests logging

### DIFF
--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -97,7 +97,6 @@ func runEth(
 	var extensionList = []executor.Extension[txcontext.TxContext]{
 		profiler.MakeCpuProfiler[txcontext.TxContext](cfg),
 		profiler.MakeDiagnosticServer[txcontext.TxContext](cfg),
-		logger.MakeProgressLogger[txcontext.TxContext](cfg, 0),
 		logger.MakeErrorLogger[txcontext.TxContext](cfg),
 	}
 

--- a/executor/extension/statedb/eth_state_test_db_prepper.go
+++ b/executor/extension/statedb/eth_state_test_db_prepper.go
@@ -25,9 +25,12 @@ import (
 	"github.com/Fantom-foundation/Aida/logger"
 	"github.com/Fantom-foundation/Aida/txcontext"
 	"github.com/Fantom-foundation/Aida/utils"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 func MakeEthStateTestDbPrepper(cfg *utils.Config) executor.Extension[txcontext.TxContext] {
+	// Disable spam from eth logger when creating database
+	log.SetDefault(log.NewLogger(log.DiscardHandler()))
 	return makeEthStateTestDbPrepper(logger.NewLogger(cfg.LogLevel, "EthStatePrepper"), cfg)
 }
 


### PR DESCRIPTION
## Description

This PR improves logging in `eth-test`:

1. Remove `ProgressLogger` as this tool is not a correct place to use this kind of logger
2. Disable `eth-logger` as it spams unusable information everytime a new `geth` database is created
3. Improve `eth-state-test-logger` by dividing log into `Notice` which logs every time a new test file is being ran and `Info` which logs the fork of the test.
4. Add file progress loggin

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

