### PR TITLE
Add random to blk ctx

### DIFF
--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -379,6 +379,7 @@ func prepareBlockCtx(inputEnv txcontext.BlockEnvironment, hashError *error) *vm.
 		Difficulty:  inputEnv.GetDifficulty(),
 		GasLimit:    inputEnv.GetGasLimit(),
 		GetHash:     getHash,
+		Random:      inputEnv.GetRandom(),
 	}
 	// If currentBaseFee is defined, add it to the vmContext.
 	baseFee := inputEnv.GetBaseFee()


### PR DESCRIPTION
## Description

This PR adds forgotten call to `GetRandom()` to `BlockContext` creation. 
This did not matter up until now, because our tools did not require it, although `geth-tests` need it for some tests.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
