### PR TITLE
Fix geth-tests deadlock

### DIFF
--- a/executor/extension/validator/eth_state_test_log_hash_validator.go
+++ b/executor/extension/validator/eth_state_test_log_hash_validator.go
@@ -47,12 +47,12 @@ func (e *ethStateTestLogHashValidator) PostBlock(state executor.State[txcontext.
 	var err error
 	if got, want := utils.RlpHash(ctx.ExecutionResult.GetReceipt().GetLogs()), state.Data.GetLogsHash(); got != want {
 		err = fmt.Errorf("unexpected logs hash, got %x, want %x", got, want)
+		if !e.cfg.ContinueOnFailure {
+			return err
+		}
+
+		ctx.ErrorInput <- err
 	}
 
-	if !e.cfg.ContinueOnFailure {
-		return err
-	}
-
-	ctx.ErrorInput <- err
 	return nil
 }


### PR DESCRIPTION
## Description

This PR fixes deadlock in `geth-tests`.
This deadlock was caused due to `ErrorInput` being filled with `nil`. 
As written on [this](https://github.com/Fantom-foundation/Aida/blob/78ef049f12b3562beb5b65a86c3b9861ea42e2b4/executor/extension/logger/error_logger.go#L97) line, `ErrorLogger` does not count with `nil` as nil is sent to the chanel it is closed which is a signal for the extension to close its reading routine. This then caused that error logger stopped its the routine hence no one was reading from the chanel hence clogging the chanel hence causing deadlock.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
