### PR TITLE
Add closing time log to aida-vm-sdb

### DIFF
--- a/cmd/aida-vm-sdb/run_tx_generator_test.go
+++ b/cmd/aida-vm-sdb/run_tx_generator_test.go
@@ -99,6 +99,7 @@ func TestVmSdb_TxGenerator_AllTransactionsAreProcessedInOrder(t *testing.T) {
 		db.EXPECT().EndBlock(),
 
 		// db_manager closes the db
+		db.EXPECT().GetHash(),
 		db.EXPECT().Close(),
 	)
 

--- a/executor/extension/statedb/state_db_manager_test.go
+++ b/executor/extension/statedb/state_db_manager_test.go
@@ -41,6 +41,7 @@ func TestStateDbManager_DbClosureWithoutKeepDb(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockStateDB := state.NewMockStateDB(mockCtrl)
 
+	mockStateDB.EXPECT().GetHash()
 	mockStateDB.EXPECT().Close()
 
 	state := executor.State[any]{


### PR DESCRIPTION
## Description

This PR reports DB close time in log. This is the first step of reporting time spent in DB Close. The time will be added to register run db in a later PR.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Adds or updates testing
