### PR TITLE
Make sonic as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "tosca"]
 	path = tosca
 	url = https://github.com/Fantom-foundation/Tosca.git
+[submodule "sonic"]
+	path = sonic
+	url = https://github.com/Fantom-foundation/Sonic.git

--- a/go.mod
+++ b/go.mod
@@ -132,4 +132,6 @@ replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ether
 
 replace github.com/Fantom-foundation/lachesis-base => github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20240823114058-cda038e6d40b
 
-replace github.com/Fantom-foundation/go-opera => github.com/Fantom-foundation/sonic v1.2.1-b.0.20240903161021-f3f7aac6713f
+// Sonic client is integrated as a git-submodule to make version configuration easier
+// when running tests.
+replace github.com/Fantom-foundation/go-opera => ./sonic

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240821150740-8b61095b913
 github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240821150740-8b61095b9134/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
 github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20240823114058-cda038e6d40b h1:oggmwdVb9tJiUJrcFvs5A3JOC1t2I231N4/RW2YXr8w=
 github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20240823114058-cda038e6d40b/go.mod h1:YaNcYnDsDooGLKqsrTt+tafplgorZ0l8C1IwmryrIWs=
-github.com/Fantom-foundation/sonic v1.2.1-b.0.20240903161021-f3f7aac6713f h1:oa17ep7a1fQoDvdDH74lblfQIFh6IgmCmQpAvfC47AM=
-github.com/Fantom-foundation/sonic v1.2.1-b.0.20240903161021-f3f7aac6713f/go.mod h1:etKBZ2pe8jtIcVs5l9gL+IEkKs24UI5OA05oFIc8aUg=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Description

Convert Sonic into a submodule for a better version control when used in testing. A version of Sonic can be passed as a parameter in Jenkins.

## Type of change

Please delete options that are not relevant.

- [x] Refactoring (changes that do NOT affect functionality)
