### PR TITLE
Include current disk usage and free space in progress logger

### DIFF
--- a/cmd/aida-sdb/trace/replay.go
+++ b/cmd/aida-sdb/trace/replay.go
@@ -88,10 +88,10 @@ func (p operationProcessor) runTransaction(block uint64, operations []operation.
 func replay(cfg *utils.Config, provider executor.Provider[[]operation.Operation], processor executor.Processor[[]operation.Operation], extra []executor.Extension[[]operation.Operation], aidaDb db.BaseDB) error {
 	var extensionList = []executor.Extension[[]operation.Operation]{
 		profiler.MakeCpuProfiler[[]operation.Operation](cfg),
-		logger.MakeProgressLogger[[]operation.Operation](cfg, 0),
 		profiler.MakeMemoryUsagePrinter[[]operation.Operation](cfg),
 		profiler.MakeMemoryProfiler[[]operation.Operation](cfg),
 		statedb.MakeStateDbManager[[]operation.Operation](cfg, ""),
+		logger.MakeProgressLogger[[]operation.Operation](cfg, 0),
 		primer.MakeStateDbPrimer[[]operation.Operation](cfg),
 	}
 

--- a/executor/extension/logger/progress_logger.go
+++ b/executor/extension/logger/progress_logger.go
@@ -168,9 +168,10 @@ func (l *progressLogger[T]) startReport(reportFrequency time.Duration, stateDbPa
 					continue
 				}
 
+				GiB := float64(1 << 30)
 				l.log.Infof(progressLoggerReportFormat+"; disk usage %.2f GiB, free space %.2f GiB",
 					elapsed.Round(1*time.Second), currentBlock, txRate, gasRate/1e6,
-					float64(used)/float64(1<<30), float64(free)/1e9,
+					float64(used)/GiB, float64(free)/GiB,
 				)
 			} else {
 				l.log.Infof(progressLoggerReportFormat,

--- a/executor/extension/logger/progress_logger.go
+++ b/executor/extension/logger/progress_logger.go
@@ -74,11 +74,11 @@ type progressLogger[T any] struct {
 }
 
 // PreRun starts the report goroutine
-func (l *progressLogger[T]) PreRun(executor.State[T], *executor.Context) error {
+func (l *progressLogger[T]) PreRun(_ executor.State[T], ctx *executor.Context) error {
 	l.wg.Add(1)
 
 	// pass the value for thread safety
-	go l.startReport(l.reportFrequency)
+	go l.startReport(l.reportFrequency, ctx.StateDbPath)
 	return nil
 }
 

--- a/executor/extension/profiler/memory_usage_printer_test.go
+++ b/executor/extension/profiler/memory_usage_printer_test.go
@@ -45,11 +45,11 @@ func TestMemoryUsagePrinter_MemoryBreakdownIsNotPrintedWhenBreakdownIsNil(t *tes
 	gomock.InOrder(
 		// Prerun
 		db.EXPECT().GetMemoryUsage().Return(usage),
-		log.EXPECT().Notice(gomock.Any()),
+		log.EXPECT().Noticef(gomock.Any(), gomock.Any(), gomock.Any()),
 
 		// Postrun
 		db.EXPECT().GetMemoryUsage().Return(usage),
-		log.EXPECT().Notice(gomock.Any()),
+		log.EXPECT().Noticef(gomock.Any(), gomock.Any(), gomock.Any()),
 	)
 
 	ext.PreRun(executor.State[any]{}, &executor.Context{State: db})

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -20,7 +20,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
+
+// GetFreeSpace returns the amount of free space in bytes on the filesystem containing the given path.
+func GetFreeSpace(path string) (int64, error) {
+	fs := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &fs)
+	if err != nil {
+		return 0, err
+	}
+	return int64(fs.Bavail) * fs.Bsize, nil
+}
 
 // GetDirectorySize iterates over all files inside given directory (including subdirectories) and returns size in bytes.
 func GetDirectorySize(path string) (int64, error) {

--- a/utils/profile.go
+++ b/utils/profile.go
@@ -67,7 +67,7 @@ func MemoryBreakdown(db state.StateDB, cfg *Config, log logger.Logger) {
 		if usage := db.GetMemoryUsage(); usage.Breakdown != nil {
 			log.Noticef("State DB memory usage: %d byte\n%s", usage.UsedBytes, usage.Breakdown)
 		} else {
-			log.Notice("Memory usage summary is unavailable. The selected storage solution: %v variant: %v, may not support memory breakdowns.", cfg.DbImpl, cfg.DbVariant)
+			log.Noticef("Memory usage summary is unavailable. The selected storage solution: %v variant: %v, may not support memory breakdowns.", cfg.DbImpl, cfg.DbVariant)
 		}
 	}
 }


### PR DESCRIPTION
## Description

This additional information in the progress logger can help identify issues caused by exhausting disk space capacity.

Recent failure on Jenkins might be caused by exceeding the available disk space. However, the available disk space is so far not logged and difficult to assess. With this change, disk utilization and available disk space is automatically logged.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
