### PR TITLE
Capture stack trace when recovering from panic

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1762,7 +1762,7 @@ func TestProcessor_PanicCaughtInPostRunIsReturned_TransactionLevelParallelism(t 
 	}
 
 	wantedErr := "sending forward recovered panic from PostRun; stop"
-	if strings.Compare(err.Error(), wantedErr) != 0 {
+	if !strings.Contains(err.Error(), wantedErr) {
 		t.Errorf("unexpected err \nwant: %v\ngot: %v", wantedErr, err.Error())
 	}
 
@@ -1808,7 +1808,7 @@ func TestProcessor_PanicCaughtInPostRunIsReturned_BlockLevelParallelism(t *testi
 	}
 
 	wantedErr := "sending forward recovered panic from PostRun; stop"
-	if strings.Compare(err.Error(), wantedErr) != 0 {
+	if !strings.Contains(err.Error(), wantedErr) {
 		t.Errorf("unexpected err \nwant: %v\ngot: %v", wantedErr, err.Error())
 	}
 


### PR DESCRIPTION
## Description

This PR improves the reporting of recovered panics in the Aida executor.

Before this change, recovered panics are losing their stack trace when being forwarded. This makes identifying the source of the panic hard.

With this change, the stack trace of the location causing the panic gets recorded.


## Type of change

- New feature (non-breaking change which adds functionality)