### PR TITLE
Make all experimental LFVM configurations accessible in Aida

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -38,9 +38,15 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/geth_adapter"
 	_ "github.com/Fantom-foundation/Tosca/go/interpreter/evmone"
 	_ "github.com/Fantom-foundation/Tosca/go/interpreter/evmzero"
-	_ "github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
+	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
+
+func init() {
+	if err := lfvm.RegisterExperimentalInterpreterConfigurations(); err != nil {
+		panic(fmt.Sprintf("failed to register experimental LFVM interpreter configurations: %v", err))
+	}
+}
 
 type ArgumentMode int
 type ChainID int


### PR DESCRIPTION
## Description

The LFVM implementation has been updated to only export the officially supported LFVM configuration by default (aka `lfvm`). Experimental configurations like `lfvm-si` or `lfvm-stats` need to be explicitly imported. This PR adds the corresponding call to Aida.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
