### PR TITLE
support new statedb operations in tracer tools

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,20 +69,20 @@ pipeline {
             steps {
                 sh "mkdir -p ${TRACEDIR}"
                 sh "rm -rf ${TRACEDIR}/*"
-//                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
-//                    sh "build/aida-sdb record --cpu-profile cpu-profile-0.dat --trace-file ${TRACEDIR}/trace-0.dat ${AIDADB} ${FROMBLOCK} ${FROMBLOCK}+1000"
-//                    sh "build/aida-sdb record --cpu-profile cpu-profile-1.dat --trace-file ${TRACEDIR}/trace-1.dat ${AIDADB} ${FROMBLOCK}+1001 ${FROMBLOCK}+2000"
-//                    sh "build/aida-sdb record --cpu-profile cpu-profile-2.dat --trace-file ${TRACEDIR}/trace-2.dat ${AIDADB} ${FROMBLOCK}+2001 ${TOBLOCK}"
-//                }
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
+                    sh "build/aida-sdb record --cpu-profile cpu-profile-0.dat --trace-file ${TRACEDIR}/trace-0.dat ${AIDADB} ${FROMBLOCK} ${FROMBLOCK}+1000"
+                    sh "build/aida-sdb record --cpu-profile cpu-profile-1.dat --trace-file ${TRACEDIR}/trace-1.dat ${AIDADB} ${FROMBLOCK}+1001 ${FROMBLOCK}+2000"
+                    sh "build/aida-sdb record --cpu-profile cpu-profile-2.dat --trace-file ${TRACEDIR}/trace-2.dat ${AIDADB} ${FROMBLOCK}+2001 ${TOBLOCK}"
+                }
             }
         }
 
         stage('aida-sdb replay') {
             steps {
-//                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
-//                    sh "build/aida-sdb replay ${VM} ${STORAGE} ${TMPDB} ${AIDADB} ${PRIME} --shadow-db --db-shadow-impl geth --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --trace-file ${TRACEDIR}/trace-0.dat ${FROMBLOCK} ${TOBLOCK}"
-//                    sh "build/aida-sdb replay ${VM} ${STORAGE} ${TMPDB} ${AIDADB} ${PRIME} --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --trace-dir ${TRACEDIR} ${FROMBLOCK} ${TOBLOCK}"
-//                }
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
+                    sh "build/aida-sdb replay ${VM} ${STORAGE} ${TMPDB} ${AIDADB} ${PRIME} --shadow-db --db-shadow-impl geth --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --trace-file ${TRACEDIR}/trace-0.dat ${FROMBLOCK} ${TOBLOCK}"
+                    sh "build/aida-sdb replay ${VM} ${STORAGE} ${TMPDB} ${AIDADB} ${PRIME} --cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown --trace-dir ${TRACEDIR} ${FROMBLOCK} ${TOBLOCK}"
+                }
                 sh "rm -rf ${TRACEDIR}"
             }
         }

--- a/executor/extension/profiler/operation_profiler_test.go
+++ b/executor/extension/profiler/operation_profiler_test.go
@@ -101,9 +101,20 @@ func TestOperationProfiler_WithEachOpOnce(t *testing.T) {
 		totalOpCount := make([]int, int(ext.depth)+1)
 		ops := operation.CreateIdLabelMap()
 
-		// These are purposely not implemented, will be blacklisted here
+		// Exclude special tracing operations (LC/LS/CS surfix)
 		notImplemented := make([]bool, len(ops))
-		for _, a := range []byte{14, 18, 21, 22, 23, 29, 42, 49, 50, 51, 53} {
+		for _, a := range []byte{
+			operation.GetCodeHashLcID,
+			operation.GetCommittedStateLclsID,
+			operation.GetStateLccsID,
+			operation.GetStateLcID,
+			operation.GetStateLclsID,
+			operation.GetTransientStateLccsID,
+			operation.GetTransientStateLcID,
+			operation.GetTransientStateLclsID,
+			operation.SetStateLclsID,
+			operation.SetTransientStateLclsID,
+		} {
 			notImplemented[a] = true
 		}
 
@@ -291,6 +302,7 @@ func getStateDbFuncs(db state.StateDB) []func() {
 	mockHash := common.BigToHash(big.NewInt(0))
 	return []func(){
 		func() { db.CreateAccount(mockAddress) },
+		func() { db.CreateContract(mockAddress) },
 		func() { db.SubBalance(mockAddress, uint256.NewInt(0), tracing.BalanceChangeUnspecified) },
 		func() { db.AddBalance(mockAddress, uint256.NewInt(0), tracing.BalanceChangeUnspecified) },
 		func() { db.GetBalance(mockAddress) },
@@ -305,10 +317,12 @@ func getStateDbFuncs(db state.StateDB) []func() {
 		func() { db.GetRefund() },
 		func() { db.GetCommittedState(mockAddress, mockHash) },
 		func() { db.GetState(mockAddress, mockHash) },
+		func() { db.GetStorageRoot(mockAddress) },
 		func() { db.GetTransientState(mockAddress, mockHash) },
 		func() { db.SetState(mockAddress, mockHash, mockHash) },
 		func() { db.SetTransientState(mockAddress, mockHash, mockHash) },
 		func() { db.SelfDestruct(mockAddress) },
+		func() { db.Selfdestruct6780(mockAddress) },
 		func() { db.HasSelfDestructed(mockAddress) },
 		func() { db.Exist(mockAddress) },
 		func() { db.Empty(mockAddress) },
@@ -349,6 +363,7 @@ func getStateDbFuncs(db state.StateDB) []func() {
 // This functions tell MockStateDB to expect any number of calls (0 or more) to each of the functions (for randomized test)
 func prepareMockStateDb(m *state.MockStateDB) {
 	m.EXPECT().CreateAccount(gomock.Any()).AnyTimes()
+	m.EXPECT().CreateContract(gomock.Any()).AnyTimes()
 	m.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	m.EXPECT().AddBalance(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	m.EXPECT().GetBalance(gomock.Any()).AnyTimes()
@@ -363,10 +378,12 @@ func prepareMockStateDb(m *state.MockStateDB) {
 	m.EXPECT().GetRefund().AnyTimes()
 	m.EXPECT().GetCommittedState(gomock.Any(), gomock.Any()).AnyTimes()
 	m.EXPECT().GetState(gomock.Any(), gomock.Any()).AnyTimes()
+	m.EXPECT().GetStorageRoot(gomock.Any()).AnyTimes()
 	m.EXPECT().GetTransientState(gomock.Any(), gomock.Any()).AnyTimes()
 	m.EXPECT().SetState(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	m.EXPECT().SetTransientState(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	m.EXPECT().SelfDestruct(gomock.Any()).AnyTimes()
+	m.EXPECT().Selfdestruct6780(gomock.Any()).AnyTimes()
 	m.EXPECT().HasSelfDestructed(gomock.Any()).AnyTimes()
 	m.EXPECT().Exist(gomock.Any()).AnyTimes()
 	m.EXPECT().Empty(gomock.Any()).AnyTimes()
@@ -397,6 +414,7 @@ func prepareMockStateDb(m *state.MockStateDB) {
 // This functions tell MockStateDB to expect exactly one call to each of the possible functions
 func prepareMockStateDbOnce(m *state.MockStateDB) {
 	m.EXPECT().CreateAccount(gomock.Any())
+	m.EXPECT().CreateContract(gomock.Any())
 	m.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any())
 	m.EXPECT().AddBalance(gomock.Any(), gomock.Any(), gomock.Any())
 	m.EXPECT().GetBalance(gomock.Any())
@@ -411,10 +429,12 @@ func prepareMockStateDbOnce(m *state.MockStateDB) {
 	m.EXPECT().GetRefund()
 	m.EXPECT().GetCommittedState(gomock.Any(), gomock.Any())
 	m.EXPECT().GetState(gomock.Any(), gomock.Any())
+	m.EXPECT().GetStorageRoot(gomock.Any())
 	m.EXPECT().GetTransientState(gomock.Any(), gomock.Any())
 	m.EXPECT().SetState(gomock.Any(), gomock.Any(), gomock.Any())
 	m.EXPECT().SetTransientState(gomock.Any(), gomock.Any(), gomock.Any())
 	m.EXPECT().SelfDestruct(gomock.Any())
+	m.EXPECT().Selfdestruct6780(gomock.Any())
 	m.EXPECT().HasSelfDestructed(gomock.Any())
 	m.EXPECT().Exist(gomock.Any())
 	m.EXPECT().Empty(gomock.Any())

--- a/state/proxy/profiler.go
+++ b/state/proxy/profiler.go
@@ -191,11 +191,11 @@ func (p *ProfilerProxy) GetTransientState(addr common.Address, key common.Hash) 
 	return res
 }
 
-// SelfDestruct marks the given account as suicided. This clears the account balance.
+// SelfDestruct marks the given account as self destructed. This clears the account balance.
 // The account is still available until the state is committed;
 // return a non-nil account after SelfDestruct.
 func (p *ProfilerProxy) SelfDestruct(addr common.Address) {
-	p.do(operation.SuicideID, func() {
+	p.do(operation.SelfDestructID, func() {
 		p.db.SelfDestruct(addr)
 	})
 }
@@ -203,7 +203,7 @@ func (p *ProfilerProxy) SelfDestruct(addr common.Address) {
 // HasSelfDestructed checks whether a contract has been suicided.
 func (p *ProfilerProxy) HasSelfDestructed(addr common.Address) bool {
 	var res bool
-	p.do(operation.HasSuicidedID, func() {
+	p.do(operation.HasSelfDestructedID, func() {
 		res = p.db.HasSelfDestructed(addr)
 	})
 	return res
@@ -239,7 +239,7 @@ func (p *ProfilerProxy) Empty(addr common.Address) bool {
 //
 // This method should only be called if Berlin/2929+2930 is applicable at the current number.
 func (p *ProfilerProxy) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	p.do(operation.PrepareAccessListID, func() {
+	p.do(operation.PrepareID, func() {
 		p.db.Prepare(rules, sender, coinbase, dest, precompiles, txAccesses)
 	})
 }
@@ -377,7 +377,7 @@ func (p *ProfilerProxy) AddPreimage(addr common.Hash, image []byte) {
 
 // Prepare sets the current transaction hash and index.
 func (p *ProfilerProxy) SetTxContext(thash common.Hash, ti int) {
-	p.do(operation.PrepareID, func() {
+	p.do(operation.SetTxContextID, func() {
 		p.db.SetTxContext(thash, ti)
 	})
 }
@@ -447,15 +447,22 @@ func (p *ProfilerProxy) GetShadowDB() state.StateDB {
 	return p.db.GetShadowDB()
 }
 
-// TODO profile new operations
 func (p *ProfilerProxy) CreateContract(addr common.Address) {
-	p.db.CreateContract(addr)
+	p.do(operation.CreateContractID, func() {
+		p.db.CreateContract(addr)
+	})
 }
 
 func (p *ProfilerProxy) Selfdestruct6780(addr common.Address) {
-	p.db.Selfdestruct6780(addr)
+	p.do(operation.SelfDestruct6780ID, func() {
+		p.db.Selfdestruct6780(addr)
+	})
 }
 
 func (p *ProfilerProxy) GetStorageRoot(addr common.Address) common.Hash {
-	return p.db.GetStorageRoot(addr)
+	var res common.Hash
+	p.do(operation.GetStorageRootID, func() {
+		res = p.db.GetStorageRoot(addr)
+	})
+	return res
 }

--- a/state/proxy/recorder.go
+++ b/state/proxy/recorder.go
@@ -60,14 +60,14 @@ func (r *RecorderProxy) CreateAccount(addr common.Address) {
 // SubBalance subtracts amount from a contract address.
 func (r *RecorderProxy) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) {
 	contract := r.ctx.EncodeContract(addr)
-	r.write(operation.NewSubBalance(contract, amount))
+	r.write(operation.NewSubBalance(contract, amount, reason))
 	r.db.SubBalance(addr, amount, reason)
 }
 
 // AddBalance adds amount to a contract address.
 func (r *RecorderProxy) AddBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) {
 	contract := r.ctx.EncodeContract(addr)
-	r.write(operation.NewAddBalance(contract, amount))
+	r.write(operation.NewAddBalance(contract, amount, reason))
 	r.db.AddBalance(addr, amount, reason)
 }
 
@@ -235,13 +235,14 @@ func (r *RecorderProxy) GetTransientState(addr common.Address, key common.Hash) 
 // return a non-nil account after SelfDestruct.
 func (r *RecorderProxy) SelfDestruct(addr common.Address) {
 	contract := r.ctx.EncodeContract(addr)
-	r.write(operation.NewSuicide(contract))
+	r.write(operation.NewSelfDestruct(contract))
 	r.db.SelfDestruct(addr)
 }
 
 // HasSelfDestructed checks whether a contract has been suicided.
 func (r *RecorderProxy) HasSelfDestructed(addr common.Address) bool {
 	hasSelfDestructed := r.db.HasSelfDestructed(addr)
+	r.write(operation.NewHasSelfDestructed(addr))
 	return hasSelfDestructed
 }
 

--- a/stochastic/event_proxy.go
+++ b/stochastic/event_proxy.go
@@ -191,7 +191,7 @@ func (p *EventProxy) GetTransientState(addr common.Address, key common.Hash) com
 // SelfDestruct an account.
 func (p *EventProxy) SelfDestruct(address common.Address) {
 	// register event
-	p.registry.RegisterAddressOp(SuicideID, &address)
+	p.registry.RegisterAddressOp(SelfDestructID, &address)
 
 	// call real StateDB
 	p.db.SelfDestruct(address)
@@ -200,7 +200,7 @@ func (p *EventProxy) SelfDestruct(address common.Address) {
 // HasSelfDestructed checks whether a contract has been suicided.
 func (p *EventProxy) HasSelfDestructed(address common.Address) bool {
 	// register event
-	p.registry.RegisterAddressOp(HasSuicidedID, &address)
+	p.registry.RegisterAddressOp(HasSelfDestructedID, &address)
 
 	// call real StateDB
 	return p.db.HasSelfDestructed(address)
@@ -434,15 +434,17 @@ func (p *EventProxy) GetShadowDB() state.StateDB {
 	return p.db.GetShadowDB()
 }
 
-// TODO support new operations
 func (p *EventProxy) CreateContract(addr common.Address) {
+	p.registry.RegisterOp(CreateContractID)
 	p.db.CreateContract(addr)
 }
 
 func (p *EventProxy) Selfdestruct6780(addr common.Address) {
+	p.registry.RegisterOp(SelfDestruct6780ID)
 	p.db.Selfdestruct6780(addr)
 }
 
 func (p *EventProxy) GetStorageRoot(addr common.Address) common.Hash {
+	p.registry.RegisterOp(CreateContractID)
 	return p.db.GetStorageRoot(addr)
 }

--- a/stochastic/operation.go
+++ b/stochastic/operation.go
@@ -88,7 +88,7 @@ var opText = map[int]string{
 	HasSelfDestructedID: "HasSelfDestructed",
 	RevertToSnapshotID:  "RevertToSnapshot",
 	SelfDestructID:      "SelfDestruct",
-	SelfDestruct6780ID:  "SelfDestruct6890",
+	SelfDestruct6780ID:  "SelfDestruct6780",
 	SetCodeID:           "SetCode",
 	SetNonceID:          "SetNonce",
 	SetStateID:          "SetState",

--- a/stochastic/operation.go
+++ b/stochastic/operation.go
@@ -42,16 +42,20 @@ const (
 	GetCommittedStateID
 	GetNonceID
 	GetStateID
-	HasSuicidedID
+	HasSelfDestructedID
 	RevertToSnapshotID
 	SetCodeID
 	SetNonceID
 	SetStateID
 	SnapshotID
 	SubBalanceID
-	SuicideID
+	SelfDestructID
+	CreateContractID
+	GetStorageRootID
 	GetTransientStateID
 	SetTransientStateID
+	SelfDestruct6780ID
+	// Add new operations below this line
 
 	NumOps
 )
@@ -66,6 +70,7 @@ var opText = map[int]string{
 	BeginSyncPeriodID:   "BeginSyncPeriod",
 	BeginTransactionID:  "BeginTransaction",
 	CreateAccountID:     "CreateAccount",
+	CreateContractID:    "CreateContract",
 	EmptyID:             "Empty",
 	EndBlockID:          "EndBlock",
 	EndSyncPeriodID:     "EndSyncPeriod",
@@ -78,15 +83,17 @@ var opText = map[int]string{
 	GetCommittedStateID: "GetCommittedState",
 	GetNonceID:          "GetNonce",
 	GetStateID:          "GetState",
-	HasSuicidedID:       "HasSuicided",
+	GetStorageRootID:    "GetStorageRoot",
+	GetTransientStateID: "GetTransientState",
+	HasSelfDestructedID: "HasSelfDestructed",
 	RevertToSnapshotID:  "RevertToSnapshot",
+	SelfDestructID:      "SelfDestruct",
+	SelfDestruct6780ID:  "SelfDestruct6890",
 	SetCodeID:           "SetCode",
 	SetNonceID:          "SetNonce",
 	SetStateID:          "SetState",
 	SnapshotID:          "Snapshot",
 	SubBalanceID:        "SubBalance",
-	SuicideID:           "Suicide",
-	GetTransientStateID: "GetTransientState",
 	SetTransientStateID: "SetTransientState",
 }
 
@@ -97,6 +104,7 @@ var opMnemo = map[int]string{
 	BeginSyncPeriodID:   "BS",
 	BeginTransactionID:  "BT",
 	CreateAccountID:     "CA",
+	CreateContractID:    "CC",
 	EmptyID:             "EM",
 	EndBlockID:          "EB",
 	EndSyncPeriodID:     "ES",
@@ -109,15 +117,17 @@ var opMnemo = map[int]string{
 	GetCommittedStateID: "GM",
 	GetNonceID:          "GN",
 	GetStateID:          "GS",
-	HasSuicidedID:       "HS",
+	GetStorageRootID:    "GR",
+	GetTransientStateID: "GT",
+	HasSelfDestructedID: "HS",
 	RevertToSnapshotID:  "RS",
+	SelfDestructID:      "SU",
+	SelfDestruct6780ID:  "S6",
 	SetCodeID:           "SC",
 	SetNonceID:          "SO",
 	SetStateID:          "SS",
 	SnapshotID:          "SN",
 	SubBalanceID:        "SB",
-	SuicideID:           "SU",
-	GetTransientStateID: "GT",
 	SetTransientStateID: "ST",
 }
 
@@ -128,6 +138,7 @@ var opNumArgs = map[int]int{
 	BeginSyncPeriodID:   0,
 	BeginTransactionID:  0,
 	CreateAccountID:     1,
+	CreateContractID:    1,
 	EmptyID:             1,
 	EndBlockID:          0,
 	EndSyncPeriodID:     0,
@@ -140,15 +151,17 @@ var opNumArgs = map[int]int{
 	GetCommittedStateID: 2,
 	GetNonceID:          1,
 	GetStateID:          2,
-	HasSuicidedID:       1,
+	GetStorageRootID:    1,
+	GetTransientStateID: 2,
+	HasSelfDestructedID: 1,
 	RevertToSnapshotID:  0,
+	SelfDestructID:      1,
+	SelfDestruct6780ID:  1,
 	SetCodeID:           1,
 	SetNonceID:          1,
 	SetStateID:          3,
 	SnapshotID:          0,
 	SubBalanceID:        1,
-	SuicideID:           1,
-	GetTransientStateID: 2,
 	SetTransientStateID: 3,
 }
 
@@ -159,6 +172,7 @@ var opId = map[string]int{
 	"BS": BeginSyncPeriodID,
 	"BT": BeginTransactionID,
 	"CA": CreateAccountID,
+	"CC": CreateContractID,
 	"EM": EmptyID,
 	"EB": EndBlockID,
 	"ES": EndSyncPeriodID,
@@ -171,16 +185,18 @@ var opId = map[string]int{
 	"GM": GetCommittedStateID,
 	"GN": GetNonceID,
 	"GS": GetStateID,
-	"HS": HasSuicidedID,
+	"GR": GetStorageRootID,
+	"GT": GetTransientStateID,
+	"HS": HasSelfDestructedID,
 	"RS": RevertToSnapshotID,
+	"SU": SelfDestructID,
+	"S6": SelfDestruct6780ID,
 	"SC": SetCodeID,
 	"SO": SetNonceID,
 	"SN": SnapshotID,
 	"SB": SubBalanceID,
 	"SS": SetStateID,
-	"SU": SuicideID,
 	"ST": SetTransientStateID,
-	"GT": GetTransientStateID,
 }
 
 // argMnemo is the argument-class mnemonics table.

--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -56,7 +56,7 @@ type stochasticState struct {
 	blockNum       uint64                    // current block number
 	syncPeriodNum  uint64                    // current sync-period number
 	snapshot       []int                     // stack of active snapshots
-	selfdestructed []int64                   // list of self destructed accounts
+	selfDestructed []int64                   // list of self destructed accounts
 	traceDebug     bool                      // trace-debug flag
 	rg             *rand.Rand                // random generator for sampling
 	log            logger.Logger
@@ -246,7 +246,7 @@ func NewStochasticState(rg *rand.Rand, db state.StateDB, contracts *generator.In
 		values:         values,
 		snapshotLambda: snapshotLambda,
 		traceDebug:     false,
-		selfdestructed: []int64{},
+		selfDestructed: []int64{},
 		blockNum:       1,
 		syncPeriodNum:  1,
 		rg:             rg,
@@ -341,7 +341,7 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 		}
 		db.BeginBlock(ss.blockNum)
 		ss.txNum = 0
-		ss.selfdestructed = []int64{}
+		ss.selfDestructed = []int64{}
 
 	case BeginSyncPeriodID:
 		if ss.traceDebug {
@@ -355,7 +355,7 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 		}
 		db.BeginTransaction(ss.txNum)
 		ss.snapshot = []int{}
-		ss.selfdestructed = []int64{}
+		ss.selfDestructed = []int64{}
 
 	case CreateAccountID:
 		db.CreateAccount(addr)
@@ -472,14 +472,14 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 
 	case SelfDestructID:
 		db.SelfDestruct(addr)
-		if idx := find(ss.selfdestructed, addrIdx); idx == -1 {
-			ss.selfdestructed = append(ss.selfdestructed, addrIdx)
+		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
+			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
 		}
 
 	case SelfDestruct6780ID:
 		db.Selfdestruct6780(addr)
-		if idx := find(ss.selfdestructed, addrIdx); idx == -1 {
-			ss.selfdestructed = append(ss.selfdestructed, addrIdx)
+		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
+			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
 		}
 
 	default:
@@ -549,10 +549,10 @@ func toHash(idx int64) common.Hash {
 // delete account information when suicide was invoked
 func (ss *stochasticState) deleteAccounts() {
 	// remove account information when suicide was invoked in the block.
-	for _, addrIdx := range ss.selfdestructed {
+	for _, addrIdx := range ss.selfDestructed {
 		if err := ss.contracts.DeleteIndex(addrIdx); err != nil {
 			ss.log.Fatal("failed deleting index")
 		}
 	}
-	ss.selfdestructed = []int64{}
+	ss.selfDestructed = []int64{}
 }

--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -56,7 +56,7 @@ type stochasticState struct {
 	blockNum       uint64                    // current block number
 	syncPeriodNum  uint64                    // current sync-period number
 	snapshot       []int                     // stack of active snapshots
-	suicided       []int64                   // list of suicided accounts
+	selfdestructed []int64                   // list of self destructed accounts
 	traceDebug     bool                      // trace-debug flag
 	rg             *rand.Rand                // random generator for sampling
 	log            logger.Logger
@@ -246,7 +246,7 @@ func NewStochasticState(rg *rand.Rand, db state.StateDB, contracts *generator.In
 		values:         values,
 		snapshotLambda: snapshotLambda,
 		traceDebug:     false,
-		suicided:       []int64{},
+		selfdestructed: []int64{},
 		blockNum:       1,
 		syncPeriodNum:  1,
 		rg:             rg,
@@ -341,7 +341,7 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 		}
 		db.BeginBlock(ss.blockNum)
 		ss.txNum = 0
-		ss.suicided = []int64{}
+		ss.selfdestructed = []int64{}
 
 	case BeginSyncPeriodID:
 		if ss.traceDebug {
@@ -355,10 +355,13 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 		}
 		db.BeginTransaction(ss.txNum)
 		ss.snapshot = []int{}
-		ss.suicided = []int64{}
+		ss.selfdestructed = []int64{}
 
 	case CreateAccountID:
 		db.CreateAccount(addr)
+
+	case CreateContractID:
+		db.CreateContract(addr)
 
 	case EmptyID:
 		db.Empty(addr)
@@ -401,7 +404,10 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 	case GetStateID:
 		db.GetState(addr, key)
 
-	case HasSuicidedID:
+	case GetStorageRootID:
+		db.GetStorageRoot(addr)
+
+	case HasSelfDestructedID:
 		db.HasSelfDestructed(addr)
 
 	case RevertToSnapshotID:
@@ -464,10 +470,16 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 			db.SubBalance(addr, uint256.NewInt(value), 0)
 		}
 
-	case SuicideID:
+	case SelfDestructID:
 		db.SelfDestruct(addr)
-		if idx := find(ss.suicided, addrIdx); idx == -1 {
-			ss.suicided = append(ss.suicided, addrIdx)
+		if idx := find(ss.selfdestructed, addrIdx); idx == -1 {
+			ss.selfdestructed = append(ss.selfdestructed, addrIdx)
+		}
+
+	case SelfDestruct6780ID:
+		db.Selfdestruct6780(addr)
+		if idx := find(ss.selfdestructed, addrIdx); idx == -1 {
+			ss.selfdestructed = append(ss.selfdestructed, addrIdx)
 		}
 
 	default:
@@ -537,10 +549,10 @@ func toHash(idx int64) common.Hash {
 // delete account information when suicide was invoked
 func (ss *stochasticState) deleteAccounts() {
 	// remove account information when suicide was invoked in the block.
-	for _, addrIdx := range ss.suicided {
+	for _, addrIdx := range ss.selfdestructed {
 		if err := ss.contracts.DeleteIndex(addrIdx); err != nil {
 			ss.log.Fatal("failed deleting index")
 		}
 	}
-	ss.suicided = []int64{}
+	ss.selfdestructed = []int64{}
 }

--- a/tracer/operation/addbalance.go
+++ b/tracer/operation/addbalance.go
@@ -33,7 +33,8 @@ import (
 // AddBalance data structure
 type AddBalance struct {
 	Contract common.Address
-	Amount   [16]byte // truncated amount to 16 bytes
+	Amount   [32]byte // truncated amount to 32 bytes
+	Reason   tracing.BalanceChangeReason
 }
 
 // GetId returns the add-balance operation identifier.
@@ -42,14 +43,12 @@ func (op *AddBalance) GetId() byte {
 }
 
 // NewAddBalance creates a new add-balance operation.
-func NewAddBalance(contract common.Address, amount *uint256.Int) *AddBalance {
-	// check if amount requires more than 256 bits (16 bytes)
-	if amount.BitLen() > 256 {
-		log.Fatalf("Amount exceeds 256 bit")
+func NewAddBalance(contract common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) *AddBalance {
+	// check if amount requires more than 32 bytes
+	if amount.ByteLen() > 32 {
+		log.Fatalf("Amount exceeds 32 bytes")
 	}
-	ret := &AddBalance{Contract: contract}
-	// copy amount to a 16-byte array with leading zeros
-	amount.SetBytes(ret.Amount[:])
+	ret := &AddBalance{Contract: contract, Amount: amount.Bytes32(), Reason: reason}
 	return ret
 }
 
@@ -73,11 +72,11 @@ func (op *AddBalance) Execute(db state.StateDB, ctx *context.Replay) time.Durati
 	amount := new(uint256.Int).SetBytes(op.Amount[:])
 	start := time.Now()
 	// ignore reason
-	db.AddBalance(contract, amount, tracing.BalanceChangeUnspecified)
+	db.AddBalance(contract, amount, op.Reason)
 	return time.Since(start)
 }
 
 // Debug prints a debug message for the add-balance operation.
 func (op *AddBalance) Debug(ctx *context.Context) {
-	fmt.Print(op.Contract, new(uint256.Int).SetBytes(op.Amount[:]))
+	fmt.Print(op.Contract, new(uint256.Int).SetBytes(op.Amount[:]), op.Reason)
 }

--- a/tracer/operation/createcontract.go
+++ b/tracer/operation/createcontract.go
@@ -33,30 +33,30 @@ type CreateContract struct {
 	Contract common.Address
 }
 
-// GetId returns the create-account operation identifier.
+// GetId returns the create-contract operation identifier.
 func (op *CreateContract) GetId() byte {
 	return CreateContractID
 }
 
-// NewCreateContract creates a new create-account operation.
+// NewCreateContract creates a new create-contract operation.
 func NewCreateContract(contract common.Address) *CreateContract {
 	return &CreateContract{Contract: contract}
 }
 
-// ReadCreateContract reads a create-account operation from a file.
+// ReadCreateContract reads a create-contract operation from a file.
 func ReadCreateContract(f io.Reader) (Operation, error) {
 	data := new(CreateContract)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
-// Write the create-account operation to file.
+// Write the create-contract operation to file.
 func (op *CreateContract) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
-// Execute the create-account operation.
+// Execute the create-contract operation.
 func (op *CreateContract) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
@@ -64,7 +64,7 @@ func (op *CreateContract) Execute(db state.StateDB, ctx *context.Replay) time.Du
 	return time.Since(start)
 }
 
-// Debug prints a debug message for the create-account operation.
+// Debug prints a debug message for the create-contract operation.
 func (op *CreateContract) Debug(ctx *context.Context) {
 	fmt.Print(op.Contract)
 }

--- a/tracer/operation/createcontract.go
+++ b/tracer/operation/createcontract.go
@@ -28,43 +28,43 @@ import (
 	"github.com/Fantom-foundation/Aida/tracer/context"
 )
 
-// CreateAccount data structure
-type CreateAccount struct {
+// CreateContract data structure
+type CreateContract struct {
 	Contract common.Address
 }
 
 // GetId returns the create-account operation identifier.
-func (op *CreateAccount) GetId() byte {
-	return CreateAccountID
+func (op *CreateContract) GetId() byte {
+	return CreateContractID
 }
 
-// NewCreateAccount creates a new create-account operation.
-func NewCreateAccount(contract common.Address) *CreateAccount {
-	return &CreateAccount{Contract: contract}
+// NewCreateContract creates a new create-account operation.
+func NewCreateContract(contract common.Address) *CreateContract {
+	return &CreateContract{Contract: contract}
 }
 
-// ReadCreateAccount reads a create-account operation from a file.
-func ReadCreateAccount(f io.Reader) (Operation, error) {
-	data := new(CreateAccount)
+// ReadCreateContract reads a create-account operation from a file.
+func ReadCreateContract(f io.Reader) (Operation, error) {
+	data := new(CreateContract)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
 // Write the create-account operation to file.
-func (op *CreateAccount) Write(f io.Writer) error {
+func (op *CreateContract) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
 // Execute the create-account operation.
-func (op *CreateAccount) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
+func (op *CreateContract) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
-	db.CreateAccount(contract)
+	db.CreateContract(contract)
 	return time.Since(start)
 }
 
 // Debug prints a debug message for the create-account operation.
-func (op *CreateAccount) Debug(ctx *context.Context) {
+func (op *CreateContract) Debug(ctx *context.Context) {
 	fmt.Print(op.Contract)
 }

--- a/tracer/operation/createcontract_test.go
+++ b/tracer/operation/createcontract_test.go
@@ -18,59 +18,54 @@ package operation
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/context"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/holiman/uint256"
 )
 
-func initSubBalance(t *testing.T) (*context.Replay, *SubBalance, common.Address, *uint256.Int, tracing.BalanceChangeReason) {
-	rand.Seed(time.Now().UnixNano())
+func initCreateContract(t *testing.T) (*context.Replay, *CreateContract, common.Address) {
 	addr := getRandomAddress(t)
-	value := uint256.NewInt(uint64(rand.Int63n(100000)))
-	reason := tracing.BalanceChangeUnspecified
 	// create context context
 	ctx := context.NewReplay()
 	contract := ctx.EncodeContract(addr)
 
 	// create new operation
-	op := NewSubBalance(contract, value, reason)
+	op := NewCreateContract(contract)
 	if op == nil {
 		t.Fatalf("failed to create operation")
 	}
 	// check id
-	if op.GetId() != SubBalanceID {
+	if op.GetId() != CreateContractID {
 		t.Fatalf("wrong ID returned")
 	}
-	return ctx, op, addr, value, reason
+
+	return ctx, op, addr
 }
 
-// TestSubBalanceReadWrite writes a new SubBalance object into a buffer, reads from it,
+// TestCreateContractReadWrite writes a new CreateContract object into a buffer, reads from it,
 // and checks equality.
-func TestSubBalanceReadWrite(t *testing.T) {
-	_, op1, _, _, _ := initSubBalance(t)
-	testOperationReadWrite(t, op1, ReadSubBalance)
+func TestCreateContractReadWrite(t *testing.T) {
+	_, op1, _ := initCreateContract(t)
+	testOperationReadWrite(t, op1, ReadCreateContract)
 }
 
-// TestSubBalanceDebug creates a new SubBalance object and checks its Debug message.
-func TestSubBalanceDebug(t *testing.T) {
-	ctx, op, addr, value, reason := initSubBalance(t)
-	testOperationDebug(t, ctx, op, fmt.Sprint(addr, value, reason))
+// TestCreateContractDebug creates a new CreateContract object and checks its Debug message.
+func TestCreateContractDebug(t *testing.T) {
+	ctx, op, addr := initCreateContract(t)
+	testOperationDebug(t, ctx, op, fmt.Sprint(addr))
+
 }
 
-// TestSubBalanceExecute
-func TestSubBalanceExecute(t *testing.T) {
-	ctx, op, addr, value, reason := initSubBalance(t)
+// TestCreateContractExecute
+func TestCreateContractExecute(t *testing.T) {
+	ctx, op, addr := initCreateContract(t)
 
 	// check execution
 	mock := NewMockStateDB()
 	op.Execute(mock, ctx)
 
 	// check whether methods were correctly called
-	expected := []Record{{SubBalanceID, []any{addr, value, reason}}}
+	expected := []Record{{CreateContractID, []any{addr}}}
 	mock.compareRecordings(expected, t)
 }

--- a/tracer/operation/getstorageroot.go
+++ b/tracer/operation/getstorageroot.go
@@ -33,30 +33,30 @@ type GetStorageRoot struct {
 	Contract common.Address
 }
 
-// GetId returns the get-code-hash operation identifier.
+// GetId returns the get-storage-root operation identifier.
 func (op *GetStorageRoot) GetId() byte {
 	return GetStorageRootID
 }
 
-// NewGetStorageRoot creates a new get-code-hash operation.
+// NewGetStorageRoot creates a new get-storage-root operation.
 func NewGetStorageRoot(contract common.Address) *GetStorageRoot {
 	return &GetStorageRoot{Contract: contract}
 }
 
-// ReadGetHash reads a get-code-hash operation from a file.
+// ReadGetHash reads a get-storage-root operation from a file.
 func ReadGetStorageRoot(f io.Reader) (Operation, error) {
 	data := new(GetStorageRoot)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
-// Write the get-code-hash operation to a file.
+// Write the get-storage-root operation to a file.
 func (op *GetStorageRoot) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
-// Execute the get-code-hash operation.
+// Execute the get-storage-root operation.
 func (op *GetStorageRoot) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
@@ -64,7 +64,7 @@ func (op *GetStorageRoot) Execute(db state.StateDB, ctx *context.Replay) time.Du
 	return time.Since(start)
 }
 
-// Debug prints a debug message for the get-code-hash operation.
+// Debug prints a debug message for the get-storage-root operation.
 func (op *GetStorageRoot) Debug(ctx *context.Context) {
 	fmt.Print(op.Contract)
 }

--- a/tracer/operation/getstorageroot.go
+++ b/tracer/operation/getstorageroot.go
@@ -28,43 +28,43 @@ import (
 	"github.com/Fantom-foundation/Aida/tracer/context"
 )
 
-// CreateAccount data structure
-type CreateAccount struct {
+// GetStorageRoot data structure
+type GetStorageRoot struct {
 	Contract common.Address
 }
 
-// GetId returns the create-account operation identifier.
-func (op *CreateAccount) GetId() byte {
-	return CreateAccountID
+// GetId returns the get-code-hash operation identifier.
+func (op *GetStorageRoot) GetId() byte {
+	return GetStorageRootID
 }
 
-// NewCreateAccount creates a new create-account operation.
-func NewCreateAccount(contract common.Address) *CreateAccount {
-	return &CreateAccount{Contract: contract}
+// NewGetStorageRoot creates a new get-code-hash operation.
+func NewGetStorageRoot(contract common.Address) *GetStorageRoot {
+	return &GetStorageRoot{Contract: contract}
 }
 
-// ReadCreateAccount reads a create-account operation from a file.
-func ReadCreateAccount(f io.Reader) (Operation, error) {
-	data := new(CreateAccount)
+// ReadGetHash reads a get-code-hash operation from a file.
+func ReadGetStorageRoot(f io.Reader) (Operation, error) {
+	data := new(GetStorageRoot)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
-// Write the create-account operation to file.
-func (op *CreateAccount) Write(f io.Writer) error {
+// Write the get-code-hash operation to a file.
+func (op *GetStorageRoot) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
-// Execute the create-account operation.
-func (op *CreateAccount) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
+// Execute the get-code-hash operation.
+func (op *GetStorageRoot) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
-	db.CreateAccount(contract)
+	db.GetStorageRoot(contract)
 	return time.Since(start)
 }
 
-// Debug prints a debug message for the create-account operation.
-func (op *CreateAccount) Debug(ctx *context.Context) {
+// Debug prints a debug message for the get-code-hash operation.
+func (op *GetStorageRoot) Debug(ctx *context.Context) {
 	fmt.Print(op.Contract)
 }

--- a/tracer/operation/getstorageroot_test.go
+++ b/tracer/operation/getstorageroot_test.go
@@ -24,47 +24,47 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func initHasSuicided(t *testing.T) (*context.Replay, *HasSuicided, common.Address) {
+func initGetStorageRoot(t *testing.T) (*context.Replay, *GetStorageRoot, common.Address) {
 	addr := getRandomAddress(t)
 	// create context context
 	ctx := context.NewReplay()
 	contract := ctx.EncodeContract(addr)
 
 	// create new operation
-	op := NewHasSuicided(contract)
+	op := NewGetStorageRoot(contract)
 	if op == nil {
 		t.Fatalf("failed to create operation")
 	}
 	// check id
-	if op.GetId() != HasSuicidedID {
+	if op.GetId() != GetStorageRootID {
 		t.Fatalf("wrong ID returned")
 	}
 
 	return ctx, op, addr
 }
 
-// TestHasSuicidedReadWrite writes a new HasSuicided object into a buffer, reads from it,
+// TestGetStorageRootReadWrite writes a new GetStorageRoot object into a buffer, reads from it,
 // and checks equality.
-func TestHasSuicidedReadWrite(t *testing.T) {
-	_, op1, _ := initHasSuicided(t)
-	testOperationReadWrite(t, op1, ReadHasSuicided)
+func TestGetStorageRootReadWrite(t *testing.T) {
+	_, op1, _ := initGetStorageRoot(t)
+	testOperationReadWrite(t, op1, ReadGetStorageRoot)
 }
 
-// TestHasSuicidedDebug creates a new HasSuicided object and checks its Debug message.
-func TestHasSuicidedDebug(t *testing.T) {
-	ctx, op, addr := initHasSuicided(t)
+// TestGetStorageRootDebug creates a new GetStorageRoot object and checks its Debug message.
+func TestGetStorageRootDebug(t *testing.T) {
+	ctx, op, addr := initGetStorageRoot(t)
 	testOperationDebug(t, ctx, op, fmt.Sprint(addr))
 }
 
-// TestHasSuicidedExecute
-func TestHasSuicidedExecute(t *testing.T) {
-	ctx, op, addr := initHasSuicided(t)
+// TestGetStorageRootExecute
+func TestGetStorageRootExecute(t *testing.T) {
+	ctx, op, addr := initGetStorageRoot(t)
 
 	// check execution
 	mock := NewMockStateDB()
 	op.Execute(mock, ctx)
 
 	// check whether methods were correctly called
-	expected := []Record{{HasSuicidedID, []any{addr}}}
+	expected := []Record{{GetStorageRootID, []any{addr}}}
 	mock.compareRecordings(expected, t)
 }

--- a/tracer/operation/hasselfdestructed.go
+++ b/tracer/operation/hasselfdestructed.go
@@ -27,43 +27,43 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// HasSuicided data structure
-type HasSuicided struct {
+// HasSelfDestructed data structure
+type HasSelfDestructed struct {
 	Contract common.Address
 }
 
-// GetId returns the HasSuicided operation identifier.
-func (op *HasSuicided) GetId() byte {
-	return HasSuicidedID
+// GetId returns the HasSelfDestructed operation identifier.
+func (op *HasSelfDestructed) GetId() byte {
+	return HasSelfDestructedID
 }
 
-// NewHasSuicided creates a new HasSuicided operation.
-func NewHasSuicided(contract common.Address) *HasSuicided {
-	return &HasSuicided{Contract: contract}
+// NewHasSelfDestructed creates a new HasSelfDestructed operation.
+func NewHasSelfDestructed(contract common.Address) *HasSelfDestructed {
+	return &HasSelfDestructed{Contract: contract}
 }
 
-// ReadHasSuicided reads a HasSuicided operation from a file.
-func ReadHasSuicided(f io.Reader) (Operation, error) {
-	data := new(HasSuicided)
+// ReadHasSelfDestructed reads a HasSelfDestructed operation from a file.
+func ReadHasSelfDestructed(f io.Reader) (Operation, error) {
+	data := new(HasSelfDestructed)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
-// Write the HasSuicided operation to a file.
-func (op *HasSuicided) Write(f io.Writer) error {
+// Write the HasSelfDestructed operation to a file.
+func (op *HasSelfDestructed) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
-// Execute the HasSuicided operation.
-func (op *HasSuicided) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
+// Execute the HasSelfDestructed operation.
+func (op *HasSelfDestructed) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
 	db.HasSelfDestructed(contract)
 	return time.Since(start)
 }
 
-// Debug prints a debug message for the HasSuicided operation.
-func (op *HasSuicided) Debug(ctx *context.Context) {
+// Debug prints a debug message for the HasSelfDestructed operation.
+func (op *HasSelfDestructed) Debug(ctx *context.Context) {
 	fmt.Print(op.Contract)
 }

--- a/tracer/operation/hasselfdestructed_test.go
+++ b/tracer/operation/hasselfdestructed_test.go
@@ -18,59 +18,53 @@ package operation
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/context"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/holiman/uint256"
 )
 
-func initSubBalance(t *testing.T) (*context.Replay, *SubBalance, common.Address, *uint256.Int, tracing.BalanceChangeReason) {
-	rand.Seed(time.Now().UnixNano())
+func initHasSelfDestructed(t *testing.T) (*context.Replay, *HasSelfDestructed, common.Address) {
 	addr := getRandomAddress(t)
-	value := uint256.NewInt(uint64(rand.Int63n(100000)))
-	reason := tracing.BalanceChangeUnspecified
 	// create context context
 	ctx := context.NewReplay()
 	contract := ctx.EncodeContract(addr)
 
 	// create new operation
-	op := NewSubBalance(contract, value, reason)
+	op := NewHasSelfDestructed(contract)
 	if op == nil {
 		t.Fatalf("failed to create operation")
 	}
 	// check id
-	if op.GetId() != SubBalanceID {
+	if op.GetId() != HasSelfDestructedID {
 		t.Fatalf("wrong ID returned")
 	}
-	return ctx, op, addr, value, reason
+
+	return ctx, op, addr
 }
 
-// TestSubBalanceReadWrite writes a new SubBalance object into a buffer, reads from it,
+// TestHasSelfDestructedReadWrite writes a new HasSelfDestructed object into a buffer, reads from it,
 // and checks equality.
-func TestSubBalanceReadWrite(t *testing.T) {
-	_, op1, _, _, _ := initSubBalance(t)
-	testOperationReadWrite(t, op1, ReadSubBalance)
+func TestHasSelfDestructedReadWrite(t *testing.T) {
+	_, op1, _ := initHasSelfDestructed(t)
+	testOperationReadWrite(t, op1, ReadHasSelfDestructed)
 }
 
-// TestSubBalanceDebug creates a new SubBalance object and checks its Debug message.
-func TestSubBalanceDebug(t *testing.T) {
-	ctx, op, addr, value, reason := initSubBalance(t)
-	testOperationDebug(t, ctx, op, fmt.Sprint(addr, value, reason))
+// TestHasSelfDestructedDebug creates a new HasSelfDestructed object and checks its Debug message.
+func TestHasSelfDestructedDebug(t *testing.T) {
+	ctx, op, addr := initHasSelfDestructed(t)
+	testOperationDebug(t, ctx, op, fmt.Sprint(addr))
 }
 
-// TestSubBalanceExecute
-func TestSubBalanceExecute(t *testing.T) {
-	ctx, op, addr, value, reason := initSubBalance(t)
+// TestHasSelfDestructedExecute
+func TestHasSelfDestructedExecute(t *testing.T) {
+	ctx, op, addr := initHasSelfDestructed(t)
 
 	// check execution
 	mock := NewMockStateDB()
 	op.Execute(mock, ctx)
 
 	// check whether methods were correctly called
-	expected := []Record{{SubBalanceID, []any{addr, value, reason}}}
+	expected := []Record{{HasSelfDestructedID, []any{addr}}}
 	mock.compareRecordings(expected, t)
 }

--- a/tracer/operation/operation.go
+++ b/tracer/operation/operation.go
@@ -53,7 +53,7 @@ const (
 	GetStateLccsID
 	GetStateLcID
 	GetStateLclsID
-	HasSuicidedID
+	HasSelfDestructedID
 	RevertToSnapshotID
 	SetCodeID
 	SetNonceID
@@ -61,31 +61,34 @@ const (
 	SetStateLclsID
 	SnapshotID
 	SubBalanceID
-	SuicideID
+	SelfDestructID
 
 	AddAddressToAccessListID
 	AddressInAccessListID
 	AddSlotToAccessListID
-	PrepareAccessListID
+	PrepareID
 	SlotInAccessListID
 
 	AddLogID
 	AddPreimageID
 	AddRefundID
 	CloseID
-	ForEachStorageID
 	GetLogsID
 	GetRefundID
 	IntermediateRootID
-	PrepareID
+	SetTxContextID
 	SubRefundID
 
+	// statedb operatioans from Altair to Cancun
+	CreateContractID
+	GetStorageRootID
 	GetTransientStateID
 	GetTransientStateLccsID
 	GetTransientStateLcID
 	GetTransientStateLclsID
 	SetTransientStateID
 	SetTransientStateLclsID
+	SelfDestruct6780ID
 
 	// WARNING: New IDs should be added here. Any change in the order of the
 	// IDs above invalidates persisted data -- in particular storage traces.
@@ -126,7 +129,7 @@ var opDict = map[byte]OperationDictionary{
 	GetStateLcID:            {label: "GetStateLc", readfunc: ReadGetStateLc},
 	GetStateLccsID:          {label: "GetStateLccs", readfunc: ReadGetStateLccs},
 	GetStateLclsID:          {label: "GetStateLcls", readfunc: ReadGetStateLcls},
-	HasSuicidedID:           {label: "HasSuicided", readfunc: ReadHasSuicided},
+	HasSelfDestructedID:     {label: "HasSelfDestructed", readfunc: ReadHasSelfDestructed},
 	RevertToSnapshotID:      {label: "RevertToSnapshot", readfunc: ReadRevertToSnapshot},
 	SetCodeID:               {label: "SetCode", readfunc: ReadSetCode},
 	SetNonceID:              {label: "SetNonce", readfunc: ReadSetNonce},
@@ -134,7 +137,10 @@ var opDict = map[byte]OperationDictionary{
 	SetStateLclsID:          {label: "SetStateLcls", readfunc: ReadSetStateLcls},
 	SnapshotID:              {label: "Snapshot", readfunc: ReadSnapshot},
 	SubBalanceID:            {label: "SubBalance", readfunc: ReadSubBalance},
-	SuicideID:               {label: "Suicide", readfunc: ReadSuicide},
+	SelfDestructID:          {label: "SelfDestruct", readfunc: ReadSelfDestruct},
+	SelfDestruct6780ID:      {label: "SelfDestruct", readfunc: ReadSelfDestruct6780},
+	CreateContractID:        {label: "CreateContract", readfunc: ReadCreateContract},
+	GetStorageRootID:        {label: "GetStorageRoot", readfunc: ReadGetStorageRoot},
 
 	// for testing
 	AddAddressToAccessListID: {label: "AddAddressToAccessList", readfunc: ReadPanic},
@@ -144,12 +150,11 @@ var opDict = map[byte]OperationDictionary{
 	AddressInAccessListID:    {label: "AddressInAccessList", readfunc: ReadPanic},
 	AddSlotToAccessListID:    {label: "AddSlotToAccessList", readfunc: ReadPanic},
 	CloseID:                  {label: "Close", readfunc: ReadPanic},
-	ForEachStorageID:         {label: "ForEachStorage", readfunc: ReadPanic},
 	GetLogsID:                {label: "GetLogs", readfunc: ReadPanic},
 	GetRefundID:              {label: "GetRefund", readfunc: ReadPanic},
 	IntermediateRootID:       {label: "IntermediateRoot", readfunc: ReadPanic},
-	PrepareAccessListID:      {label: "PrepareAccessList", readfunc: ReadPanic},
 	PrepareID:                {label: "Prepare", readfunc: ReadPanic},
+	SetTxContextID:           {label: "SetTxContext", readfunc: ReadPanic},
 	SlotInAccessListID:       {label: "SlotInAccessList", readfunc: ReadPanic},
 	SubRefundID:              {label: "SubRefund", readfunc: ReadPanic},
 

--- a/tracer/operation/operation_test.go
+++ b/tracer/operation/operation_test.go
@@ -70,12 +70,16 @@ func (s *MockStateDB) Empty(addr common.Address) bool {
 }
 
 func (s *MockStateDB) SelfDestruct(addr common.Address) {
-	s.recording = append(s.recording, Record{SuicideID, []any{addr}})
+	s.recording = append(s.recording, Record{SelfDestructID, []any{addr}})
 }
 
 func (s *MockStateDB) HasSelfDestructed(addr common.Address) bool {
-	s.recording = append(s.recording, Record{HasSuicidedID, []any{addr}})
+	s.recording = append(s.recording, Record{HasSelfDestructedID, []any{addr}})
 	return false
+}
+
+func (s *MockStateDB) Selfdestruct6780(addr common.Address) {
+	s.recording = append(s.recording, Record{SelfDestruct6780ID, []any{addr}})
 }
 
 func (s *MockStateDB) GetBalance(addr common.Address) *uint256.Int {
@@ -218,7 +222,7 @@ func (s *MockStateDB) GetHash() (common.Hash, error) {
 }
 
 func (s *MockStateDB) SetTxContext(thash common.Hash, ti int) {
-	s.recording = append(s.recording, Record{PrepareID, []any{thash, ti}})
+	s.recording = append(s.recording, Record{SetTxContextID, []any{thash, ti}})
 }
 
 func (s *MockStateDB) AddRefund(gas uint64) {
@@ -235,7 +239,7 @@ func (s *MockStateDB) GetRefund() uint64 {
 }
 
 func (s *MockStateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	s.recording = append(s.recording, Record{PrepareAccessListID, []any{rules, sender, coinbase, dest, precompiles, txAccesses}})
+	s.recording = append(s.recording, Record{PrepareID, []any{rules, sender, coinbase, dest, precompiles, txAccesses}})
 }
 
 func (s *MockStateDB) AddressInAccessList(addr common.Address) bool {
@@ -265,7 +269,6 @@ func (s *MockStateDB) AddPreimage(hash common.Hash, preimage []byte) {
 }
 
 func (s *MockStateDB) ForEachStorage(addr common.Address, cb func(common.Hash, common.Hash) bool) error {
-	s.recording = append(s.recording, Record{ForEachStorageID, []any{addr, cb}})
 	return nil
 }
 
@@ -284,15 +287,12 @@ func (s *MockStateDB) GetSubstatePostAlloc() txcontext.WorldState {
 }
 
 func (s *MockStateDB) CreateContract(addr common.Address) {
-	panic("CreateContract not supported in mock")
-}
-
-func (s *MockStateDB) Selfdestruct6780(addr common.Address) {
-	panic("Selfdestruct6780 not supported in mock")
+	s.recording = append(s.recording, Record{CreateContractID, []any{addr}})
 }
 
 func (s *MockStateDB) GetStorageRoot(addr common.Address) common.Hash {
-	panic("GetStorageRoot not supported in mock")
+	s.recording = append(s.recording, Record{GetStorageRootID, []any{addr}})
+	return common.Hash{}
 }
 
 func (s *MockStateDB) Close() error {

--- a/tracer/operation/selfdestruct.go
+++ b/tracer/operation/selfdestruct.go
@@ -33,30 +33,30 @@ type SelfDestruct struct {
 	Contract common.Address
 }
 
-// GetId returns the suicide operation identifier.
+// GetId returns the self-destruct operation identifier.
 func (op *SelfDestruct) GetId() byte {
 	return SelfDestructID
 }
 
-// NewSelfDestruct creates a new suicide operation.
+// NewSelfDestruct creates a new self-destruct operation.
 func NewSelfDestruct(contract common.Address) *SelfDestruct {
 	return &SelfDestruct{Contract: contract}
 }
 
-// ReadSelfDestruct reads a suicide operation from a file.
+// ReadSelfDestruct reads a self-destruct operation from a file.
 func ReadSelfDestruct(f io.Reader) (Operation, error) {
 	data := new(SelfDestruct)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
-// Write the suicide operation to a file.
+// Write the self-destruct operation to a file.
 func (op *SelfDestruct) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
-// Execute the suicide operation.
+// Execute the self-destruct operation.
 func (op *SelfDestruct) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
@@ -64,7 +64,7 @@ func (op *SelfDestruct) Execute(db state.StateDB, ctx *context.Replay) time.Dura
 	return time.Since(start)
 }
 
-// Debug prints a debug message for the suicide operation.
+// Debug prints a debug message for the self-destruct operation.
 func (op *SelfDestruct) Debug(ctx *context.Context) {
 	fmt.Print(ctx.DecodeContract(op.Contract))
 }

--- a/tracer/operation/selfdestruct.go
+++ b/tracer/operation/selfdestruct.go
@@ -28,43 +28,43 @@ import (
 	"github.com/Fantom-foundation/Aida/tracer/context"
 )
 
-// CreateAccount data structure
-type CreateAccount struct {
+// SelfDestruct data structure
+type SelfDestruct struct {
 	Contract common.Address
 }
 
-// GetId returns the create-account operation identifier.
-func (op *CreateAccount) GetId() byte {
-	return CreateAccountID
+// GetId returns the suicide operation identifier.
+func (op *SelfDestruct) GetId() byte {
+	return SelfDestructID
 }
 
-// NewCreateAccount creates a new create-account operation.
-func NewCreateAccount(contract common.Address) *CreateAccount {
-	return &CreateAccount{Contract: contract}
+// NewSelfDestruct creates a new suicide operation.
+func NewSelfDestruct(contract common.Address) *SelfDestruct {
+	return &SelfDestruct{Contract: contract}
 }
 
-// ReadCreateAccount reads a create-account operation from a file.
-func ReadCreateAccount(f io.Reader) (Operation, error) {
-	data := new(CreateAccount)
+// ReadSelfDestruct reads a suicide operation from a file.
+func ReadSelfDestruct(f io.Reader) (Operation, error) {
+	data := new(SelfDestruct)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
-// Write the create-account operation to file.
-func (op *CreateAccount) Write(f io.Writer) error {
+// Write the suicide operation to a file.
+func (op *SelfDestruct) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
-// Execute the create-account operation.
-func (op *CreateAccount) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
+// Execute the suicide operation.
+func (op *SelfDestruct) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
-	db.CreateAccount(contract)
+	db.SelfDestruct(contract)
 	return time.Since(start)
 }
 
-// Debug prints a debug message for the create-account operation.
-func (op *CreateAccount) Debug(ctx *context.Context) {
-	fmt.Print(op.Contract)
+// Debug prints a debug message for the suicide operation.
+func (op *SelfDestruct) Debug(ctx *context.Context) {
+	fmt.Print(ctx.DecodeContract(op.Contract))
 }

--- a/tracer/operation/selfdestruct6780.go
+++ b/tracer/operation/selfdestruct6780.go
@@ -28,43 +28,43 @@ import (
 	"github.com/Fantom-foundation/Aida/tracer/context"
 )
 
-// Suicide data structure
-type Suicide struct {
+// SelfDestruct6780 data structure
+type SelfDestruct6780 struct {
 	Contract common.Address
 }
 
 // GetId returns the suicide operation identifier.
-func (op *Suicide) GetId() byte {
-	return SuicideID
+func (op *SelfDestruct6780) GetId() byte {
+	return SelfDestruct6780ID
 }
 
-// NewSuicide creates a new suicide operation.
-func NewSuicide(contract common.Address) *Suicide {
-	return &Suicide{Contract: contract}
+// NewSelfDestruct6780 creates a new suicide operation.
+func NewSelfDestruct6780(contract common.Address) *SelfDestruct6780 {
+	return &SelfDestruct6780{Contract: contract}
 }
 
-// ReadSuicide reads a suicide operation from a file.
-func ReadSuicide(f io.Reader) (Operation, error) {
-	data := new(Suicide)
+// ReadSelfDestruct6780 reads a suicide operation from a file.
+func ReadSelfDestruct6780(f io.Reader) (Operation, error) {
+	data := new(SelfDestruct6780)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
 // Write the suicide operation to a file.
-func (op *Suicide) Write(f io.Writer) error {
+func (op *SelfDestruct6780) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
 // Execute the suicide operation.
-func (op *Suicide) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
+func (op *SelfDestruct6780) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
-	db.SelfDestruct(contract)
+	db.Selfdestruct6780(contract)
 	return time.Since(start)
 }
 
 // Debug prints a debug message for the suicide operation.
-func (op *Suicide) Debug(ctx *context.Context) {
+func (op *SelfDestruct6780) Debug(ctx *context.Context) {
 	fmt.Print(ctx.DecodeContract(op.Contract))
 }

--- a/tracer/operation/selfdestruct6780.go
+++ b/tracer/operation/selfdestruct6780.go
@@ -33,30 +33,30 @@ type SelfDestruct6780 struct {
 	Contract common.Address
 }
 
-// GetId returns the suicide operation identifier.
+// GetId returns the self-destruct operation identifier.
 func (op *SelfDestruct6780) GetId() byte {
 	return SelfDestruct6780ID
 }
 
-// NewSelfDestruct6780 creates a new suicide operation.
+// NewSelfDestruct6780 creates a new self-destruct operation.
 func NewSelfDestruct6780(contract common.Address) *SelfDestruct6780 {
 	return &SelfDestruct6780{Contract: contract}
 }
 
-// ReadSelfDestruct6780 reads a suicide operation from a file.
+// ReadSelfDestruct6780 reads a self-destruct operation from a file.
 func ReadSelfDestruct6780(f io.Reader) (Operation, error) {
 	data := new(SelfDestruct6780)
 	err := binary.Read(f, binary.LittleEndian, data)
 	return data, err
 }
 
-// Write the suicide operation to a file.
+// Write the self-destruct operation to a file.
 func (op *SelfDestruct6780) Write(f io.Writer) error {
 	err := binary.Write(f, binary.LittleEndian, *op)
 	return err
 }
 
-// Execute the suicide operation.
+// Execute the self-destruct operation.
 func (op *SelfDestruct6780) Execute(db state.StateDB, ctx *context.Replay) time.Duration {
 	contract := ctx.DecodeContract(op.Contract)
 	start := time.Now()
@@ -64,7 +64,7 @@ func (op *SelfDestruct6780) Execute(db state.StateDB, ctx *context.Replay) time.
 	return time.Since(start)
 }
 
-// Debug prints a debug message for the suicide operation.
+// Debug prints a debug message for the self-destruct operation.
 func (op *SelfDestruct6780) Debug(ctx *context.Context) {
 	fmt.Print(ctx.DecodeContract(op.Contract))
 }

--- a/tracer/operation/selfdestruct6780_test.go
+++ b/tracer/operation/selfdestruct6780_test.go
@@ -18,59 +18,53 @@ package operation
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/Fantom-foundation/Aida/tracer/context"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/holiman/uint256"
 )
 
-func initSubBalance(t *testing.T) (*context.Replay, *SubBalance, common.Address, *uint256.Int, tracing.BalanceChangeReason) {
-	rand.Seed(time.Now().UnixNano())
+func initSelfDestruct6780(t *testing.T) (*context.Replay, *SelfDestruct6780, common.Address) {
 	addr := getRandomAddress(t)
-	value := uint256.NewInt(uint64(rand.Int63n(100000)))
-	reason := tracing.BalanceChangeUnspecified
 	// create context context
 	ctx := context.NewReplay()
 	contract := ctx.EncodeContract(addr)
 
 	// create new operation
-	op := NewSubBalance(contract, value, reason)
+	op := NewSelfDestruct6780(contract)
 	if op == nil {
 		t.Fatalf("failed to create operation")
 	}
 	// check id
-	if op.GetId() != SubBalanceID {
+	if op.GetId() != SelfDestruct6780ID {
 		t.Fatalf("wrong ID returned")
 	}
-	return ctx, op, addr, value, reason
+
+	return ctx, op, addr
 }
 
-// TestSubBalanceReadWrite writes a new SubBalance object into a buffer, reads from it,
+// TestSelfDestruct6780ReadWrite writes a new SelfDestruct6780 object into a buffer, reads from it,
 // and checks equality.
-func TestSubBalanceReadWrite(t *testing.T) {
-	_, op1, _, _, _ := initSubBalance(t)
-	testOperationReadWrite(t, op1, ReadSubBalance)
+func TestSelfDestruct6780ReadWrite(t *testing.T) {
+	_, op1, _ := initSelfDestruct6780(t)
+	testOperationReadWrite(t, op1, ReadSelfDestruct6780)
 }
 
-// TestSubBalanceDebug creates a new SubBalance object and checks its Debug message.
-func TestSubBalanceDebug(t *testing.T) {
-	ctx, op, addr, value, reason := initSubBalance(t)
-	testOperationDebug(t, ctx, op, fmt.Sprint(addr, value, reason))
+// TestSelfDestruct6780Debug creates a new SelfDestruct6780 object and checks its Debug message.
+func TestSelfDestruct6780Debug(t *testing.T) {
+	ctx, op, addr := initSelfDestruct6780(t)
+	testOperationDebug(t, ctx, op, fmt.Sprint(addr))
 }
 
-// TestSubBalanceExecute
-func TestSubBalanceExecute(t *testing.T) {
-	ctx, op, addr, value, reason := initSubBalance(t)
+// TestSelfDestruct6780Execute
+func TestSelfDestruct6780Execute(t *testing.T) {
+	ctx, op, addr := initSelfDestruct6780(t)
 
 	// check execution
 	mock := NewMockStateDB()
 	op.Execute(mock, ctx)
 
 	// check whether methods were correctly called
-	expected := []Record{{SubBalanceID, []any{addr, value, reason}}}
+	expected := []Record{{SelfDestruct6780ID, []any{addr}}}
 	mock.compareRecordings(expected, t)
 }

--- a/tracer/operation/selfdestruct_test.go
+++ b/tracer/operation/selfdestruct_test.go
@@ -24,47 +24,47 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func initSuicide(t *testing.T) (*context.Replay, *Suicide, common.Address) {
+func initSelfDestruct(t *testing.T) (*context.Replay, *SelfDestruct, common.Address) {
 	addr := getRandomAddress(t)
 	// create context context
 	ctx := context.NewReplay()
 	contract := ctx.EncodeContract(addr)
 
 	// create new operation
-	op := NewSuicide(contract)
+	op := NewSelfDestruct(contract)
 	if op == nil {
 		t.Fatalf("failed to create operation")
 	}
 	// check id
-	if op.GetId() != SuicideID {
+	if op.GetId() != SelfDestructID {
 		t.Fatalf("wrong ID returned")
 	}
 
 	return ctx, op, addr
 }
 
-// TestSuicideReadWrite writes a new Suicide object into a buffer, reads from it,
+// TestSelfDestructReadWrite writes a new SelfDestruct object into a buffer, reads from it,
 // and checks equality.
-func TestSuicideReadWrite(t *testing.T) {
-	_, op1, _ := initSuicide(t)
-	testOperationReadWrite(t, op1, ReadSuicide)
+func TestSelfDestructReadWrite(t *testing.T) {
+	_, op1, _ := initSelfDestruct(t)
+	testOperationReadWrite(t, op1, ReadSelfDestruct)
 }
 
-// TestSuicideDebug creates a new Suicide object and checks its Debug message.
-func TestSuicideDebug(t *testing.T) {
-	ctx, op, addr := initSuicide(t)
+// TestSelfDestructDebug creates a new SelfDestruct object and checks its Debug message.
+func TestSelfDestructDebug(t *testing.T) {
+	ctx, op, addr := initSelfDestruct(t)
 	testOperationDebug(t, ctx, op, fmt.Sprint(addr))
 }
 
-// TestSuicideExecute
-func TestSuicideExecute(t *testing.T) {
-	ctx, op, addr := initSuicide(t)
+// TestSelfDestructExecute
+func TestSelfDestructExecute(t *testing.T) {
+	ctx, op, addr := initSelfDestruct(t)
 
 	// check execution
 	mock := NewMockStateDB()
 	op.Execute(mock, ctx)
 
 	// check whether methods were correctly called
-	expected := []Record{{SuicideID, []any{addr}}}
+	expected := []Record{{SelfDestructID, []any{addr}}}
 	mock.compareRecordings(expected, t)
 }


### PR DESCRIPTION
## Description

Support the new statedb operations in `aida-sdb` tool and update interface of existing operations. Changes are as follows:

- [x] - AddBalance/SubBalance now supports recording of balance change reason. 
- [x] - Balance type is changed to 32 bytes as per https://github.com/Fantom-foundation/Carmen/pull/771
- [x] -  Fix incorrect copy of balance bytes in AddBalance/SubBalance
- [x] - Add 3 new operations CreateContract, GetStorageHash and SelfDestruct6780 to `operation`.
- [x] - Support the new operations in profiler.
- [x] - Support the new operations in stochastic tests.

Note: this PR must be merge after #1103.

Fixes #1122 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Adds or updates testing
