### PR TITLE
Use correct variable.

### DIFF
--- a/ethtest/open.go
+++ b/ethtest/open.go
@@ -78,7 +78,7 @@ func getTestsWithinPath[T ethTest](cfg *utils.Config, testType utils.EthTestType
 		return nil, errors.New("please chose which testType do you want to read")
 	}
 
-	filePaths, err := utils.GetFilesWithinDirectories(".json", []string{path})
+	filePaths, err := utils.GetFilesWithinDirectories(".json", dirPaths)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read files within directory %v; %v", path, err)
 	}


### PR DESCRIPTION
## Description

This PR fixes incorrect variable passage.
Wrong path was passed, this caused that only path to runnable tests was usable - this is fixed and path to the root of `geth-test` repo can be now used instead and the app will find the runnable files itself.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

