### PR TITLE
adds support for EIP-3651 (warm coinbase) in Prepare method

### DIFF
--- a/state/carmen.go
+++ b/state/carmen.go
@@ -296,6 +296,9 @@ func (s *carmenStateDB) Prepare(rules params.Rules, sender, coinbase common.Addr
 			s.txCtx.AddSlotToAccessList(carmen.Address(el.Address), carmen.Key(key))
 		}
 	}
+	if rules.IsShanghai {
+		s.txCtx.AddAddressToAccessList(carmen.Address(coinbase))
+	}
 }
 
 func (s *carmenStateDB) AddressInAccessList(addr common.Address) bool {


### PR DESCRIPTION
This PR extends method Prepare with EIP-3651 - warm coinbase - functionality. 

This PR fixes ethereum-tests related to previously failing `access list`

