### PR TITLE
Integrate support for Tosca processor

### DIFF
--- a/cmd/aida-sdb/record.go
+++ b/cmd/aida-sdb/record.go
@@ -74,7 +74,12 @@ func RecordStateDbTrace(ctx *cli.Context) error {
 	substateIterator := executor.OpenSubstateProvider(cfg, ctx, aidaDb)
 	defer substateIterator.Close()
 
-	return record(cfg, substateIterator, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		return err
+	}
+
+	return record(cfg, substateIterator, processor, nil)
 }
 
 func record(

--- a/cmd/aida-stochastic-sdb/stochastic/record.go
+++ b/cmd/aida-stochastic-sdb/stochastic/record.go
@@ -72,7 +72,10 @@ func stochasticRecordAction(ctx *cli.Context) error {
 	}
 	defer utils.StopCPUProfile(cfg)
 
-	processor := executor.MakeLiveDbTxProcessor(cfg)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		return err
+	}
 
 	// iterate through subsets in sequence
 	sdb, err := db.NewReadOnlySubstateDB(cfg.AidaDb)

--- a/cmd/aida-vm-adb/run_vm_adb.go
+++ b/cmd/aida-vm-adb/run_vm_adb.go
@@ -57,7 +57,12 @@ func RunVmAdb(ctx *cli.Context) error {
 	substateIterator := executor.OpenSubstateProvider(cfg, ctx, aidaDb)
 	defer substateIterator.Close()
 
-	return run(cfg, substateIterator, nil, executor.MakeArchiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeArchiveDbTxProcessor(cfg)
+	if err != nil {
+		return err
+	}
+
+	return run(cfg, substateIterator, nil, processor, nil)
 }
 
 func run(

--- a/cmd/aida-vm-adb/run_vm_adb_test.go
+++ b/cmd/aida-vm-adb/run_vm_adb_test.go
@@ -104,9 +104,14 @@ func TestVmAdb_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 		archiveBlockThree.EXPECT().Release(),
 	)
 
+	processor, err := executor.MakeArchiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
 	// since we are working with mock transactions, run logically fails on 'intrinsic gas too low'
 	// since this is a test that tests orded of the db events, we can ignore this error
-	err := run(cfg, provider, db, executor.MakeArchiveDbTxProcessor(cfg), nil)
+	err = run(cfg, provider, db, processor, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "intrinsic gas too low") {
 			return
@@ -192,9 +197,14 @@ func TestVmAdb_AllDbEventsAreIssuedInOrder_Parallel(t *testing.T) {
 		archiveBlockThree.EXPECT().Release(),
 	)
 
+	processor, err := executor.MakeArchiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
 	// since we are working with mock transactions, run logically fails on 'intrinsic gas too low'
 	// since this is a test that tests orded of the db events, we can ignore this error
-	err := run(cfg, provider, db, executor.MakeArchiveDbTxProcessor(cfg), nil)
+	err = run(cfg, provider, db, processor, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "intrinsic gas too low") {
 			return
@@ -398,8 +408,13 @@ func TestVmAdb_ValidationDoesNotFailOnValidTransaction_Sequential(t *testing.T) 
 		// end transaction is not called because we expect fail
 	)
 
+	processor, err := executor.MakeArchiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
 	// run fails but not on validation
-	err := run(cfg, provider, db, executor.MakeArchiveDbTxProcessor(cfg), nil)
+	err = run(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Errorf("run must fail")
 	}
@@ -443,8 +458,13 @@ func TestVmAdb_ValidationDoesNotFailOnValidTransaction_Parallel(t *testing.T) {
 		archive.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
 	)
 
+	processor, err := executor.MakeArchiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
 	// run fails but not on validation
-	err := run(cfg, provider, db, executor.MakeArchiveDbTxProcessor(cfg), nil)
+	err = run(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Errorf("run must fail")
 	}
@@ -479,7 +499,12 @@ func TestVmAdb_ValidationFailsOnInvalidTransaction_Sequential(t *testing.T) {
 		archive.EXPECT().GetCode(testingAddress).Return([]byte{}),
 	)
 
-	err := run(cfg, provider, db, executor.MakeArchiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeArchiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	err = run(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Errorf("validation must fail")
 	}
@@ -516,7 +541,12 @@ func TestVmAdb_ValidationFailsOnInvalidTransaction_Parallel(t *testing.T) {
 		archive.EXPECT().GetCode(testingAddress).Return([]byte{}),
 	)
 
-	err := run(cfg, provider, db, executor.MakeArchiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeArchiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	err = run(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Errorf("validation must fail")
 	}

--- a/cmd/aida-vm-sdb/main.go
+++ b/cmd/aida-vm-sdb/main.go
@@ -73,6 +73,7 @@ var RunSubstateCmd = cli.Command{
 		&utils.ShadowDbVariantFlag,
 
 		// VM
+		&utils.EvmImplementation,
 		&utils.VmImplementation,
 
 		// Profiling
@@ -150,6 +151,7 @@ var RunTxGeneratorCmd = cli.Command{
 		&utils.OverwriteRunIdFlag,
 
 		// VM
+		&utils.EvmImplementation,
 		&utils.VmImplementation,
 
 		// Profiling

--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -50,6 +50,7 @@ var RunEthTestsCmd = cli.Command{
 		&utils.ShadowDbVariantFlag,
 
 		// VM
+		&utils.EvmImplementation,
 		&utils.VmImplementation,
 
 		// Profiling
@@ -88,7 +89,12 @@ func RunEthereumTest(ctx *cli.Context) error {
 	cfg.StateValidationMode = utils.SubsetCheck
 	cfg.ValidateTxState = true
 
-	return runEth(cfg, executor.NewEthStateTestProvider(cfg), nil, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		return err
+	}
+
+	return runEth(cfg, executor.NewEthStateTestProvider(cfg), nil, processor, nil)
 }
 
 func runEth(

--- a/cmd/aida-vm-sdb/run_eth_test.go
+++ b/cmd/aida-vm-sdb/run_eth_test.go
@@ -79,7 +79,12 @@ func TestVmSdb_Eth_AllDbEventsAreIssuedInOrder(t *testing.T) {
 		db.EXPECT().EndBlock(),
 	)
 
-	err := runEth(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	err = runEth(cfg, provider, db, processor, nil)
 	if err != nil {
 		errors.Unwrap(err)
 		if strings.Contains(err.Error(), "intrinsic gas too low") {
@@ -206,7 +211,12 @@ func TestVmSdb_Eth_ValidationDoesNotFailOnValidTransaction(t *testing.T) {
 		// EndTransaction is not called because execution fails
 	)
 
-	err := runEth(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	err = runEth(cfg, provider, db, processor, nil)
 	if err != nil {
 		errors.Unwrap(err)
 		if strings.Contains(err.Error(), "intrinsic gas too low") {
@@ -251,7 +261,12 @@ func TestVmSdb_Eth_ValidationDoesFailOnInvalidTransaction(t *testing.T) {
 	db.EXPECT().BeginBlock(uint64(2))
 	db.EXPECT().BeginTransaction(uint32(1))
 
-	err := runEth(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	err = runEth(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Fatal("run must fail")
 	}

--- a/cmd/aida-vm-sdb/run_substate_test.go
+++ b/cmd/aida-vm-sdb/run_substate_test.go
@@ -105,9 +105,14 @@ func TestVmSdb_Substate_AllDbEventsAreIssuedInOrder(t *testing.T) {
 		db.EXPECT().EndBlock(),
 	)
 
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
 	// since we are working with mock transactions, run logically fails on 'intrinsic gas too low'
 	// since this is a test that tests orded of the db events, we can ignore this error
-	err := runSubstates(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil, nil)
+	err = runSubstates(cfg, provider, db, processor, nil, nil)
 	if err != nil {
 		errors.Unwrap(err)
 		if strings.Contains(err.Error(), "intrinsic gas too low") {
@@ -229,8 +234,13 @@ func TestVmSdb_Substate_ValidationDoesNotFailOnValidTransaction(t *testing.T) {
 		// EndTransaction does not get called because execution fails
 	)
 
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
 	// run fails but not on validation
-	err := runSubstates(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil, nil)
+	err = runSubstates(cfg, provider, db, processor, nil, nil)
 	if err == nil {
 		t.Errorf("run must fail")
 	}
@@ -266,7 +276,12 @@ func TestVmSdb_Substate_ValidationFailsOnInvalidTransaction(t *testing.T) {
 		// EndTransaction does not get called because validation fails
 	)
 
-	err := runSubstates(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil, nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	err = runSubstates(cfg, provider, db, processor, nil, nil)
 	if err == nil {
 		t.Errorf("validation must fail")
 	}

--- a/cmd/aida-vm-sdb/run_tx_generator.go
+++ b/cmd/aida-vm-sdb/run_tx_generator.go
@@ -49,7 +49,12 @@ func RunTxGenerator(ctx *cli.Context) error {
 
 	provider := executor.NewNormaTxProvider(cfg, db)
 
-	return runTransactions(cfg, provider, db, dbPath, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		return err
+	}
+
+	return runTransactions(cfg, provider, db, dbPath, processor, nil)
 }
 
 func runTransactions(

--- a/cmd/aida-vm/main.go
+++ b/cmd/aida-vm/main.go
@@ -44,6 +44,7 @@ func main() {
 			//&utils.BasicBlockProfilingFlag,
 			//&utils.ProfilingDbNameFlag,
 			&utils.ChannelBufferSizeFlag,
+			&utils.EvmImplementation,
 			&utils.VmImplementation,
 			&utils.ValidateTxStateFlag,
 			&utils.ValidateFlag,

--- a/cmd/aida-vm/run_vm.go
+++ b/cmd/aida-vm/run_vm.go
@@ -48,7 +48,12 @@ func RunVm(ctx *cli.Context) error {
 	substateIterator := executor.OpenSubstateProvider(cfg, ctx, aidaDb)
 	defer substateIterator.Close()
 
-	return run(cfg, substateIterator, nil, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		return err
+	}
+
+	return run(cfg, substateIterator, nil, processor, nil)
 }
 
 // run executes the actual block-processing evaluation for RunVm above.

--- a/cmd/aida-vm/run_vm_test.go
+++ b/cmd/aida-vm/run_vm_test.go
@@ -93,7 +93,12 @@ func TestVm_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 		db.EXPECT().EndTransaction(),
 	)
 
-	run(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	run(cfg, provider, db, processor, nil)
 }
 
 func TestVm_AllTransactionsAreProcessedInOrder_Sequential(t *testing.T) {
@@ -255,8 +260,13 @@ func TestVmAdb_ValidationDoesNotFailOnValidTransaction_Sequential(t *testing.T) 
 		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
 	)
 
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
 	// run fails but not on validation
-	err := run(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil)
+	err = run(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Fatal("run must fail")
 	}
@@ -299,8 +309,13 @@ func TestVmAdb_ValidationDoesNotFailOnValidTransaction_Parallel(t *testing.T) {
 		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
 	)
 
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
 	// run fails but not on validation
-	err := run(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil)
+	err = run(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Fatal("run must fail")
 	}
@@ -334,7 +349,12 @@ func TestVm_ValidationFailsOnInvalidTransaction_Sequential(t *testing.T) {
 		db.EXPECT().BeginTransaction(uint32(1)),
 	)
 
-	err := run(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	err = run(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Errorf("validation must fail")
 	}
@@ -368,7 +388,12 @@ func TestVm_ValidationFailsOnInvalidTransaction_Parallel(t *testing.T) {
 		db.EXPECT().BeginTransaction(uint32(1)),
 	)
 
-	err := run(cfg, provider, db, executor.MakeLiveDbTxProcessor(cfg), nil)
+	processor, err := executor.MakeLiveDbTxProcessor(cfg)
+	if err != nil {
+		t.Fatalf("failed to create processor: %v", err)
+	}
+
+	err = run(cfg, provider, db, processor, nil)
 	if err == nil {
 		t.Fatal("validation must fail")
 	}

--- a/executor/extension/profiler/vm_statistics_printer_test.go
+++ b/executor/extension/profiler/vm_statistics_printer_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Fantom-foundation/Aida/executor"
 	"github.com/Fantom-foundation/Aida/utils"
-	"github.com/Fantom-foundation/Tosca/go/vm"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"go.uber.org/mock/gomock"
 )
 
@@ -33,8 +33,8 @@ func TestVirtualMachineStatisticsPrinter_WorksWithDefaultSetup(t *testing.T) {
 
 func TestVirtualMachineStatisticsPrinter_TriggersStatPrintingAtEndOfRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	interpreter := vm.NewMockProfilingInterpreter(ctrl)
-	vm.RegisterInterpreter("test-vm", interpreter)
+	interpreter := tosca.NewMockProfilingInterpreter(ctrl)
+	tosca.RegisterInterpreter("test-vm", interpreter)
 
 	interpreter.EXPECT().DumpProfile()
 

--- a/executor/extension/statedb/archive_inquirer_test.go
+++ b/executor/extension/statedb/archive_inquirer_test.go
@@ -37,7 +37,10 @@ import (
 
 func TestArchiveInquirer_DisabledIfNoQueryRateIsGiven(t *testing.T) {
 	config := utils.Config{}
-	ext := MakeArchiveInquirer(&config)
+	ext, err := MakeArchiveInquirer(&config)
+	if err != nil {
+		t.Fatalf("failed to create inquirer: %v", err)
+	}
 	if _, ok := ext.(extension.NilExtension[txcontext.TxContext]); !ok {
 		t.Errorf("inquirer should not be active by default")
 	}
@@ -49,8 +52,10 @@ func TestArchiveInquirer_ReportsErrorIfNoArchiveIsPresent(t *testing.T) {
 	cfg := utils.Config{}
 	cfg.ChainID = utils.MainnetChainID
 	cfg.ArchiveQueryRate = 100
-	ext := makeArchiveInquirer(&cfg, log)
-
+	ext, err := makeArchiveInquirer(&cfg, log)
+	if err != nil {
+		t.Fatalf("failed to create inquirer: %v", err)
+	}
 	state := executor.State[txcontext.TxContext]{}
 	if err := ext.PreRun(state, nil); err == nil {
 		t.Errorf("expected an error, got nothing")
@@ -69,8 +74,10 @@ func TestArchiveInquirer_CanStartUpAndShutdownGracefully(t *testing.T) {
 	cfg.ChainID = utils.MainnetChainID
 	cfg.ArchiveMode = true
 	cfg.ArchiveQueryRate = 100
-	ext := makeArchiveInquirer(&cfg, log)
-
+	ext, err := makeArchiveInquirer(&cfg, log)
+	if err != nil {
+		t.Fatalf("failed to create inquirer: %v", err)
+	}
 	state := executor.State[txcontext.TxContext]{}
 	context := executor.Context{State: db}
 
@@ -123,7 +130,11 @@ func TestArchiveInquirer_RunsRandomTransactionsInBackground(t *testing.T) {
 	archive.EXPECT().Exist(gomock.Any()).AnyTimes()
 	archive.EXPECT().CreateContract(gomock.Any()).AnyTimes()
 
-	ext := makeArchiveInquirer(cfg, log)
+	ext, err := makeArchiveInquirer(cfg, log)
+	if err != nil {
+		t.Fatalf("failed to create inquirer: %v", err)
+	}
+
 	if err := ext.PreRun(state, &context); err != nil {
 		t.Errorf("failed PreRun, got %v", err)
 	}

--- a/executor/extension/validator/utils.go
+++ b/executor/extension/validator/utils.go
@@ -110,7 +110,9 @@ func printAllocationDiffSummary(want, have txcontext.WorldState, log logger.Logg
 
 	have.ForEachAccount(func(addr common.Address, acc txcontext.Account) {
 		wantAcc := want.Get(addr)
-		printAccountDiffSummary(fmt.Sprintf("key=%v:", addr), wantAcc, acc, log)
+		if wantAcc != nil {
+			printAccountDiffSummary(fmt.Sprintf("key=%v:", addr), wantAcc, acc, log)
+		}
 	})
 
 }

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -20,23 +20,38 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
+	"strings"
 	"sync/atomic"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/Fantom-foundation/Aida/logger"
 	"github.com/Fantom-foundation/Aida/state"
 	"github.com/Fantom-foundation/Aida/txcontext"
 	"github.com/Fantom-foundation/Aida/utils"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+
+	_ "github.com/Fantom-foundation/Tosca/go/processor/floria"
+	_ "github.com/Fantom-foundation/Tosca/go/processor/opera"
 )
 
 // MakeLiveDbTxProcessor creates a executor.Processor which processes transaction into LIVE StateDb.
-func MakeLiveDbTxProcessor(cfg *utils.Config) *LiveDbTxProcessor {
-	return &LiveDbTxProcessor{MakeTxProcessor(cfg)}
+func MakeLiveDbTxProcessor(cfg *utils.Config) (*LiveDbTxProcessor, error) {
+	processor, err := MakeTxProcessor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &LiveDbTxProcessor{processor}, nil
 }
 
 type LiveDbTxProcessor struct {
@@ -61,8 +76,12 @@ func (p *LiveDbTxProcessor) Process(state State[txcontext.TxContext], ctx *Conte
 }
 
 // MakeArchiveDbTxProcessor creates a executor.Processor which processes transaction into ARCHIVE StateDb.
-func MakeArchiveDbTxProcessor(cfg *utils.Config) *ArchiveDbTxProcessor {
-	return &ArchiveDbTxProcessor{MakeTxProcessor(cfg)}
+func MakeArchiveDbTxProcessor(cfg *utils.Config) (*ArchiveDbTxProcessor, error) {
+	processor, err := MakeTxProcessor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &ArchiveDbTxProcessor{processor}, nil
 }
 
 type ArchiveDbTxProcessor struct {
@@ -91,9 +110,10 @@ type TxProcessor struct {
 	numErrors *atomic.Int32 // transactions can be processed in parallel, so this needs to be thread safe
 	vmCfg     vm.Config
 	log       logger.Logger
+	processor processor
 }
 
-func MakeTxProcessor(cfg *utils.Config) *TxProcessor {
+func MakeTxProcessor(cfg *utils.Config) (*TxProcessor, error) {
 	var vmCfg vm.Config
 	switch cfg.ChainID {
 	case utils.EthereumChainID:
@@ -109,12 +129,47 @@ func MakeTxProcessor(cfg *utils.Config) *TxProcessor {
 	vmCfg.InterpreterImpl = cfg.VmImpl
 	vmCfg.Tracer = nil
 
+	chainCfg, err := utils.GetChainConfig(cfg.ChainID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get chain config: %w", err)
+	}
+
+	var processor processor
+	switch strings.ToLower(cfg.EvmImpl) {
+	case "", "aida":
+		processor = &aidaProcessor{
+			vmCfg:    vmCfg,
+			chainCfg: chainCfg,
+			log:      logger.NewLogger(cfg.LogLevel, "AidaProcessor"),
+		}
+	default:
+		interpreter := tosca.GetInterpreter(cfg.VmImpl)
+		if interpreter == nil {
+			available := maps.Keys(tosca.GetAllRegisteredInterpreters())
+			return nil, fmt.Errorf("unknown interpreter: %s, supported: %v", cfg.VmImpl, available)
+		}
+		evm := tosca.GetProcessor(cfg.EvmImpl, interpreter)
+		if evm == nil {
+			available := maps.Keys(tosca.GetAllRegisteredProcessorFactories())
+			available = append(available, "aida")
+			slices.Sort(available)
+			return nil, fmt.Errorf("unknown EVM implementation: %s, supported: %v", cfg.EvmImpl, available)
+		}
+
+		processor = &toscaProcessor{
+			processor: evm,
+			chainCfg:  chainCfg,
+			log:       logger.NewLogger(cfg.LogLevel, fmt.Sprintf("ToscaProcessor-%s-%s", cfg.EvmImpl, cfg.VmImpl)),
+		}
+	}
+
 	return &TxProcessor{
 		cfg:       cfg,
 		numErrors: new(atomic.Int32),
 		vmCfg:     vmCfg,
 		log:       logger.NewLogger(cfg.LogLevel, "TxProcessor"),
-	}
+		processor: processor,
+	}, nil
 }
 
 func (s *TxProcessor) isErrFatal() bool {
@@ -139,11 +194,21 @@ func (s *TxProcessor) ProcessTransaction(db state.VmStateDB, block int, tx int, 
 	if tx >= utils.PseudoTx {
 		return s.processPseudoTx(st.GetOutputState(), db), nil
 	}
-	return s.processRegularTx(db, block, tx, st)
+	return s.processor.processRegularTx(db, block, tx, st)
+}
+
+type processor interface {
+	processRegularTx(db state.VmStateDB, block int, tx int, st txcontext.TxContext) (transactionResult, error)
+}
+
+type aidaProcessor struct {
+	vmCfg    vm.Config
+	chainCfg *params.ChainConfig
+	log      logger.Logger
 }
 
 // processRegularTx executes VM on a chosen storage system.
-func (s *TxProcessor) processRegularTx(db state.VmStateDB, block int, tx int, st txcontext.TxContext) (res transactionResult, finalError error) {
+func (s *aidaProcessor) processRegularTx(db state.VmStateDB, block int, tx int, st txcontext.TxContext) (res transactionResult, finalError error) {
 	var (
 		gasPool   = new(evmcore.GasPool)
 		txHash    = common.HexToHash(fmt.Sprintf("0x%016d%016d", block, tx))
@@ -158,7 +223,7 @@ func (s *TxProcessor) processRegularTx(db state.VmStateDB, block int, tx int, st
 	db.SetTxContext(txHash, tx)
 	blockCtx := prepareBlockCtx(inputEnv, &hashError)
 	txCtx := evmcore.NewEVMTxContext(msg)
-	evm := vm.NewEVM(*blockCtx, txCtx, db, s.cfg.ChainCfg, s.vmCfg)
+	evm := vm.NewEVM(*blockCtx, txCtx, db, s.chainCfg, s.vmCfg)
 	snapshot := db.Snapshot()
 
 	// apply
@@ -224,4 +289,284 @@ func prepareBlockCtx(inputEnv txcontext.BlockEnvironment, hashError *error) *vm.
 		blockCtx.BaseFee = new(big.Int).Set(baseFee)
 	}
 	return blockCtx
+}
+
+type toscaProcessor struct {
+	processor tosca.Processor
+	chainCfg  *params.ChainConfig
+	log       logger.Logger
+}
+
+func (t *toscaProcessor) processRegularTx(db state.VmStateDB, block int, tx int, st txcontext.TxContext) (res transactionResult, finalError error) {
+	// The main task of this function is to link the context provided through parameters
+	// with the context required by a Tosca Processor implementation to execute a transaction.
+	processor := t.processor
+
+	blockEnvironment := st.GetBlockEnvironment()
+	message := st.GetMessage()
+
+	revision := tosca.R07_Istanbul
+	if block >= int(t.chainCfg.BerlinBlock.Uint64()) {
+		revision = tosca.R09_Berlin
+	}
+	if block >= int(t.chainCfg.LondonBlock.Uint64()) {
+		revision = tosca.R10_London
+	}
+
+	blockParams := tosca.BlockParameters{
+		BlockNumber: int64(block),
+		Timestamp:   int64(blockEnvironment.GetTimestamp()),
+		GasLimit:    tosca.Gas(blockEnvironment.GetGasLimit()),
+		Coinbase:    tosca.Address(blockEnvironment.GetCoinbase()),
+		ChainID:     tosca.Word(bigToValue(t.chainCfg.ChainID)),
+		PrevRandao:  tosca.Hash(bigToValue(blockEnvironment.GetDifficulty())),
+		BaseFee:     bigToValue(blockEnvironment.GetBaseFee()),
+		BlobBaseFee: tosca.Value{}, // = 0, since blobs are not supported by Fantom yet
+		Revision:    revision,
+	}
+
+	accessList := []tosca.AccessTuple{}
+	for _, tuple := range message.AccessList {
+		keys := make([]tosca.Key, len(tuple.StorageKeys))
+		for i, key := range tuple.StorageKeys {
+			keys[i] = tosca.Key(key)
+		}
+		accessList = append(accessList, tosca.AccessTuple{
+			Address: tosca.Address(tuple.Address),
+			Keys:    keys,
+		})
+	}
+
+	transaction := tosca.Transaction{
+		Sender: tosca.Address(message.From),
+		Recipient: func() *tosca.Address {
+			addr := message.To
+			if addr == nil {
+				return nil
+			}
+			toscaAddr := tosca.Address(*addr)
+			return &toscaAddr
+		}(),
+		Nonce:      message.Nonce,
+		Input:      message.Data,
+		Value:      bigToValue(message.Value),
+		GasPrice:   bigToValue(message.GasPrice),
+		GasLimit:   tosca.Gas(message.GasLimit),
+		AccessList: accessList,
+	}
+
+	context := &toscaTxContext{
+		blockEnvironment: blockEnvironment,
+		db:               db,
+	}
+
+	receipt, err := processor.Run(blockParams, transaction, context)
+	if err != nil {
+		return transactionResult{}, err
+	}
+
+	log := []*types.Log{}
+	for _, l := range receipt.Logs {
+		topics := make([]common.Hash, len(l.Topics))
+		for i, t := range l.Topics {
+			topics[i] = common.Hash(t)
+		}
+		log = append(log, &types.Log{
+			Address: common.Address(l.Address),
+			Topics:  topics,
+			Data:    l.Data,
+		})
+	}
+	msg := st.GetMessage()
+
+	if !receipt.Success {
+		// The actual error is not relevant. Anything
+		// that is not equal to nil will be considered
+		// as a failed execution that got rolled back.
+		err = fmt.Errorf("transaction failed")
+	}
+
+	result := &evmcore.ExecutionResult{
+		UsedGas:    uint64(receipt.GasUsed),
+		Err:        err,
+		ReturnData: receipt.Output,
+	}
+
+	return newTransactionResult(log, msg, result, nil, msg.From), nil
+}
+
+// toscaTxContext is a bridge between Tosca's transaction context and the one provided by the executor.
+type toscaTxContext struct {
+	blockEnvironment txcontext.BlockEnvironment
+	db               state.VmStateDB
+}
+
+func (a *toscaTxContext) CreateAccount(addr tosca.Address, code tosca.Code) bool {
+	if a.db.Exist(common.Address(addr)) {
+		return false
+	}
+	a.db.CreateAccount(common.Address(addr))
+	a.db.SetCode(common.Address(addr), code)
+	return true
+}
+
+func (a *toscaTxContext) AccountExists(addr tosca.Address) bool {
+	return a.db.Exist(common.Address(addr))
+}
+
+func (a *toscaTxContext) GetBalance(addr tosca.Address) tosca.Value {
+	return uint256ToValue(a.db.GetBalance(common.Address(addr)))
+}
+
+func (a *toscaTxContext) SetBalance(addr tosca.Address, balance tosca.Value) {
+	want := balance.ToUint256()
+	account := common.Address(addr)
+	cur := a.db.GetBalance(account)
+	if cur.Cmp(want) == 0 {
+		return
+	}
+	if cur.Cmp(want) > 0 {
+		diff := new(uint256.Int).Sub(cur, want)
+		a.db.SubBalance(account, diff, 0 /*unknown tracing*/)
+	} else {
+		diff := new(uint256.Int).Sub(want, cur)
+		a.db.AddBalance(account, diff, 0 /*unknown tracing*/)
+	}
+}
+
+func (a *toscaTxContext) GetNonce(addr tosca.Address) uint64 {
+	return a.db.GetNonce(common.Address(addr))
+}
+
+func (a *toscaTxContext) SetNonce(addr tosca.Address, nonce uint64) {
+	a.db.SetNonce(common.Address(addr), nonce)
+}
+
+func (a *toscaTxContext) GetCodeSize(addr tosca.Address) int {
+	return a.db.GetCodeSize(common.Address(addr))
+}
+
+func (a *toscaTxContext) GetCodeHash(addr tosca.Address) tosca.Hash {
+	return tosca.Hash(a.db.GetCodeHash(common.Address(addr)))
+}
+
+func (a *toscaTxContext) GetCode(addr tosca.Address) tosca.Code {
+	return a.db.GetCode(common.Address(addr))
+}
+
+func (a *toscaTxContext) SetCode(addr tosca.Address, code tosca.Code) {
+	a.db.SetCode(common.Address(addr), code)
+}
+
+func (a *toscaTxContext) GetStorage(addr tosca.Address, key tosca.Key) tosca.Word {
+	return tosca.Word(a.db.GetState(common.Address(addr), common.Hash(key)))
+}
+
+func (a *toscaTxContext) GetCommittedStorage(addr tosca.Address, key tosca.Key) tosca.Word {
+	return tosca.Word(a.db.GetCommittedState(common.Address(addr), common.Hash(key)))
+}
+
+func (a *toscaTxContext) SetStorage(addr tosca.Address, key tosca.Key, value tosca.Word) tosca.StorageStatus {
+	original := a.GetCommittedStorage(addr, key)
+	current := a.GetStorage(addr, key)
+	a.db.SetState(common.Address(addr), common.Hash(key), common.Hash(value))
+	return tosca.GetStorageStatus(original, current, value)
+}
+
+func (a *toscaTxContext) GetTransientStorage(addr tosca.Address, key tosca.Key) tosca.Word {
+	return tosca.Word(a.db.GetTransientState(common.Address(addr), common.Hash(key)))
+}
+
+func (a *toscaTxContext) SetTransientStorage(addr tosca.Address, key tosca.Key, value tosca.Word) {
+	a.db.SetTransientState(common.Address(addr), common.Hash(key), common.Hash(value))
+}
+
+func (a *toscaTxContext) GetBlockHash(number int64) tosca.Hash {
+	h, _ := a.blockEnvironment.GetBlockHash(uint64(number))
+	return tosca.Hash(h)
+}
+
+func (a *toscaTxContext) EmitLog(log tosca.Log) {
+	tpcs := make([]common.Hash, len(log.Topics))
+	for i, t := range log.Topics {
+		tpcs[i] = common.Hash(t)
+	}
+
+	a.db.AddLog(&types.Log{
+		Address: common.Address(log.Address),
+		Topics:  tpcs,
+		Data:    log.Data,
+	})
+}
+
+func (a *toscaTxContext) GetLogs() []tosca.Log {
+	res := []tosca.Log{}
+	for _, l := range a.db.GetLogs(common.Hash{}, 0, common.Hash{}) {
+		topics := make([]tosca.Hash, len(l.Topics))
+		for i, t := range l.Topics {
+			topics[i] = tosca.Hash(t)
+		}
+		res = append(res, tosca.Log{
+			Address: tosca.Address(l.Address),
+			Topics:  topics,
+			Data:    l.Data,
+		})
+	}
+	return res
+}
+
+func (a *toscaTxContext) SelfDestruct(addr tosca.Address, beneficiary tosca.Address) bool {
+	a.db.SelfDestruct(common.Address(addr))
+	return true
+}
+
+func (a *toscaTxContext) AccessAccount(addr tosca.Address) tosca.AccessStatus {
+	res := a.IsAddressInAccessList(addr)
+	a.db.AddAddressToAccessList(common.Address(addr))
+	if res {
+		return tosca.WarmAccess
+	}
+	return tosca.ColdAccess
+}
+
+func (a *toscaTxContext) AccessStorage(addr tosca.Address, key tosca.Key) tosca.AccessStatus {
+	_, res := a.IsSlotInAccessList(addr, key)
+	a.db.AddSlotToAccessList(common.Address(addr), common.Hash(key))
+	if res {
+		return tosca.WarmAccess
+	}
+	return tosca.ColdAccess
+}
+
+func (a *toscaTxContext) HasSelfDestructed(addr tosca.Address) bool {
+	return a.db.HasSelfDestructed(common.Address(addr))
+}
+
+func (a *toscaTxContext) CreateSnapshot() tosca.Snapshot {
+	return tosca.Snapshot(a.db.Snapshot())
+}
+
+func (a *toscaTxContext) RestoreSnapshot(snapshot tosca.Snapshot) {
+	a.db.RevertToSnapshot(int(snapshot))
+}
+
+func (a *toscaTxContext) IsAddressInAccessList(addr tosca.Address) bool {
+	return a.db.AddressInAccessList(common.Address(addr))
+}
+
+func (a *toscaTxContext) IsSlotInAccessList(addr tosca.Address, key tosca.Key) (addressPresent, slotPresent bool) {
+	return a.db.SlotInAccessList(common.Address(addr), common.Hash(key))
+}
+
+func bigToValue(value *big.Int) tosca.Value {
+	if value == nil {
+		return tosca.Value{}
+	}
+	var res tosca.Value
+	value.FillBytes(res[:])
+	return res
+}
+
+func uint256ToValue(value *uint256.Int) tosca.Value {
+	return tosca.ValueFromUint256(value)
 }

--- a/utildb/gen_deleted_accounts.go
+++ b/utildb/gen_deleted_accounts.go
@@ -152,7 +152,10 @@ func GenDeletedAccountsAction(cfg *utils.Config, sdb db.SubstateDB, ddb *db.Dest
 	iter := sdb.NewSubstateIterator(int(firstBlock), cfg.Workers)
 	defer iter.Release()
 
-	processor := executor.MakeTxProcessor(cfg)
+	processor, err := executor.MakeTxProcessor(cfg)
+	if err != nil {
+		return nil
+	}
 
 	for iter.Next() {
 		tx := iter.Value()

--- a/utils/config.go
+++ b/utils/config.go
@@ -182,6 +182,7 @@ type Config struct {
 	DeletionDb             string         // directory of deleted account database
 	DiagnosticServer       int64          // if not zero, the port used for hosting a HTTP server for performance diagnostics
 	ErrorLogging           string         // if defined, error logging to file is enabled
+	EvmImpl                string         // evm implementation (aida/opera/tosca)
 	Genesis                string         // genesis file
 	EthTestType            EthTestType    // which geth test are we running
 	IncludeStorage         bool           // represents a flag for contract storage inclusion in an operation
@@ -244,7 +245,7 @@ type Config struct {
 	ValidateStateHashes    bool           // if this is true state hash validation is enabled in Executor
 	ValidateTxState        bool           // validate stateDB before and after transaction
 	ValuesNumber           int64          // number of values to generate
-	VmImpl                 string         // vm implementation (geth/lfvm)
+	VmImpl                 string         // vm implementation (geth/lfvm/evmzero/evmone)
 	Workers                int            // number of worker threads
 	TxGeneratorType        []string       // type of the application used for transaction generation
 	Forks                  []string       // Which forks are going to get executed byz
@@ -273,6 +274,7 @@ func NewTestConfig(t *testing.T, chainId ChainID, first, last uint64, validate b
 		t.Fatalf("cannot get chain cfg: %v", err)
 	}
 	return &Config{
+		ChainID:         chainId,
 		First:           first,
 		Last:            last,
 		ChainCfg:        chainCfg,
@@ -741,6 +743,7 @@ func (cc *configContext) reportNewConfig() {
 	}
 	log.Infof("Chain id: %v (record & run-vm only)", cfg.ChainID)
 	log.Infof("SyncPeriod length: %v", cfg.SyncPeriodLength)
+	log.Noticef("Used EVM implementation: %v", cfg.EvmImpl)
 	log.Noticef("Used VM implementation: %v", cfg.VmImpl)
 	log.Infof("Aida DB directory: %v", cfg.AidaDb)
 

--- a/utils/default_config.go
+++ b/utils/default_config.go
@@ -57,6 +57,7 @@ func createConfigFromFlags(ctx *cli.Context) *Config {
 		DeletionDb:             getFlagValue(ctx, DeletionDbFlag).(string),
 		DiagnosticServer:       getFlagValue(ctx, DiagnosticServerFlag).(int64),
 		ErrorLogging:           getFlagValue(ctx, ErrorLoggingFlag).(string),
+		EvmImpl:                getFlagValue(ctx, EvmImplementation).(string),
 		Forks:                  getFlagValue(ctx, ForksFlag).([]string),
 		Genesis:                getFlagValue(ctx, GenesisFlag).(string),
 		EthTestType:            EthTestType(getFlagValue(ctx, EthTestTypeFlag).(int)),

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -247,6 +247,11 @@ var (
 		Name:  "validate-tx",
 		Usage: "enables validation after transaction processing",
 	}
+	EvmImplementation = cli.StringFlag{
+		Name:  "evm-impl",
+		Usage: "select EVM implementation",
+		Value: "aida",
+	}
 	VmImplementation = cli.StringFlag{
 		Name:  "vm-impl",
 		Usage: "select VM implementation",

--- a/utils/profile.go
+++ b/utils/profile.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Fantom-foundation/Aida/logger"
 	"github.com/Fantom-foundation/Aida/state"
-	"github.com/Fantom-foundation/Tosca/go/vm"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
 
 func StartCPUProfile(cfg *Config) error {
@@ -75,7 +75,7 @@ func MemoryBreakdown(db state.StateDB, cfg *Config, log logger.Logger) {
 // PrintEvmStatistics prints EVM implementation specific statical information
 // to the console. Does nothing, if such information is not offered.
 func PrintEvmStatistics(cfg *Config) {
-	pvm, ok := vm.GetInterpreter(cfg.VmImpl).(vm.ProfilingInterpreter)
+	pvm, ok := tosca.GetInterpreter(cfg.VmImpl).(tosca.ProfilingInterpreter)
 	if pvm != nil && ok {
 		pvm.DumpProfile()
 	}


### PR DESCRIPTION
## Description

This PR adds support for switching between different transaction processor (aka EVM) implementations. The default option (named `aida`) is the implementation provided by Aida used so far to process transactions. Additional options may be gradually provided by a registry in Tosca.

The aim of this change is to enable the development of an alternative EVM implementation, independent of the opera or go-ethereum code base.

## Note for Reviewers

The PR includes 3 inter-dependent changes:
- the introduction of a configurable `TxProcessor`, allowing to switch between Aida's and Tosca's implementation. This is mostly limited to the `executor/transaction_processor.go` file
- the flag enabling the switch between implementations; these changes are mainly limited to the `utils` directory and the parameter lists in the executibles
- the extension of the `MakeLiveDbTxProcessor` and `MakeArchiveDbTxProcessor` signatures to also potentially return an error; this had a ripple-down effect to some other utilities (e.g. `MakeArchiveInquirer`) and numerous tests where this potential error needed to be handled

The recommended way to review this PR is to follow this order of added features.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

TODO:
- [x] a full test run of `aida-vm` with `aida` evm and `geth` interpreter
- [x] a full test run of `aida-vm` with `aida` evm and `evmzero` interpreter