### PR TITLE
Add error from message result to transaction result.

### DIFF
--- a/executor/transaction_result.go
+++ b/executor/transaction_result.go
@@ -17,6 +17,7 @@
 package executor
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Fantom-foundation/Aida/txcontext"
@@ -94,6 +95,7 @@ func newTransactionResult(logs []*types.Log, msg *core.Message, msgResult *evmco
 		} else {
 			status = types.ReceiptStatusSuccessful
 		}
+		err = errors.Join(err, msgResult.Err)
 	}
 
 	return transactionResult{

--- a/executor/transaction_result_test.go
+++ b/executor/transaction_result_test.go
@@ -1,0 +1,22 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+)
+
+func TestNewTransactionResult_ExecutionResult_Error_IsAdded(t *testing.T) {
+	injectedErr := errors.New("injected err")
+	msg := &core.Message{To: &(common.Address{1})}
+	result := &evmcore.ExecutionResult{Err: injectedErr}
+
+	tr := newTransactionResult(nil, msg, result, nil, common.Address{2})
+
+	if got, want := tr.err, injectedErr; !errors.Is(got, want) {
+		t.Errorf("unexpected error, got: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds `ExecutionResult.Err` returned by `ApplyMessage` to Aidas `TransactionResult`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
