### PR TITLE
Txcontext result

### DIFF
--- a/txcontext/result.go
+++ b/txcontext/result.go
@@ -23,11 +23,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+// Result is a transaction result.
 type Result interface {
+	// GetReceipt returns the Receipt of current result.
 	GetReceipt() Receipt
+	// GetRawResult returns raw data as byte array and/or an error which depends on whether transaction failed or not.
 	GetRawResult() ([]byte, error)
+	// GetGasUsed returns how much gas transaction used.
 	GetGasUsed() uint64
-	String() string
 }
 
 // Receipt represents an interface for managing and retrieving the result of a blockchain transaction or contract execution.


### PR DESCRIPTION
## Description

This PR removes mandatory `String()` method from `Result` interface and adds proper documentation to the interface.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
