### PR TITLE
Add exception for blobGas exceed.

### DIFF
--- a/ethtest/mock_data.go
+++ b/ethtest/mock_data.go
@@ -156,7 +156,7 @@ func CreateNoErrorTestTransaction(*testing.T) txcontext.TxContext {
 }
 
 func CreateTransactionThatFailsBlobGasExceedCheck(*testing.T) txcontext.TxContext {
-	return &stateTestContext{
+	return &StateTestContext{
 		msg: &core.Message{BlobHashes: []common.Hash{
 			// add many blob hashes to fail the check
 			{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},

--- a/ethtest/mock_data.go
+++ b/ethtest/mock_data.go
@@ -153,3 +153,12 @@ func CreateNoErrorTestTransaction(*testing.T) txcontext.TxContext {
 		expectedError: "",
 	}
 }
+
+func CreateTransactionThatFailsBlobGasExceedCheck(*testing.T) txcontext.TxContext {
+	return &stateTestContext{
+		msg: &core.Message{BlobHashes: []common.Hash{
+			// add many blob hashes to fail the check
+			{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+		}},
+	}
+}

--- a/ethtest/mock_data.go
+++ b/ethtest/mock_data.go
@@ -160,7 +160,7 @@ func CreateTransactionThatFailsBlobGasExceedCheck(*testing.T) txcontext.TxContex
 			// add many blob hashes to fail the check
 			{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
 		}},
-  }
+	}
 }
 
 func CreateTestTransactionWithHash(_ *testing.T, hash common.Hash) txcontext.TxContext {

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -123,9 +123,7 @@ func (p *ethTestProcessor) Process(state State[txcontext.TxContext], ctx *Contex
 	// This check needs to be done before ApplyMessage is called, otherwise different state-root hash is produced
 	msg := state.Data.GetMessage()
 	if len(msg.BlobHashes)*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
-		txHash := common.HexToHash(fmt.Sprintf("0x%016d%016d", state.Block, state.Transaction))
-		blockHash := common.HexToHash(fmt.Sprintf("0x%016d", state.Transaction))
-		ctx.ExecutionResult = newTransactionResult(ctx.State.GetLogs(txHash, uint64(state.Block), blockHash), msg, nil, errors.New("blob gas exceeds maximum"), msg.From)
+		ctx.ExecutionResult = newTransactionResult([]*types.Log{}, msg, nil, errors.New("blob gas exceeds maximum"), msg.From)
 		return nil
 	}
 

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -120,6 +120,10 @@ type ethTestProcessor struct {
 
 // Process transaction inside state into given LIVE StateDb
 func (p *ethTestProcessor) Process(state State[txcontext.TxContext], ctx *Context) error {
+	// This check needs to be done before ApplyMessage is called, otherwise different state-root hash is produced
+	if len(state.Data.GetMessage().BlobHashes)*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
+		return errors.New("blob gas exceeds maximum")
+	}
 	// We ignore error in this case, because some tests require the processor to fail,
 	// ethStateTestValidator decides whether error is fatal.
 	ctx.ExecutionResult, _ = p.ProcessTransaction(ctx.State, state.Block, state.Transaction, state.Data)

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -121,9 +121,14 @@ type ethTestProcessor struct {
 // Process transaction inside state into given LIVE StateDb
 func (p *ethTestProcessor) Process(state State[txcontext.TxContext], ctx *Context) error {
 	// This check needs to be done before ApplyMessage is called, otherwise different state-root hash is produced
-	if len(state.Data.GetMessage().BlobHashes)*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
-		return errors.New("blob gas exceeds maximum")
+	msg := state.Data.GetMessage()
+	if len(msg.BlobHashes)*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
+		txHash := common.HexToHash(fmt.Sprintf("0x%016d%016d", state.Block, state.Transaction))
+		blockHash := common.HexToHash(fmt.Sprintf("0x%016d", state.Transaction))
+		ctx.ExecutionResult = newTransactionResult(ctx.State.GetLogs(txHash, uint64(state.Block), blockHash), msg, nil, errors.New("blob gas exceeds maximum"), msg.From)
+		return nil
 	}
+
 	// We ignore error in this case, because some tests require the processor to fail,
 	// ethStateTestValidator decides whether error is fatal.
 	ctx.ExecutionResult, _ = p.ProcessTransaction(ctx.State, state.Block, state.Transaction, state.Data)

--- a/executor/transaction_processor_test.go
+++ b/executor/transaction_processor_test.go
@@ -18,10 +18,7 @@ package executor
 
 import (
 	"fmt"
-	"github.com/Fantom-foundation/Aida/ethtest"
-	"github.com/Fantom-foundation/Aida/state"
-	"github.com/Fantom-foundation/Aida/txcontext"
-	"go.uber.org/mock/gomock"
+
 	"math/big"
 	"strings"
 	"testing"

--- a/executor/transaction_processor_test.go
+++ b/executor/transaction_processor_test.go
@@ -140,9 +140,8 @@ func TestEthTestProcessor_DoesNotExecuteTransactionWhenBlobGasCouldExceed(t *tes
 		t.Fatalf("cannot make eth test processor: %v", err)
 	}
 	ctrl := gomock.NewController(t)
-	// Process is returned early - only get logs is expected
+	// Process is returned early - nothing is expected
 	stateDb := state.NewMockStateDB(ctrl)
-	stateDb.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any())
 
 	ctx := &Context{State: stateDb}
 	err = p.Process(State[txcontext.TxContext]{Data: ethtest.CreateTransactionThatFailsBlobGasExceedCheck(t)}, ctx)


### PR DESCRIPTION
## Description

This PR adds exception to `geth-tests` which causes `tx-processing` to fail early.
According to the implementation in [geth](https://github.com/ethereum/go-ethereum/blob/65e5ca7d8126f7a8c708f8affb64f16c22cc63c0/tests/state_test_util.go#L256) this must be done here.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
