### PR TITLE
Geth tests state root validation

### DIFF
--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -127,9 +127,9 @@ func runEth(
 		extensionList,
 		logger.MakeEthStateTestLogger(cfg, 0),
 		validator.MakeShadowDbValidator(cfg),
+		validator.MakeEthStateTestStateHashValidator(cfg),
 		statedb.MakeEthStateScopeTestEventEmitter(),
 		validator.MakeEthStateTestValidator(cfg),
-		validator.MakeEthStateTestStateHashValidator(cfg),
 	)
 
 	extensionList = append(extensionList, extra...)

--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -130,7 +130,6 @@ func runEth(
 		validator.MakeEthStateTestStateHashValidator(cfg),
 		statedb.MakeEthStateScopeTestEventEmitter(),
 		validator.MakeEthStateTestValidator(cfg),
-		statedb.MakeEthStateScopeTestEventEmitter(),
 	)
 
 	extensionList = append(extensionList, extra...)

--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -129,6 +129,7 @@ func runEth(
 		validator.MakeShadowDbValidator(cfg),
 		statedb.MakeEthStateScopeTestEventEmitter(),
 		validator.MakeEthStateTestValidator(cfg),
+		validator.MakeEthStateTestStateHashValidator(cfg),
 	)
 
 	extensionList = append(extensionList, extra...)

--- a/cmd/aida-vm-sdb/run_eth_test.go
+++ b/cmd/aida-vm-sdb/run_eth_test.go
@@ -217,6 +217,7 @@ func TestVmSdb_Eth_ValidationDoesNotFailOnValidTransaction(t *testing.T) {
 		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
 		db.EXPECT().EndTransaction(),
 		db.EXPECT().EndBlock(),
+		db.EXPECT().GetHash(),
 		// EndTransaction is not called because execution fails
 	)
 

--- a/ethtest/mock_data.go
+++ b/ethtest/mock_data.go
@@ -155,3 +155,8 @@ func CreateNoErrorTestTransaction(*testing.T) txcontext.TxContext {
 		expectedError: "",
 	}
 }
+func CreateTestTransactionWithHash(_ *testing.T, hash common.Hash) txcontext.TxContext {
+	return &stateTestContext{
+		rootHash: hash,
+	}
+}

--- a/executor/extension/validator/eth_state_test_state_hash_validator.go
+++ b/executor/extension/validator/eth_state_test_state_hash_validator.go
@@ -44,8 +44,6 @@ type ethStateTestStateHashValidator struct {
 }
 
 // PostBlock validates state root hash.
-// This needs to be done here instead of PostTransaction because EndBlock is being called in PostTransaction in
-// executor/extension/statedb/eth_state_test_scope_event_emitter.go, and it needs to be called before GetHash.
 func (e *ethStateTestStateHashValidator) PostBlock(state executor.State[txcontext.TxContext], ctx *executor.Context) error {
 	got, err := ctx.State.GetHash()
 	if err != nil {

--- a/executor/extension/validator/eth_state_test_state_hash_validator.go
+++ b/executor/extension/validator/eth_state_test_state_hash_validator.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Aida Testing Infrastructure for Sonic
+//
+// Aida is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Aida is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Aida. If not, see <http://www.gnu.org/licenses/>.
+
+package validator
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Aida/executor"
+	"github.com/Fantom-foundation/Aida/executor/extension"
+	"github.com/Fantom-foundation/Aida/txcontext"
+	"github.com/Fantom-foundation/Aida/utils"
+)
+
+func MakeEthStateTestStateHashValidator(cfg *utils.Config) executor.Extension[txcontext.TxContext] {
+	if !cfg.Validate {
+		return extension.NilExtension[txcontext.TxContext]{}
+	}
+	return makeEthStateTestStateHashValidator(cfg)
+}
+
+func makeEthStateTestStateHashValidator(cfg *utils.Config) executor.Extension[txcontext.TxContext] {
+	return &ethStateTestStateHashValidator{
+		cfg: cfg,
+	}
+}
+
+type ethStateTestStateHashValidator struct {
+	extension.NilExtension[txcontext.TxContext]
+	cfg *utils.Config
+}
+
+// PostBlock validates state root hash.
+// This needs to be done here instead of PostTransaction because EndBlock is being called in PostTransaction in
+// executor/extension/statedb/eth_state_test_scope_event_emitter.go, and it needs to be called before GetHash.
+func (e *ethStateTestStateHashValidator) PostBlock(state executor.State[txcontext.TxContext], ctx *executor.Context) error {
+	got, err := ctx.State.GetHash()
+	if err != nil {
+		return err
+	}
+	want := state.Data.GetStateHash()
+	if got != want {
+		err = fmt.Errorf("unexpected root hash, got: %s, want: %s", got, want)
+		if !e.cfg.ContinueOnFailure {
+			return err
+		}
+		ctx.ErrorInput <- err
+	}
+
+	return nil
+}

--- a/executor/extension/validator/eth_state_test_state_hash_validator_test.go
+++ b/executor/extension/validator/eth_state_test_state_hash_validator_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Aida Testing Infrastructure for Sonic
+//
+// Aida is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Aida is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Aida. If not, see <http://www.gnu.org/licenses/>.
+
 package validator
 
 import (
@@ -17,7 +33,7 @@ import (
 func TestEthStateTestValidator_PostBlockCheckStateRoot(t *testing.T) {
 	cfg := &utils.Config{}
 	cfg.ContinueOnFailure = false
-	ext := makeEthStateTestStateHashValidator(cfg, nil)
+	ext := makeEthStateTestStateHashValidator(cfg)
 
 	ctrl := gomock.NewController(t)
 	db := state.NewMockStateDB(ctrl)

--- a/executor/extension/validator/eth_state_test_state_hash_validator_test.go
+++ b/executor/extension/validator/eth_state_test_state_hash_validator_test.go
@@ -1,0 +1,60 @@
+package validator
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Fantom-foundation/Aida/ethtest"
+	"github.com/Fantom-foundation/Aida/executor"
+	"github.com/Fantom-foundation/Aida/state"
+	"github.com/Fantom-foundation/Aida/txcontext"
+	"github.com/Fantom-foundation/Aida/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"go.uber.org/mock/gomock"
+)
+
+func TestEthStateTestValidator_PostBlockCheckStateRoot(t *testing.T) {
+	cfg := &utils.Config{}
+	cfg.ContinueOnFailure = false
+	ext := makeEthStateTestStateHashValidator(cfg, nil)
+
+	ctrl := gomock.NewController(t)
+	db := state.NewMockStateDB(ctrl)
+
+	tests := []struct {
+		name          string
+		ctx           txcontext.TxContext
+		gotHash       common.Hash
+		expectedError error
+	}{
+		{
+			name:          "same_hashes",
+			ctx:           ethtest.CreateTestTransactionWithHash(t, common.Hash{1}),
+			gotHash:       common.Hash{1},
+			expectedError: nil,
+		},
+		{
+			name:          "different_hashes",
+			ctx:           ethtest.CreateTestTransactionWithHash(t, common.Hash{1}),
+			gotHash:       common.Hash{2},
+			expectedError: fmt.Errorf("unexpected root hash, got: %s, want: %s", common.Hash{2}, common.Hash{1}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db.EXPECT().GetHash().Return(test.gotHash, nil)
+			ctx := &executor.Context{State: db}
+			st := executor.State[txcontext.TxContext]{Block: 1, Transaction: 1, Data: test.ctx}
+
+			err := ext.PostBlock(st, ctx)
+			if err == nil && test.expectedError == nil {
+				return
+			}
+			if got, want := err, test.expectedError; !strings.EqualFold(got.Error(), want.Error()) {
+				t.Errorf("unexpected error, got: %v, want: %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR adds `state-root` validation to `geth-tests`
Must be merged after #1197 

- [ ] New feature (non-breaking change which adds functionality)
