### PR TITLE
refactor fork flag and tx-generator cmd uses fork flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                 stage('Check formatting') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
-                            sh '''diff=`find . \\( -path ./carmen -o -path ./tosca \\) -prune -o -name '*.go' -exec gofmt -s -l {} \\;`
+                            sh '''diff=`find . \\( -path ./carmen -o -path ./tosca -o -path ./sonic \\) -prune -o -name '*.go' -exec gofmt -s -l {} \\;`
                                   echo $diff
                                   test -z $diff
                                '''
@@ -57,7 +57,7 @@ pipeline {
                             currentBuild.description = "Building on ${env.NODE_NAME}"
                         }
                         sh "git submodule update --init --recursive"
-                        sh "make all"
+                        sh "make all -j 4"
                     }
                 }
 
@@ -148,8 +148,8 @@ pipeline {
                     steps {
                         dir('eth-test-package') {
                             checkout scmGit(
-                                userRemoteConfigs: [[url: 'https://github.com/ethereum/tests.git']]
-                                branches: [[name: 'develop']],
+                                userRemoteConfigs: [[url: 'https://github.com/ethereum/tests.git']],
+                                branches: [[name: 'develop']]
                             )
                         }
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {

--- a/cmd/aida-vm-sdb/main.go
+++ b/cmd/aida-vm-sdb/main.go
@@ -174,6 +174,7 @@ var RunTxGeneratorCmd = cli.Command{
 		&utils.NoHeartbeatLoggingFlag,
 		&utils.BlockLengthFlag,
 		&utils.TrackerGranularityFlag,
+		&utils.ForkFlag,
 	},
 	Description: `
 The aida-vm-sdb tx-generator command requires two arguments: <blockNumFirst> <blockNumLast>

--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -74,7 +74,7 @@ var RunEthTestsCmd = cli.Command{
 
 		// Ethereum execution tests
 		&utils.EthTestTypeFlag,
-		&utils.ForksFlag,
+		&utils.ForkFlag,
 	},
 	Description: `
 The aida-vm-sdb geth-state-tests command requires one argument: <pathToJsonTest or pathToDirWithJsonTests>`,

--- a/cmd/aida-vm-sdb/run_tx_generator.go
+++ b/cmd/aida-vm-sdb/run_tx_generator.go
@@ -40,12 +40,13 @@ const (
 
 // RunTxGenerator performs sequential block processing on a StateDb using transaction generator
 func RunTxGenerator(ctx *cli.Context) error {
-	cfg, err := utils.NewConfig(ctx, utils.BlockRangeArgs)
+	cfg, err := utils.NewConfig(ctx, utils.LastBlockArg)
 	if err != nil {
 		return err
 	}
 
 	cfg.StateValidationMode = utils.SubsetCheck
+	cfg.ChainID = utils.EthTestsChainID // Use EthTests chain ID for configurable forks
 
 	db, dbPath, err := utils.PrepareStateDB(cfg)
 	if err != nil {

--- a/cmd/aida-vm-sdb/run_tx_generator_test.go
+++ b/cmd/aida-vm-sdb/run_tx_generator_test.go
@@ -108,7 +108,7 @@ func TestVmSdb_TxGenerator_AllTransactionsAreProcessedInOrder(t *testing.T) {
 	}
 }
 
-func newTestTxCtx(t *testing.T, blkNumber uint64) txcontext.TxContext {
+func newTestTxCtx(_ *testing.T, blkNumber uint64) txcontext.TxContext {
 	return txgenerator.NewTxContext(
 		testTxBlkEnv{blkNumber},
 		&core.Message{

--- a/ethtest/test_case_splitter.go
+++ b/ethtest/test_case_splitter.go
@@ -3,7 +3,6 @@ package ethtest
 import (
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/Fantom-foundation/Aida/logger"
 	"github.com/Fantom-foundation/Aida/txcontext"
@@ -43,24 +42,20 @@ func NewTestCaseSplitter(cfg *utils.Config) (*TestCaseSplitter, error) {
 	log := logger.NewLogger(cfg.LogLevel, "eth-test-decoder")
 
 	return &TestCaseSplitter{
-		enabledForks: sortForks(log, cfg.Forks),
+		enabledForks: sortForks(log, cfg.Fork),
 		log:          log,
 		jsons:        tests,
 		chainConfigs: make(map[string]*params.ChainConfig),
 	}, nil
 }
 
-func sortForks(log logger.Logger, cfgForks []string) (forks []string) {
-	if len(cfgForks) == 1 && strings.ToLower(cfgForks[0]) == "all" {
+func sortForks(log logger.Logger, fork string) (forks []string) {
+	if fork == "all" {
 		forks = maps.Keys(usableForks)
 	} else {
-		for _, fork := range cfgForks {
-			fork = strings.Replace(strings.ToLower(fork), "glacier", "Glacier", -1)
-			fork = strings.Title(fork)
-			if _, ok := usableForks[fork]; !ok {
-				log.Warningf("Unknown name fork name %v, removing", fork)
-				continue
-			}
+		if _, ok := usableForks[fork]; !ok {
+			log.Warningf("Unknown name fork name %v, removing", fork)
+		} else {
 			forks = append(forks, fork)
 		}
 	}

--- a/ethtest/test_case_splitter_test.go
+++ b/ethtest/test_case_splitter_test.go
@@ -61,10 +61,10 @@ func TestTestCaseSplitter_NewTestCaseSplitter_SortsForks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	log := logger.NewMockLogger(ctrl)
 
-	log.EXPECT().Warningf("Unknown name fork name %v, removing", "Toberemoved")
+	log.EXPECT().Warningf("Unknown name fork name %v, removing", "toBeRemoved")
 
-	got := sortForks(log, []string{"CaNcuN", "london", "toBeRemoved"})
-	want := []string{"Cancun", "London"}
+	got := sortForks(log, "toBeRemoved")
+	want := []string{}
 	if !slices.Equal(got, want) {
 		t.Fatalf("unexpected forks, got: %v\nwant: %v", got, want)
 	}
@@ -74,7 +74,7 @@ func TestTestCaseSplitter_NewTestCaseSplitter_AllAddsAllForks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	log := logger.NewMockLogger(ctrl)
 
-	got := sortForks(log, []string{"all"})
+	got := sortForks(log, "all")
 	want := maps.Keys(usableForks)
 	// Maps are unordered...
 	slices.Sort(got)
@@ -88,10 +88,8 @@ func TestTestCaseSplitter_NewTestCaseSplitter_GlaciersAreCapitalized(t *testing.
 	ctrl := gomock.NewController(t)
 	log := logger.NewMockLogger(ctrl)
 
-	log.EXPECT().Warningf("Unknown name fork name %v, removing", "SomeGlacier")
-
-	got := sortForks(log, []string{"muirGlacier", "arrowglacier", "someglaCier"})
-	want := []string{"MuirGlacier", "ArrowGlacier"}
+	got := sortForks(log, "MuirGlacier")
+	want := []string{"MuirGlacier"}
 	// Maps are unordered...
 	slices.Sort(got)
 	slices.Sort(want)

--- a/executor/eth_test_provider_test.go
+++ b/executor/eth_test_provider_test.go
@@ -32,7 +32,7 @@ func Test_ethTestProvider_Run(t *testing.T) {
 
 	cfg := &utils.Config{
 		ArgPath: pathFile,
-		Forks:   []string{"all"},
+		Fork:    "all",
 	}
 
 	provider := NewEthStateTestProvider(cfg)

--- a/executor/norma_tx_provider.go
+++ b/executor/norma_tx_provider.go
@@ -74,7 +74,7 @@ func (p normaTxProvider) Run(from int, to int, consumer Consumer[txcontext.TxCon
 	// define norma consumer that will be used to consume transactions
 	// this is the only place that is responsible for incrementing block and tx numbers
 	nc := func(tx *types.Transaction, sender *common.Address) error {
-		data, err := txgenerator.NewNormaTxContext(tx, uint64(currentBlock), sender)
+		data, err := txgenerator.NewNormaTxContext(tx, uint64(currentBlock), sender, p.cfg.Fork)
 		if err != nil {
 			return err
 		}

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -19,11 +19,12 @@ package executor
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/params"
 	"math/big"
 	"slices"
 	"strings"
 	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/Fantom-foundation/Aida/ethtest"
 	"github.com/ethereum/go-ethereum/core"

--- a/txcontext/txgenerator/norma.go
+++ b/txcontext/txgenerator/norma.go
@@ -28,7 +28,7 @@ import (
 
 // NewNormaTxContext creates a new transaction context for a norma transaction.
 // It expects a signed transaction if sender is nil.
-func NewNormaTxContext(tx *types.Transaction, blkNumber uint64, sender *common.Address) (txcontext.TxContext, error) {
+func NewNormaTxContext(tx *types.Transaction, blkNumber uint64, sender *common.Address, fork string) (txcontext.TxContext, error) {
 	s := common.Address{}
 	if sender == nil {
 		addr, err := types.Sender(types.NewEIP155Signer(tx.ChainId()), tx)
@@ -43,6 +43,7 @@ func NewNormaTxContext(tx *types.Transaction, blkNumber uint64, sender *common.A
 		txData: txData{
 			Env: normaTxBlockEnv{
 				blkNumber: blkNumber,
+				fork:      fork,
 			},
 			Message: &core.Message{
 				To:                tx.To(),
@@ -71,6 +72,7 @@ type normaTxData struct {
 // normaTxBlockEnv is a block environment for norma transactions.
 type normaTxBlockEnv struct {
 	blkNumber uint64
+	fork      string
 }
 
 // GetRandom is not used in Norma Tx-Generator.
@@ -123,6 +125,5 @@ func (e normaTxBlockEnv) GetBaseFee() *big.Int {
 }
 
 func (e normaTxBlockEnv) GetFork() string {
-	// for now, only necessary for get-tests
-	return ""
+	return e.fork
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -153,50 +153,53 @@ var GitCommit = "0000000000000000000000000000000000000000"
 
 // Config represents execution configuration for Aida tools.
 type Config struct {
+	// command
 	AppName     string
 	CommandName string
 
+	// block range
 	First uint64 // first block
 	Last  uint64 // last block
 
-	AidaDb                   string  // directory to profiling database containing substate, update, delete accounts data
-	ArchiveMaxQueryAge       int     // the maximum age for archive queries (in blocks)
-	ArchiveMode              bool    // enable archive mode
-	ArchiveQueryRate         int     // the queries per second send to the archive
-	ArchiveVariant           string  // selects the implementation variant of the archive
-	ArgPath                  string  // path to file or directory given as argument
-	BalanceRange             int64   // balance range for stochastic simulation/replay
-	BasicBlockProfiling      bool    // enable profiling of basic block
-	BlockLength              uint64  // length of a block in number of transactions
-	CPUProfile               string  // pprof cpu profile output file name
-	CPUProfilePerInterval    bool    // a different CPU profile is taken per 100k block interval
-	Cache                    int     // Cache for StateDb or Priming
-	CarmenCheckpointInterval int     // how often (in blocks) will Carmen create checkpoints
-	CarmenCheckpointPeriod   int     // how often (in minutes) will Carmen create checkpoints
-	CarmenSchema             int     // the current DB schema ID to use in Carmen
-	CarmenStateCacheSize     int     // the number of values cached in the Carmen StateDB (0 for default value)
-	CarmenNodeCacheSize      int     // the size of the in-memory cache to be used by a Carmen LiveDB in byte (0 for default value)
-	ChainID                  ChainID // Blockchain ID (mainnet: 250/testnet: 4002)
-	chainCfg                 *params.ChainConfig
-	ChannelBufferSize        int    // set a buffer size for profiling channel
-	CompactDb                bool   // compact database after merging
-	ContinueOnFailure        bool   // continue validation when an error detected
-	ContractNumber           int64  // number of contracts to create
-	CustomDbName             string // name of state-db directory
-	DbComponent              string // options for util-db info are 'all', 'substate', 'delete', 'update', 'state-hash'
-	DbImpl                   string // storage implementation
-	DbLogging                string // set to true if all DB operations should be logged
-	DbTmp                    string // path to temporary database
-	DbVariant                string // database variant
-	Debug                    bool   // enable trace debug flag
-	DebugFrom                uint64 // the first block to print trace debug
-	DeleteSourceDbs          bool   // delete source databases
-	DeletionDb               string // directory of deleted account database
-	DiagnosticServer         int64  // if not zero, the port used for hosting a HTTP server for performance diagnostics
-	ErrorLogging             string // if defined, error logging to file is enabled
-	EvmImpl                  string
-	Genesis                  string         // genesis file
+	// global configs
+	AidaDb                   string         // directory to profiling database containing substate, update, delete accounts data
+	ArchiveMaxQueryAge       int            // the maximum age for archive queries (in blocks)
+	ArchiveMode              bool           // enable archive mode
+	ArchiveQueryRate         int            // the queries per second send to the archive
+	ArchiveVariant           string         // selects the implementation variant of the archive
+	ArgPath                  string         // path to file or directory given as argument
+	BalanceRange             int64          // balance range for stochastic simulation/replay
+	BasicBlockProfiling      bool           // enable profiling of basic block
+	BlockLength              uint64         // length of a block in number of transactions
+	CPUProfile               string         // pprof cpu profile output file name
+	CPUProfilePerInterval    bool           // a different CPU profile is taken per 100k block interval
+	Cache                    int            // Cache for StateDb or Priming
+	CarmenCheckpointInterval int            // how often (in blocks) will Carmen create checkpoints
+	CarmenCheckpointPeriod   int            // how often (in minutes) will Carmen create checkpoints
+	CarmenNodeCacheSize      int            // the size of the in-memory cache to be used by a Carmen LiveDB in byte (0 for default value)
+	CarmenSchema             int            // the current DB schema ID to use in Carmen
+	CarmenStateCacheSize     int            // the number of values cached in the Carmen StateDB (0 for default value)
+	ChainID                  ChainID        // Blockchain ID (mainnet: 250/testnet: 4002)
+	ChannelBufferSize        int            // set a buffer size for profiling channel
+	CompactDb                bool           // compact database after merging
+	ContinueOnFailure        bool           // continue validation when an error detected
+	ContractNumber           int64          // number of contracts to create
+	CustomDbName             string         // name of state-db directory
+	DbComponent              string         // options for util-db info are 'all', 'substate', 'delete', 'update', 'state-hash'
+	DbImpl                   string         // storage implementation
+	DbLogging                string         // set to true if all DB operations should be logged
+	DbTmp                    string         // path to temporary database
+	DbVariant                string         // database variant
+	Debug                    bool           // enable trace debug flag
+	DebugFrom                uint64         // the first block to print trace debug
+	DeleteSourceDbs          bool           // delete source databases
+	DeletionDb               string         // directory of deleted account database
+	DiagnosticServer         int64          // if not zero, the port used for hosting a HTTP server for performance diagnostics
+	ErrorLogging             string         // if defined, error logging to file is enabled
 	EthTestType              EthTestType    // which geth test are we running
+	EvmImpl                  string         // processor implementation
+	Fork                     string         // Which forks are going to get executed byz
+	Genesis                  string         // genesis file
 	IncludeStorage           bool           // represents a flag for contract storage inclusion in an operation
 	IsExistingStateDb        bool           // this is true if we are using an existing StateDb
 	KeepDb                   bool           // set to true if db is kept after run
@@ -251,6 +254,7 @@ type Config struct {
 	TrackProgress            bool           // enables track progress logging
 	TrackerGranularity       int            // defines how often will tracker report achieved block
 	TransactionLength        uint64         // determines indirectly the length of a transaction
+	TxGeneratorType          []string       // type of the application used for transaction generation
 	UpdateBufferSize         uint64         // cache size in Bytes
 	UpdateDb                 string         // update-set directory
 	UpdateOnFailure          bool           // if enabled and continue-on-failure is also enabled, this updates any error found in StateDb
@@ -261,12 +265,11 @@ type Config struct {
 	ValuesNumber             int64          // number of values to generate
 	VmImpl                   string         // vm implementation (geth/lfvm)
 	Workers                  int            // number of worker threads
-	TxGeneratorType          []string       // type of the application used for transaction generation
-	Forks                    []string       // Which forks are going to get executed byz
 
 	// -- cached results --
-
+	chainCfg           *params.ChainConfig   // cached chain configuration
 	interpreterFactory vm.InterpreterFactory // cached interpreter factory to facilitate reuse in interpreter instances
+
 }
 
 type configContext struct {

--- a/utils/default_config.go
+++ b/utils/default_config.go
@@ -17,6 +17,8 @@
 package utils
 
 import (
+	"strings"
+
 	"github.com/Fantom-foundation/Aida/cmd/util-db/flags"
 	"github.com/Fantom-foundation/Aida/logger"
 	"github.com/urfave/cli/v2"
@@ -60,7 +62,7 @@ func createConfigFromFlags(ctx *cli.Context) *Config {
 		DiagnosticServer:         getFlagValue(ctx, DiagnosticServerFlag).(int64),
 		ErrorLogging:             getFlagValue(ctx, ErrorLoggingFlag).(string),
 		EvmImpl:                  getFlagValue(ctx, EvmImplementation).(string),
-		Forks:                    getFlagValue(ctx, ForksFlag).([]string),
+		Fork:                     getFlagValue(ctx, ForkFlag).(string),
 		Genesis:                  getFlagValue(ctx, GenesisFlag).(string),
 		EthTestType:              EthTestType(getFlagValue(ctx, EthTestTypeFlag).(int)),
 		IncludeStorage:           getFlagValue(ctx, IncludeStorageFlag).(bool),
@@ -107,7 +109,6 @@ func createConfigFromFlags(ctx *cli.Context) *Config {
 		StateValidationMode: SubsetCheck,
 		SubstateDb:          getFlagValue(ctx, AidaDbFlag).(string),
 		SubstateEncoding:    getFlagValue(ctx, SubstateEncodingFlag).(string),
-
 		SyncPeriodLength:    getFlagValue(ctx, SyncPeriodLengthFlag).(uint64),
 		TargetDb:            getFlagValue(ctx, TargetDbFlag).(string),
 		TargetEpoch:         getFlagValue(ctx, TargetEpochFlag).(uint64),
@@ -156,7 +157,12 @@ func getFlagValue(ctx *cli.Context, flag interface{}) interface{} {
 			}
 
 		case cli.StringFlag:
-			if cmdFlag.Names()[0] == f.Name {
+			if cmdFlag.Names()[0] == ForkFlag.Name {
+				fork := ctx.String(f.Name)
+				fork = strings.Replace(strings.ToLower(fork), "glacier", "Glacier", -1)
+				fork = strings.Title(fork)
+				return fork
+			} else if cmdFlag.Names()[0] == f.Name {
 				return ctx.String(f.Name)
 			}
 

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -431,10 +431,10 @@ var (
 		Name:  "err-logging",
 		Usage: "defines path to error-log-file where any PROCESSING error is recorded",
 	}
-	ForksFlag = cli.StringSliceFlag{
-		Name:  "forks",
-		Usage: "defines which forks are going to get executed by the eth-tests (\"all\" | <\"cancun\", \"shanghai\", \"paris\", \"bellatrix\", \"grayglacier\", \"arrowglacier\", \"altair\", \"london\", \"berlin\", \"istanbul\", \"muirglacier\">)",
-		Value: cli.NewStringSlice("all"),
+	ForkFlag = cli.StringFlag{
+		Name:  "fork",
+		Usage: "defines a fork to get executed by the eth-tests (\"all\", \"cancun\", \"shanghai\", \"paris\", \"bellatrix\", \"grayglacier\", \"arrowglacier\", \"altair\", \"london\", \"berlin\", \"istanbul\", \"muirglacier\")",
+		Value: "all",
 	}
 	DbComponentFlag = cli.StringFlag{
 		Name:     "db-component",

--- a/utils/statedb.go
+++ b/utils/statedb.go
@@ -224,7 +224,7 @@ func makeStateDBVariant(
 	case "memory":
 		return state.MakeEmptyGethInMemoryStateDB(variant)
 	case "geth":
-		chainCfg, err := cfg.GetChainConfig("")
+		chainCfg, err := cfg.GetChainConfig(cfg.Fork)
 		if err != nil {
 			return nil, fmt.Errorf("cannot get chain config: %w", err)
 		}


### PR DESCRIPTION
## Description

This PR refactor `--forks` flag to `--fork`. The flag now only accept one argument. Eth-test may use `All` forks which generate full list of available forks. 

Extend transaction generator test to accept `--fork`. The command now can run at any fork without block height dependency to Fantom mainnet.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (changes that do NOT affect functionality)
- [x] Adds or updates testing
