### PR TITLE
Restores memory footage report

### DIFF
--- a/cmd/aida-sdb/trace/replay.go
+++ b/cmd/aida-sdb/trace/replay.go
@@ -88,9 +88,9 @@ func (p operationProcessor) runTransaction(block uint64, operations []operation.
 func replay(cfg *utils.Config, provider executor.Provider[[]operation.Operation], processor executor.Processor[[]operation.Operation], extra []executor.Extension[[]operation.Operation], aidaDb db.BaseDB) error {
 	var extensionList = []executor.Extension[[]operation.Operation]{
 		profiler.MakeCpuProfiler[[]operation.Operation](cfg),
+		statedb.MakeStateDbManager[[]operation.Operation](cfg, ""),
 		profiler.MakeMemoryUsagePrinter[[]operation.Operation](cfg),
 		profiler.MakeMemoryProfiler[[]operation.Operation](cfg),
-		statedb.MakeStateDbManager[[]operation.Operation](cfg, ""),
 		logger.MakeProgressLogger[[]operation.Operation](cfg, 0),
 		primer.MakeStateDbPrimer[[]operation.Operation](cfg),
 	}

--- a/state/carmen.go
+++ b/state/carmen.go
@@ -438,12 +438,11 @@ func (s *carmenHeadState) GetArchiveBlockHeight() (uint64, bool, error) {
 }
 
 func (s *carmenStateDB) GetMemoryUsage() *MemoryUsage {
-	// todo waiting for implementation from carmen side
-	//usage := s.db.GetMemoryFootprint()
-	//if usage == nil {
-	//	return &MemoryUsage{uint64(0), nil}
-	//}
-	return &MemoryUsage{uint64(0), nil}
+	usage := s.db.GetMemoryFootprint()
+	if usage == nil {
+		return &MemoryUsage{uint64(0), nil}
+	}
+	return &MemoryUsage{uint64(usage.Total()), usage}
 }
 
 func (s *carmenStateDB) GetShadowDB() StateDB {

--- a/state/carmen.go
+++ b/state/carmen.go
@@ -438,6 +438,9 @@ func (s *carmenHeadState) GetArchiveBlockHeight() (uint64, bool, error) {
 }
 
 func (s *carmenStateDB) GetMemoryUsage() *MemoryUsage {
+	if s.db == nil {
+		return &MemoryUsage{uint64(0), nil}
+	}
 	usage := s.db.GetMemoryFootprint()
 	if usage == nil {
 		return &MemoryUsage{uint64(0), nil}


### PR DESCRIPTION
## Description

This PR restores memory logging.
- `--memory-breakdown` now shows memory usage in heap
- logger and tracker now log total memory usage

Fixes #1105 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)