### PR TITLE
[Refactor] Add "aida-geth" when reminding available evm-impl

### DIFF
--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -167,6 +167,7 @@ func MakeTxProcessor(cfg *utils.Config) (*TxProcessor, error) {
 		if evm == nil {
 			available := maps.Keys(tosca.GetAllRegisteredProcessorFactories())
 			available = append(available, "aida")
+			available = append(available, "aida-geth")
 			slices.Sort(available)
 			return nil, fmt.Errorf("unknown EVM implementation: %s, supported: %v", cfg.EvmImpl, available)
 		}


### PR DESCRIPTION
Currently, `aida-geth` is not part of the reminder text when the provided `--evm-impl` is not supported.

Before:
```
go run ./cmd/aida-vm --evm-impl unsupported ...

unknown EVM implementation: unsupported, supported: [aida floria geth opera]
```

After:
```
go run ./cmd/aida-vm --evm-impl unsupported ...

unknown EVM implementation: unsupported, supported: [aida aida-geth floria geth opera]
```

Fixes # (issue)
- [ ] Refactoring (changes that do NOT affect functionality)