### PR TITLE
[Squashed 1027] Move Default values from Extension to App

### DIFF
--- a/cmd/aida-rpc/run_rpc.go
+++ b/cmd/aida-rpc/run_rpc.go
@@ -32,6 +32,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	rpcDefaultProgressReportFrequency = 100_000
+)
+
 func RunRpc(ctx *cli.Context) error {
 	cfg, err := utils.NewConfig(ctx, utils.BlockRangeArgs)
 	if err != nil {
@@ -76,8 +80,11 @@ func run(
 	var extensionList = []executor.Extension[*rpc.RequestAndResults]{
 		// RegisterProgress should be the first on the list = last to receive PostRun.
 		// This is because it collects the error and records it externally.
-		// If not, error that happen afterwards (e.g. on top of) will not be correcly recorded.
-		register.MakeRegisterRequestProgress(cfg, 100_000),
+		// If not, error that happen afterwards (e.g. on top of) will not be correctly recorded.
+		register.MakeRegisterRequestProgress(cfg,
+			rpcDefaultProgressReportFrequency,
+			register.OnPreBlock,
+		),
 
 		profiler.MakeCpuProfiler[*rpc.RequestAndResults](cfg),
 		logger.MakeProgressLogger[*rpc.RequestAndResults](cfg, 15*time.Second),

--- a/cmd/aida-vm-sdb/run_substate.go
+++ b/cmd/aida-vm-sdb/run_substate.go
@@ -35,6 +35,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	substateDefaultProgressReportFrequency = 100_000
+)
+
 // RunSubstate performs sequential block processing on a StateDb
 func RunSubstate(ctx *cli.Context) error {
 	cfg, err := utils.NewConfig(ctx, utils.BlockRangeArgs)
@@ -86,7 +90,10 @@ func runSubstates(cfg *utils.Config, provider executor.Provider[txcontext.TxCont
 	extensionList = append(extensionList, extra...)
 
 	extensionList = append(extensionList, []executor.Extension[txcontext.TxContext]{
-		register.MakeRegisterProgress(cfg, 100_000),
+		register.MakeRegisterProgress(cfg,
+			substateDefaultProgressReportFrequency,
+			register.OnPreBlock,
+		),
 		// RegisterProgress should be the as top-most as possible on the list
 		// In this case, after StateDb is created.
 		// Any error that happen in extension above it will not be correctly recorded.

--- a/cmd/aida-vm-sdb/run_tx_generator_test.go
+++ b/cmd/aida-vm-sdb/run_tx_generator_test.go
@@ -99,6 +99,7 @@ func TestVmSdb_TxGenerator_AllTransactionsAreProcessedInOrder(t *testing.T) {
 		db.EXPECT().EndBlock(),
 
 		// db_manager closes the db
+		db.EXPECT().GetHash(),
 		db.EXPECT().Close(),
 	)
 

--- a/executor/extension/register/register_request_progress.go
+++ b/executor/extension/register/register_request_progress.go
@@ -33,6 +33,8 @@ import (
 )
 
 const (
+	defaultRequestReportFrequency = 100_000
+
 	registerRequestProgressCreateTableIfNotExist = `
 		CREATE TABLE IF NOT EXISTS stats_rpc (
 			count INTEGER NOT NULL,
@@ -54,8 +56,8 @@ const (
 )
 
 // MakeRegisterRequestProgress creates a blockProgressTracker that depends on the
-// PostBlock event and is only useful as part of a sequential evaluation.
-func MakeRegisterRequestProgress(cfg *utils.Config, reportFrequency int) executor.Extension[*rpc.RequestAndResults] {
+// PostBlock event and is only useful as part of a sequential evaluation.a
+func MakeRegisterRequestProgress(cfg *utils.Config, reportFrequency int, when whenToPrint) executor.Extension[*rpc.RequestAndResults] {
 	// As temporary measure: issue a warning to user if both RegisterRun and TrackProgress is on.
 	log := logger.NewLogger(cfg.LogLevel, "RegisterRequestProgress")
 	if cfg.RegisterRun != "" && cfg.TrackProgress {
@@ -66,19 +68,20 @@ func MakeRegisterRequestProgress(cfg *utils.Config, reportFrequency int) executo
 		return extension.NilExtension[*rpc.RequestAndResults]{}
 	}
 
-	if reportFrequency == 0 {
-		reportFrequency = RegisterProgressDefaultReportFrequency
+	var freq int = defaultRequestReportFrequency
+	if reportFrequency != 0 {
+		freq = reportFrequency
 	}
 
-	return makeRegisterRequestProgress(cfg, reportFrequency, log)
+	return makeRegisterRequestProgress(cfg, freq, when, log)
 }
 
-func makeRegisterRequestProgress(cfg *utils.Config, reportFrequency int, log logger.Logger) *registerRequestProgress {
-
+func makeRegisterRequestProgress(cfg *utils.Config, reportFrequency int, when whenToPrint, log logger.Logger) *registerRequestProgress {
 	return &registerRequestProgress{
 		cfg:             cfg,
 		log:             log,
 		reportFrequency: reportFrequency,
+		when:            when,
 		ps:              utils.NewPrinters(),
 		id:              rr.MakeRunIdentity(time.Now().Unix(), cfg),
 	}
@@ -93,6 +96,7 @@ type registerRequestProgress struct {
 	log  logger.Logger
 	lock sync.Mutex
 	ps   *utils.Printers
+	when whenToPrint
 
 	// Where am I?
 	lastReportedRequestCount uint64

--- a/executor/extension/statedb/state_db_manager_test.go
+++ b/executor/extension/statedb/state_db_manager_test.go
@@ -41,6 +41,7 @@ func TestStateDbManager_DbClosureWithoutKeepDb(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockStateDB := state.NewMockStateDB(mockCtrl)
 
+	mockStateDB.EXPECT().GetHash()
 	mockStateDB.EXPECT().Close()
 
 	state := executor.State[any]{


### PR DESCRIPTION
From https://github.com/Fantom-foundation/Aida/pull/1027

Currently, RegisterProgress, RegisterRequestProgress has two tiers of default value check:
1. When executing app, pass value from flag to extension (if flag not set, default to default config value)
2. extension, on "makeExtension", figures out its own default value based on app name.

This should be refactored so that
a. extension no longer aware of how to figure out its own default value
b. default value is figured out by the app (run_substate.go, run_tx_generator.go, etc.) and this is then passed to the extension.


## Type of change

- [ ] Refactoring (changes that do NOT affect functionality)
