### PR TITLE
Upgrade go to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/Fantom-foundation/Aida
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23
 
 require (
 	github.com/Fantom-foundation/Carmen/go v0.0.0-20240720214637-e2e21d535f38


### PR DESCRIPTION
## Description

As written [here](https://go.dev/blog/go1.23) latest version of go is `1.23`

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
