### PR TITLE
[Hotfix] txcontext.BlockEnvironment.GetRandom now returns Random instead of nil

### DIFF
--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -167,7 +167,6 @@ func MakeTxProcessor(cfg *utils.Config) (*TxProcessor, error) {
 		if evm == nil {
 			available := maps.Keys(tosca.GetAllRegisteredProcessorFactories())
 			available = append(available, "aida")
-			available = append(available, "aida-geth")
 			slices.Sort(available)
 			return nil, fmt.Errorf("unknown EVM implementation: %s, supported: %v", cfg.EvmImpl, available)
 		}

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -167,6 +167,7 @@ func MakeTxProcessor(cfg *utils.Config) (*TxProcessor, error) {
 		if evm == nil {
 			available := maps.Keys(tosca.GetAllRegisteredProcessorFactories())
 			available = append(available, "aida")
+			available = append(available, "aida-geth")
 			slices.Sort(available)
 			return nil, fmt.Errorf("unknown EVM implementation: %s, supported: %v", cfg.EvmImpl, available)
 		}
@@ -377,6 +378,7 @@ func prepareBlockCtx(inputEnv txcontext.BlockEnvironment, hashError *error) *vm.
 		BlockNumber: new(big.Int).SetUint64(inputEnv.GetNumber()),
 		Time:        inputEnv.GetTimestamp(),
 		Difficulty:  inputEnv.GetDifficulty(),
+		Random:      inputEnv.GetRandom(),
 		GasLimit:    inputEnv.GetGasLimit(),
 		GetHash:     getHash,
 	}

--- a/txcontext/substate/block_environment.go
+++ b/txcontext/substate/block_environment.go
@@ -34,7 +34,12 @@ type blockEnvironment struct {
 }
 
 func (e *blockEnvironment) GetRandom() *common.Hash {
-	return nil
+	if e.Random == nil {
+		return nil
+	}
+
+	h := common.Hash(e.Random.Bytes())
+	return &h
 }
 
 func (e *blockEnvironment) GetBlockHash(block uint64) (common.Hash, error) {


### PR DESCRIPTION
Currently, `txcontext.BlockEnvironment` returns nil when `GetRandom` even though it has access to `Random`.
This makes any replay block that make use of `Random` rather than `Difficulty` failed erroneously.

Before:
```
go run ./cmd/aida-vm --validate --chainid 1 --workers 1 --evm-impl aida-geth --vm-impl geth --aida-db ~/dev/data/protobuf/15.5-16M --substate-encoding pb 15537394 15537394

live-db-validator err:
world-state output error at block 15537394 tx 0;   Failed to validate balance for account 0x00000000000357848314F068fECA5D42e878a1d9
    have 5731278617347499170
    want 3718218632201979149
  Failed to validate storage for account 0x9ACf7474a5b54E99c1Ff2737919e3A2DFFE72253, key 0x000000000000000000000000000000000000000000000000000000000000000c
    have 0x0000000000000000000000000000000000000000000000000000000000000000
    want 0xa86c2e601b6c44eb4848f7d23d9df3113fbcac42041c49cbed5000cb4f118777
  Failed to validate balance for account 0xeEE27662c2B8EBa3CD936A23F039F3189633e4C8
    have 35102708387352264758
    want 37115534417566290944
```

After:
```
go run ./cmd/aida-vm --validate --chainid 1 --workers 1 --evm-impl aida-geth --vm-impl geth --aida-db ~/dev/data/protobuf/15.5-16M --substate-encoding pb 15537394 15537394

NOTICE: Total elapsed time: 0s; last block 15537394; total transaction rate ~738.05 Tx/s, ~276.61 MGas/s
```