### PR TITLE
Add exception for invalid transaction bytes.

### DIFF
--- a/ethtest/mock_data.go
+++ b/ethtest/mock_data.go
@@ -41,7 +41,7 @@ func CreateTestTransaction(t *testing.T) txcontext.TxContext {
 		t.Fatalf("cannot get chain config: %v", err)
 	}
 	to := common.HexToAddress("0x10")
-	return &stateTestContext{
+	return &StateTestContext{
 		env: &stBlockEnvironment{
 			Coinbase:   common.Address{},
 			Difficulty: newBigInt(1),
@@ -143,18 +143,18 @@ func CreateTestStJson(*testing.T) *stJSON {
 }
 
 func CreateErrorTestTransaction(*testing.T) txcontext.TxContext {
-	return &stateTestContext{
+	return &StateTestContext{
 		expectedError: "err",
 	}
 }
 
 func CreateNoErrorTestTransaction(*testing.T) txcontext.TxContext {
-	return &stateTestContext{
+	return &StateTestContext{
 		expectedError: "",
 	}
 }
 func CreateTestTransactionWithHash(_ *testing.T, hash common.Hash) txcontext.TxContext {
-	return &stateTestContext{
+	return &StateTestContext{
 		rootHash: hash,
 	}
 }

--- a/ethtest/mock_data.go
+++ b/ethtest/mock_data.go
@@ -18,6 +18,7 @@ package ethtest
 
 import (
 	"encoding/hex"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"testing"
 
@@ -156,5 +157,29 @@ func CreateNoErrorTestTransaction(*testing.T) txcontext.TxContext {
 func CreateTestTransactionWithHash(_ *testing.T, hash common.Hash) txcontext.TxContext {
 	return &StateTestContext{
 		rootHash: hash,
+	}
+}
+
+func CreateTransactionWithInvalidTxBytes(t *testing.T) txcontext.TxContext {
+	// specific tx bytes that fail the unmarshalling
+	txBytes, err := hexutil.Decode("0x03f8d601800285012a05f200833d090080830186a000f85bf85994095e7baea6a6c7c4c2dfeb977efac326af552d87f842a00000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000010ae1a001a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d880a0fc12b67159a3567f8bdbc49e0be369a2e20e09d57a51c41310543a4128409464a02de0cfe5495c4f58ff60645ceda0afd67a4c90a70bc89fe207269435b35e5b67")
+	if err != nil {
+		t.Fatalf("cannot decode tx bytes: %v", err)
+	}
+	return &StateTestContext{
+		txBytes: txBytes,
+		msg:     &core.Message{},
+	}
+}
+func CreateTransactionThatFailsSenderValidation(t *testing.T) txcontext.TxContext {
+	// specific tx bytes that fail the validation
+	txBytes, err := hexutil.Decode("0x03f864018080078252089400000000000000000000000000000000000001000180c001c080a0de3ecf0321e2d26c34d6b9bd1ffb5a30167abafd5ecacd477049544c23d402cda06c56b464881a4af7bb8216d47c6c5e3286395027af44044b3d7d31a2d24901f2")
+	if err != nil {
+		t.Fatalf("cannot decode tx bytes: %v", err)
+	}
+	return &StateTestContext{
+		txBytes: txBytes,
+		msg:     &core.Message{},
+		env:     &stBlockEnvironment{fork: "Shanghai"}, // FORK MUST BE Shanghai
 	}
 }

--- a/ethtest/state_test_context.go
+++ b/ethtest/state_test_context.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/Fantom-foundation/Aida/txcontext"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
 
 func newStateTestTxContext(stJson *stJSON, msg *core.Message, post stPost, chainCfg *params.ChainConfig, fork string, postNumber int) txcontext.TxContext {
-	return &stateTestContext{
+	return &StateTestContext{
 		fork:          fork,
 		path:          stJson.path,
 		postNumber:    postNumber,
@@ -37,10 +38,11 @@ func newStateTestTxContext(stJson *stJSON, msg *core.Message, post stPost, chain
 		msg:           msg,
 		rootHash:      post.RootHash,
 		expectedError: post.ExpectException,
+		txBytes:       post.TxBytes,
 	}
 }
 
-type stateTestContext struct {
+type StateTestContext struct {
 	txcontext.NilTxContext
 	fork          string // which fork is the test running
 	path          string // path to file from which is the test
@@ -51,33 +53,38 @@ type stateTestContext struct {
 	msg           *core.Message
 	rootHash      common.Hash
 	expectedError string
+	txBytes       hexutil.Bytes
 }
 
-func (s *stateTestContext) GetStateHash() common.Hash {
+func (s *StateTestContext) GetTxBytes() hexutil.Bytes {
+	return s.txBytes
+}
+
+func (s *StateTestContext) GetStateHash() common.Hash {
 	return s.rootHash
 }
 
-func (s *stateTestContext) GetOutputState() txcontext.WorldState {
+func (s *StateTestContext) GetOutputState() txcontext.WorldState {
 	// we dont execute pseudo transactions here
 	return nil
 }
 
-func (s *stateTestContext) GetInputState() txcontext.WorldState {
+func (s *StateTestContext) GetInputState() txcontext.WorldState {
 	return NewWorldState(s.inputState)
 }
 
-func (s *stateTestContext) GetBlockEnvironment() txcontext.BlockEnvironment {
+func (s *StateTestContext) GetBlockEnvironment() txcontext.BlockEnvironment {
 	return s.env
 }
 
-func (s *stateTestContext) GetMessage() *core.Message {
+func (s *StateTestContext) GetMessage() *core.Message {
 	return s.msg
 }
 
-func (s *stateTestContext) GetResult() txcontext.Result {
+func (s *StateTestContext) GetResult() txcontext.Result {
 	return stateTestResult{s.expectedError}
 }
 
-func (s *stateTestContext) String() string {
+func (s *StateTestContext) String() string {
 	return fmt.Sprintf("Test path: %v\nDescription: %v\nFork: %v\nPost number: %v", s.path, s.description, s.fork, s.postNumber)
 }

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -19,6 +19,7 @@ package executor
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"slices"
 	"strings"
@@ -131,7 +132,7 @@ func (p *ethTestProcessor) Process(state State[txcontext.TxContext], ctx *Contex
 		var ttx types.Transaction
 		err := ttx.UnmarshalBinary(txBytes)
 		if err != nil {
-			ctx.ExecutionResult = newTransactionResult(ctx.State.GetLogs(txHash, uint64(state.Block), blockHash), msg, nil, errors.New("blob gas exceeds maximum"), msg.From)
+			ctx.ExecutionResult = newTransactionResult(ctx.State.GetLogs(txHash, uint64(state.Block), blockHash), msg, nil, fmt.Errorf("cannot unmarshal tx-bytes: %w", err), msg.From)
 			return nil
 		}
 
@@ -140,7 +141,8 @@ func (p *ethTestProcessor) Process(state State[txcontext.TxContext], ctx *Contex
 			return err
 		}
 		if _, err = types.Sender(types.LatestSigner(chainCfg), &ttx); err != nil {
-			ctx.ExecutionResult = newTransactionResult(ctx.State.GetLogs(txHash, uint64(state.Block), blockHash), msg, nil, errors.New("blob gas exceeds maximum"), msg.From)
+			fmt.Printf("%s\n", hexutil.Encode(txBytes))
+			ctx.ExecutionResult = newTransactionResult(ctx.State.GetLogs(txHash, uint64(state.Block), blockHash), msg, nil, fmt.Errorf("cannot validate sender: %w", err), msg.From)
 			return nil
 		}
 	}

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/Fantom-foundation/Aida/ethtest"
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/params"
@@ -120,6 +121,30 @@ type ethTestProcessor struct {
 
 // Process transaction inside state into given LIVE StateDb
 func (p *ethTestProcessor) Process(state State[txcontext.TxContext], ctx *Context) error {
+	// This check needs to be done before ApplyMessage is called, otherwise different state-root hash is produced
+	msg := state.Data.GetMessage()
+	txHash := common.HexToHash(fmt.Sprintf("0x%016d%016d", state.Block, state.Transaction))
+	blockHash := common.HexToHash(fmt.Sprintf("0x%016d", state.Transaction))
+	txBytes := state.Data.(*ethtest.StateTestContext).GetTxBytes()
+
+	if len(txBytes) != 0 {
+		var ttx types.Transaction
+		err := ttx.UnmarshalBinary(txBytes)
+		if err != nil {
+			ctx.ExecutionResult = newTransactionResult(ctx.State.GetLogs(txHash, uint64(state.Block), blockHash), msg, nil, errors.New("blob gas exceeds maximum"), msg.From)
+			return nil
+		}
+
+		chainCfg, err := p.cfg.GetChainConfig(state.Data.GetBlockEnvironment().GetFork())
+		if err != nil {
+			return err
+		}
+		if _, err = types.Sender(types.LatestSigner(chainCfg), &ttx); err != nil {
+			ctx.ExecutionResult = newTransactionResult(ctx.State.GetLogs(txHash, uint64(state.Block), blockHash), msg, nil, errors.New("blob gas exceeds maximum"), msg.From)
+			return nil
+		}
+	}
+
 	// We ignore error in this case, because some tests require the processor to fail,
 	// ethStateTestValidator decides whether error is fatal.
 	ctx.ExecutionResult, _ = p.ProcessTransaction(ctx.State, state.Block, state.Transaction, state.Data)

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -121,7 +121,10 @@ type ethTestProcessor struct {
 
 // Process transaction inside state into given LIVE StateDb
 func (p *ethTestProcessor) Process(state State[txcontext.TxContext], ctx *Context) error {
-	// This check needs to be done before ApplyMessage is called, otherwise different state-root hash is produced
+	// This check needs to be done before ApplyMessage is called to identify invalid transactions. Invalid
+	// transactions are expected to be filtered out before running them (via ApplyMessage). If they
+	// got processed, they would at least update the nonce of the transaction sender, thereby influencing
+	// the resulting state hash. This would be detected as a failed test case.
 	msg := state.Data.GetMessage()
 	txBytes := state.Data.(*ethtest.StateTestContext).GetTxBytes()
 

--- a/executor/transaction_processor_test.go
+++ b/executor/transaction_processor_test.go
@@ -158,9 +158,8 @@ func TestEthTestProcessor_DoesNotExecuteTransactionWithInvalidTxBytes(t *testing
 				t.Fatalf("cannot make eth test processor: %v", err)
 			}
 			ctrl := gomock.NewController(t)
-			// Process is returned early - only get logs is expected
+			// Process is returned early - no calls are expected
 			stateDb := state.NewMockStateDB(ctrl)
-			stateDb.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any())
 
 			ctx := &Context{State: stateDb}
 			err = p.Process(State[txcontext.TxContext]{Data: test.data}, ctx)


### PR DESCRIPTION
## Description

This PR adds exception when `transaction-hash` incorrect.
According to [this](https://github.com/ethereum/go-ethereum/blob/65e5ca7d8126f7a8c708f8affb64f16c22cc63c0/tests/state_test_util.go#L268) code - this exception should not even allow the transaction being processed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
